### PR TITLE
changed order for leftover deletion

### DIFF
--- a/pkg/kyma/cmd/uninstall/cmd.go
+++ b/pkg/kyma/cmd/uninstall/cmd.go
@@ -95,15 +95,6 @@ func (cmd *command) Run() error {
 	}
 	s.Successf("Tiller deleted")
 
-	s = cmd.NewStep("Deleting Namespaces")
-	// see https://github.com/kyma-project/kyma/issues/1826
-	err = cmd.deleteLeftoverResources("namespace", namespacesToDelete)
-	if err != nil {
-		s.Failure()
-		return err
-	}
-	s.Successf("Namespaces deleted")
-
 	s = cmd.NewStep("Deleting CRDs")
 	// see https://github.com/kyma-project/kyma/issues/1826
 	err = cmd.deleteLeftoverResources("crd", crdGroupsToDelete)
@@ -112,6 +103,15 @@ func (cmd *command) Run() error {
 		return err
 	}
 	s.Successf("CRDs deleted")
+
+	s = cmd.NewStep("Deleting Namespaces")
+	// see https://github.com/kyma-project/kyma/issues/1826
+	err = cmd.deleteLeftoverResources("namespace", namespacesToDelete)
+	if err != nil {
+		s.Failure()
+		return err
+	}
+	s.Successf("Namespaces deleted")
 
 	err = cmd.printUninstallSummary()
 	if err != nil {


### PR DESCRIPTION
**Description**

Uninstall failed in CRD deletion phase as finalizers of resources were not processed anymore. I changed the order by first deleting the CRDs and then the namespaces to have the related controllers still in place on CRD deletion

