### PR TITLE
uninstall: adapt to installer changes

### DIFF
--- a/pkg/kyma/cmd/uninstall/cmd.go
+++ b/pkg/kyma/cmd/uninstall/cmd.go
@@ -276,7 +276,7 @@ func (cmd *command) waitForInstallerToUninstall() error {
 			case "Error":
 				if !errorOccured {
 					errorOccured = true
-					cmd.CurrentStep.LogInfof("There was an error uninstalling Kyma, which might be OK. Will retry later...\n%s6", desc)
+					cmd.CurrentStep.LogInfof("There was an error uninstalling Kyma, which might be OK. Will retry later...\n%s", desc)
 					cmd.CurrentStep.LogInfof("For more information, run: 'kubectl logs -n kyma-installer -l name=kyma-installer'")
 				}
 

--- a/pkg/kyma/cmd/uninstall/cmd.go
+++ b/pkg/kyma/cmd/uninstall/cmd.go
@@ -55,7 +55,7 @@ This command:
 		Aliases: []string{"i"},
 	}
 
-	cobraCmd.Flags().DurationVarP(&o.Timeout, "timeout", "", 0, "Timeout after which Kyma CLI stops watching the installation progress")
+	cobraCmd.Flags().DurationVarP(&o.Timeout, "timeout", "", 30*time.Minute, "Timeout after which Kyma CLI stops watching the uninstallation progress")
 
 	return cobraCmd
 }
@@ -276,8 +276,8 @@ func (cmd *command) waitForInstallerToUninstall() error {
 			case "Error":
 				if !errorOccured {
 					errorOccured = true
-					cmd.CurrentStep.Failuref("Failed to uninstall Kyma: %s", desc)
-					cmd.CurrentStep.LogInfof("To fetch the logs from the Installer, run: 'kubectl logs -n kyma-installer -l name=kyma-installer'")
+					cmd.CurrentStep.LogInfof("There was an error uninstalling Kyma, which might be OK. Will retry later...\n%s6", desc)
+					cmd.CurrentStep.LogInfof("For more information, run: 'kubectl logs -n kyma-installer -l name=kyma-installer'")
 				}
 
 			case "InProgress":

--- a/pkg/kyma/cmd/uninstall/cmd_test.go
+++ b/pkg/kyma/cmd/uninstall/cmd_test.go
@@ -1,0 +1,37 @@
+package uninstall
+
+import (
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/kyma-project/cli/pkg/kyma/core"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUninstallFlags ensures that the provided command flags are stored in the options.
+func TestUninstallFlags(t *testing.T) {
+	o := NewOptions(&core.Options{})
+	c := NewCmd(o)
+	c.SetOutput(ioutil.Discard) // not interested in the command's output
+
+	// test default flag values
+	require.Error(t, c.Execute(), "Command execution should fail") // command fails becuase there is no kyma to uninstall, but it is ok.
+	require.Equal(t, 30*time.Minute, o.Timeout, "Default uninstall timeout not correct")
+
+	// test passing flags
+	c.SetArgs([]string{"--timeout=60m0s"})
+
+	require.Error(t, c.Execute(), "Command execution should fail")
+	require.Equal(t, 60*time.Minute, o.Timeout, "Default uninstall timeout not correct")
+}
+
+func TestUninstallSubcommands(t *testing.T) {
+	o := NewOptions(&core.Options{})
+	c := NewCmd(o)
+	c.SetOutput(ioutil.Discard) // not interested in the command's output
+
+	sub := c.Commands()
+
+	require.Equal(t, 0, len(sub), "Number of uninstall subcommands not as expected")
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Adapt to the installer changes:
  - Add a default timeout to avoid being waiting forever.
  - Changed error messages to reflect the retry nature of the uninstallation process.
- Added first uninstall command unit tests

**Related issue(s)**
#111 