### PR TITLE
updated minikube and kubectl version

### DIFF
--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	kubectlVersion string = "1.12.0"
+	kubectlVersion string = "1.12.5"
 	sleep                 = 5 * time.Second
 )
 

--- a/internal/minikube/minikube.go
+++ b/internal/minikube/minikube.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	minikubeVersion string = "0.33.0"
+	minikubeVersion string = "1.0.1"
 )
 
 //RunCmd executes a minikube command with given arguments


### PR DESCRIPTION
**Description**
I updated the versions, no further changes were required.

Changes proposed in this pull request:

- Support for Minikube 1.0.1 
- Support for Kubectl 1.12.5 (kyma is based on kubernetes 1.12.5 already)

**Related issue(s)**
https://github.com/kyma-project/cli/issues/76
