### PR TITLE
Fix goreleaser version build flag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
 - env:
   - CGO_ENABLED=0
   - KYMA_VERSION=master
-  ldflags: -X github.com/kyma-project/cli/pkg/kyma/cmd.Version={{.Version}} -X github.com/kyma-project/cli/pkg/kyma/cmd/install.DefaultKymaVersion={{.Env.KYMA_VERSION}}
+  ldflags: -X github.com/kyma-project/cli/pkg/kyma/cmd/version.Version={{.Version}} -X github.com/kyma-project/cli/pkg/kyma/cmd/install.DefaultKymaVersion={{.Env.KYMA_VERSION}}
   main: ./cmd/kyma/
   goos:
     - darwin


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix the CLI version build flag set by the goreleaser.
