### PR TITLE
Add tech writers as owners of all MD files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,5 @@
 # These are the default owners for the whole content of the repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
 * @suleymanakbas91 @clebs @a-thaler @lilitgh @igor-karpukhin @hisarbalik @bszwarc
+
+# All .md files
+*.md @kazydek @klaudiagrz @tomekpapiernik @bszwarc @mmitoraj


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add tech writers as MD file owners.
