### PR TITLE
Increased memory for minikube up to 10240MB

### DIFF
--- a/pkg/kyma/cmd/provision/minikube/cmd.go
+++ b/pkg/kyma/cmd/provision/minikube/cmd.go
@@ -89,7 +89,7 @@ func NewCmd(o *MinikubeOptions) *cobra.Command {
 	cmd.Flags().StringVar(&o.VMDriver, "vm-driver", defaultVMDriver, "VMDriver to use, possible values are: "+strings.Join(drivers, ","))
 	cmd.Flags().StringVar(&o.HypervVirtualSwitch, "hypervVirtualSwitch", "", "Name of the hyperv switch to use, required if --vm-driver=hyperv")
 	cmd.Flags().StringVar(&o.DiskSize, "disk-size", "30g", "Disk size to use")
-	cmd.Flags().StringVar(&o.Memory, "memory", "8192", "Memory to use")
+	cmd.Flags().StringVar(&o.Memory, "memory", "10240", "Memory to use")
 	cmd.Flags().StringVar(&o.CPU, "cpu", "4", "CPUs to use")
 	return cmd
 }


### PR DESCRIPTION
Increased memory for the minikube up to 10240MB. Related to: https://github.com/kyma-project/kyma/pull/4228