### PR TITLE
fix hosts lines on windows

### DIFF
--- a/pkg/kyma/cmd/provision/minikube/cmd.go
+++ b/pkg/kyma/cmd/provision/minikube/cmd.go
@@ -154,7 +154,7 @@ func (o *MinikubeOptions) Run() error {
 		s.Failure()
 		return err
 	}
-	s.Successf("Minukube up and running")
+	s.Successf("Minikube up and running")
 
 	err = addDevDomainsToEtcHosts(o, s)
 	if err != nil {

--- a/pkg/kyma/cmd/provision/minikube/hosts_windows.go
+++ b/pkg/kyma/cmd/provision/minikube/hosts_windows.go
@@ -4,6 +4,7 @@ package minikube
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/kyma-project/cli/internal/step"
 )
@@ -11,7 +12,26 @@ import (
 func addDevDomainsToEtcHostsOSSpecific(o *MinikubeOptions, s step.Step, hostAlias string) error {
 
 	s.LogErrorf("Please add these lines to your " + hostsFile + " file:")
-	fmt.Println(hostAlias)
+	hostsArray := strings.Split(hostAlias, " ")
+	ip := hostsArray[0]
+	hostsPerLine := split(hostsArray[1:], 7) // 7 hostnames per line
+
+	for k := 0; k < len(hostsPerLine); k++ {
+		fmt.Printf("%s %s\n", ip, strings.Join(hostsPerLine[k], " "))
+	}
 
 	return nil
+}
+
+func split(buf []string, lim int) [][]string {
+	var chunk []string
+	chunks := make([][]string, 0, len(buf)/lim+1)
+	for len(buf) >= lim {
+		chunk, buf = buf[:lim], buf[lim:]
+		chunks = append(chunks, chunk)
+	}
+	if len(buf) > 0 {
+		chunks = append(chunks, buf[:len(buf)])
+	}
+	return chunks
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Windows hosts file does not accept more than 9 hostname per line. This PR divides the `hostAlias` variable to 7 hostnames per line for windows. It doesn't touch *nix systems.
- It fixes a typo `minukube` -> `minikube`
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

fixes #93 
