### PR TITLE
Do not print password in summary if password was provided during the Kyma installation

### DIFF
--- a/pkg/kyma/cmd/install/cmd.go
+++ b/pkg/kyma/cmd/install/cmd.go
@@ -598,7 +598,9 @@ func (cmd *command) printSummary() error {
 	fmt.Printf("Kyma is installed in version %s\n", version)
 	fmt.Printf("Kyma console:     https://console.%s\n", cmd.opts.Domain)
 	fmt.Printf("Kyma admin email: %s\n", emailDecoded)
-	fmt.Printf("Kyma admin pwd:   %s\n", pwdDecoded)
+	if cmd.opts.Password == "" {
+		fmt.Printf("Kyma admin pwd:   %s\n", pwdDecoded)
+	}
 	fmt.Println()
 	fmt.Println("Happy Kyma-ing! :)")
 	fmt.Println()

--- a/pkg/kyma/cmd/install/cmd.go
+++ b/pkg/kyma/cmd/install/cmd.go
@@ -598,7 +598,7 @@ func (cmd *command) printSummary() error {
 	fmt.Printf("Kyma is installed in version %s\n", version)
 	fmt.Printf("Kyma console:     https://console.%s\n", cmd.opts.Domain)
 	fmt.Printf("Kyma admin email: %s\n", emailDecoded)
-	if cmd.opts.Password == "" {
+	if cmd.opts.Password == "" || cmd.opts.NonInteractive {
 		fmt.Printf("Kyma admin pwd:   %s\n", pwdDecoded)
 	}
 	fmt.Println()


### PR DESCRIPTION
Do not print password in summary if a password was provided during the Kyma installation (`-p` option used).