### PR TITLE
Fix passing kubeconfig flag to kubectl

### DIFF
--- a/internal/kubectl/kubectl.go
+++ b/internal/kubectl/kubectl.go
@@ -22,8 +22,8 @@ func runCmd(verbose bool, args ...string) (string, error) {
 }
 
 //RunApplyCmd executes a kubectl apply command with given resources
-func runApplyCmd(resources []map[string]interface{}, verbose bool) (string, error) {
-	cmd := exec.Command("kubectl", "apply", "-f", "-")
+func runApplyCmd(resources []map[string]interface{}, verbose bool, kubeconfig string) (string, error) {
+	cmd := exec.Command("kubectl", fmt.Sprintf("--kubeconfig=%s", kubeconfig), "apply", "-f", "-")
 	buf := &bytes.Buffer{}
 	enc := yaml.NewEncoder(buf)
 	for _, y := range resources {

--- a/internal/kubectl/wrapper.go
+++ b/internal/kubectl/wrapper.go
@@ -1,17 +1,24 @@
 package kubectl
 
+import "fmt"
+
 type Wrapper struct {
-	verbose bool
+	verbose    bool
+	kubeconfig string
 }
 
-func NewWrapper(verbose bool) *Wrapper {
-	return &Wrapper{verbose}
+func NewWrapper(verbose bool, kubeconfig string) *Wrapper {
+	return &Wrapper{
+		verbose:    verbose,
+		kubeconfig: kubeconfig,
+	}
 }
 
 func (w *Wrapper) RunCmd(args ...string) (string, error) {
+	args = append(args, fmt.Sprintf("--kubeconfig=%s", w.kubeconfig))
 	return runCmd(w.verbose, args...)
 }
 
 func (w *Wrapper) RunApplyCmd(resources []map[string]interface{}) (string, error) {
-	return runApplyCmd(resources, w.verbose)
+	return runApplyCmd(resources, w.verbose, w.kubeconfig)
 }

--- a/pkg/kyma/core/command.go
+++ b/pkg/kyma/core/command.go
@@ -21,7 +21,7 @@ func (c *Command) NewStep(msg string) step.Step {
 
 func (c *Command) Kubectl() *kubectl.Wrapper {
 	if c.kubectl == nil {
-		c.kubectl = kubectl.NewWrapper(c.Verbose)
+		c.kubectl = kubectl.NewWrapper(c.Verbose, c.Options.KubeconfigPath)
 	}
 	return c.kubectl
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Pass CLI kubeconfig flag on to kubectl

**Related issue(s)**
#125 