### PR TITLE
Add compass UI urls for minikube provisioning

### DIFF
--- a/pkg/kyma/cmd/provision/minikube/cmd.go
+++ b/pkg/kyma/cmd/provision/minikube/cmd.go
@@ -56,7 +56,7 @@ var (
 		"kiali",
 		"compass-gateway",
 		"compass",
-		"compass-mf"
+		"compass-mf",
 	}
 
 	drivers = []string{

--- a/pkg/kyma/cmd/provision/minikube/cmd.go
+++ b/pkg/kyma/cmd/provision/minikube/cmd.go
@@ -55,6 +55,8 @@ var (
 		"oathkeeper-api-server",
 		"kiali",
 		"compass-gateway",
+		"compass",
+		"compass-mf"
 	}
 
 	drivers = []string{


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add compass UI urls for minikube provisioning

**Related issue(s)**
https://github.com/kyma-incubator/compass/issues/152
