### PR TITLE
Include Compass Gateway domain for Minikube provisioning

### DIFF
--- a/pkg/kyma/cmd/provision/minikube/cmd.go
+++ b/pkg/kyma/cmd/provision/minikube/cmd.go
@@ -43,6 +43,7 @@ var (
 		"log-ui",
 		"loki",
 		"kiali",
+		"compass-gateway",
 	}
 
 	drivers = []string{


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Include Compass Gateway domain for Minikube provisioning

**Related issue(s)**
See https://github.com/kyma-project/kyma/issues/4242
