### PR TITLE
octopus: refactor k8s rest client

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  digest = "1:5ad08b0e14866764a6d7475eb11c9cf05cad9a52c442593bdfa544703ff77f61"
+  digest = "1:80004fcc5cf64e591486b3e11b406f1e0d17bf85d475d64203c8494f5da4fcd1"
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
   pruneopts = "UT"
-  revision = "0ebda48a7f143b1cce9eb37a8c1106ac762a3430"
-  version = "v0.34.0"
+  revision = "cdaaf98f9226c39dc162b8e55083b2fbc67b4674"
+  version = "v0.43.0"
 
 [[projects]]
   branch = "master"
@@ -21,28 +21,47 @@
   revision = "d6e3b3328b783f23731bc4d058875b0371ff8109"
 
 [[projects]]
-  digest = "1:6e6779c1e7984081358a4aee6f944233c8cbabfb28ca9dc0e20af595d476ebf4"
+  digest = "1:55388fd080150b9a072912f97b1f5891eb0b50df43401f8b75fb4273d3fec9fc"
   name = "github.com/Masterminds/semver"
   packages = ["."]
   pruneopts = "UT"
-  revision = "517734cc7d6470c0d07130e40fd40bdeb9bcd3fd"
-  version = "v1.3.1"
+  revision = "c7af12943936e8c39859482e61f0574c2fd7fc75"
+  version = "v1.4.2"
 
 [[projects]]
-  digest = "1:f9ae348e1f793dcf9ed930ed47136a67343dbd6809c5c91391322267f4476892"
+  digest = "1:d5e752c67b445baa5b6cb6f8aa706775c2aa8e41aca95a0c651520ff2c80361a"
   name = "github.com/Microsoft/go-winio"
-  packages = ["."]
+  packages = [
+    ".",
+    "pkg/guid",
+  ]
   pruneopts = "UT"
-  revision = "97e4973ce50b2ff5f09635a57e2b88a037aae829"
-  version = "v0.4.11"
+  revision = "6c72808b55902eae4c5943626030429ff20f3b63"
+  version = "v0.4.14"
 
 [[projects]]
-  digest = "1:5b290e0afae8906d379aa7fe01ce2007930636bdb80a96e148346131dd433cb8"
+  digest = "1:6b6d999be55cc0e0704ed0ac4532175f1f71639fbda6d143dc86ac5a5d3bc87f"
+  name = "github.com/Microsoft/hcsshim"
+  packages = ["osversion"]
+  pruneopts = "UT"
+  revision = "f92b8fb9c92e17da496af5a69e3ee13fbe9916e1"
+  version = "v0.8.6"
+
+[[projects]]
+  digest = "1:937ce6e0cd5ccfec205f444a0d9c74f5680cbb68cd0a992b000559bf964ea20b"
   name = "github.com/briandowns/spinner"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ac46072a5a9105597c1fd63f9e246477b116772e"
-  version = "1.6"
+  revision = "e3fb08e7443c496a847cb2eef48e3883f3e12c38"
+  version = "v1.6.1"
+
+[[projects]]
+  digest = "1:eb0414b9f841f10af66f6bec6074c5a26ebca71f374c12f187feca7554bad408"
+  name = "github.com/containerd/containerd"
+  packages = ["errdefs"]
+  pruneopts = "UT"
+  revision = "85f6aa58b8a3170aec9824568f7a31832878b603"
+  version = "v1.2.7"
 
 [[projects]]
   branch = "master"
@@ -50,7 +69,7 @@
   name = "github.com/containerd/continuity"
   packages = ["pathdriver"]
   pruneopts = "UT"
-  revision = "004b46473808b3e7a4a3049c20e4376c91eb966d"
+  revision = "aaeac12a7ffcd198ae25440a9dff125c2e2703a7"
 
 [[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
@@ -61,11 +80,17 @@
   version = "v1.1.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:b090e9cc078ff7b86465f84c10565bb5edef47575b6c9af4b2feabc0b5f6508d"
+  digest = "1:699aca47d5af672db37b96102bb088edbf26f84f73d3dafff6fa917026eb6971"
+  name = "github.com/docker/distribution"
+  packages = ["registry/api/errcode"]
+  pruneopts = "UT"
+  revision = "2461543d988979529609e8cb6fca9ca190dc48da"
+  version = "v2.7.1"
+
+[[projects]]
+  digest = "1:d5181230d0e80d4d592266ee784b31029ff527c91c24e03d1fe2081562b9b6e9"
   name = "github.com/docker/docker"
   packages = [
-    "api/types",
     "api/types/blkiodev",
     "api/types/container",
     "api/types/filters",
@@ -77,7 +102,6 @@
     "api/types/swarm/runtime",
     "api/types/versions",
     "errdefs",
-    "opts",
     "pkg/fileutils",
     "pkg/homedir",
     "pkg/idtools",
@@ -89,7 +113,7 @@
     "pkg/system",
   ]
   pruneopts = "UT"
-  revision = "5ec31380a5d3ea92fc68e53cd1fc96f11ac02e6e"
+  revision = "ae0c0cdffdf24c2424abaf8d67fe0e0d27c06ccd"
 
 [[projects]]
   digest = "1:ade935c55cd6d0367c843b109b09c9d748b1982952031414740750fdf94747eb"
@@ -100,19 +124,12 @@
   version = "v0.4.0"
 
 [[projects]]
-  digest = "1:6f82cacd0af5921e99bf3f46748705239b36489464f4529a1589bc895764fb18"
+  digest = "1:e95ef557dc3120984bb66b385ae01b4bb8ff56bcde28e7b0d1beed0cccc4d69f"
   name = "github.com/docker/go-units"
   packages = ["."]
   pruneopts = "UT"
-  revision = "47565b4f722fb6ceae66b95f853feed578a4a51c"
-  version = "v0.3.3"
-
-[[projects]]
-  digest = "1:3b4afe788202e2911355e54c30323ec56617c52015fcdff23380058f4cee8540"
-  name = "github.com/docker/libnetwork"
-  packages = ["ipamutils"]
-  pruneopts = "UT"
-  revision = "1a06131fb8a047d919f7deaf02a4c414d7884b83"
+  revision = "519db1ee28dcc9fd2474ae59fca29a810482bfb1"
+  version = "v0.4.0"
 
 [[projects]]
   digest = "1:b498b36dbb2b306d1c5205ee5236c9e60352be8f9eea9bf08186723a9f75b4f3"
@@ -130,15 +147,15 @@
   version = "v1.12.0"
 
 [[projects]]
-  digest = "1:865079840386857c809b72ce300be7580cb50d3d3129ce11bf9aa6ca2bc1934a"
+  digest = "1:4bb94bb2d837b5c7489d9e5e1fcffbc81fa1cb43024cbb4fe827787378f01e3b"
   name = "github.com/fatih/color"
   packages = ["."]
   pruneopts = "UT"
-  revision = "5b77d2a35fb0ede96d138fc9a99f5c9b6aef11b4"
-  version = "v1.7.0"
+  revision = "507f6050b8568533fb3f5504de8e5205fa62a114"
+  version = "v1.6.0"
 
 [[projects]]
-  digest = "1:27faff505d42f8291f35961b3e47a7598a70599379afa171f9a78047059736da"
+  digest = "1:cdfaeda17fd9797a6e09a9fa1705087bc7f1a0e2e763b6849ce0938a050abdf6"
   name = "github.com/fsouza/go-dockerclient"
   packages = [
     ".",
@@ -147,8 +164,8 @@
     "internal/term",
   ]
   pruneopts = "UT"
-  revision = "bcd4059882ad0ce568e55b899c16b0f1ee7dc4ae"
-  version = "v1.3.5"
+  revision = "f65478639354bd0c6d1db4de15c4e28b0ea75997"
+  version = "v1.4.2"
 
 [[projects]]
   digest = "1:2cd7915ab26ede7d95b8749e6b1f933f1c6d5398030684e6505940a10f31cfda"
@@ -159,31 +176,15 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:edd2fa4578eb086265db78a9201d15e76b298dfd0d5c379da83e9c61712cf6df"
-  name = "github.com/go-logr/logr"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "9fb12b3b21c5415d16ac18dc5cd42c1cfdd40c4e"
-  version = "v0.1.0"
-
-[[projects]]
-  digest = "1:d81dfed1aa731d8e4a45d87154ec15ef18da2aa80fa9a2f95bec38577a244a99"
-  name = "github.com/go-logr/zapr"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "03f06a783fbb7dfaf3f629c7825480e43a7105e6"
-  version = "v0.1.1"
-
-[[projects]]
-  digest = "1:b7a8552c62868d867795b63eaf4f45d3e92d36db82b428e680b9c95a8c33e5b1"
+  digest = "1:4d02824a56d268f74a6b6fdd944b20b58a77c3d70e81008b3ee0c4f1a6777340"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
     "sortkeys",
   ]
   pruneopts = "UT"
-  revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
-  version = "v0.5"
+  revision = "ba06b47c162d49f2af050fb4c75bcbc86a159d5c"
+  version = "v1.2.1"
 
 [[projects]]
   branch = "master"
@@ -205,7 +206,7 @@
   revision = "883fe33ffc4344bad1ecd881f61afd5ec5d80e0a"
 
 [[projects]]
-  digest = "1:17fe264ee908afc795734e8c4e63db2accabaf57326dbf21763a7d6b86096260"
+  digest = "1:f5ce1529abc1204444ec73779f44f94e2fa8fcdb7aca3c355b0c95947e4005c6"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -215,8 +216,8 @@
     "ptypes/timestamp",
   ]
   pruneopts = "UT"
-  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
-  version = "v1.1.0"
+  revision = "6c65a5562fc06764971b7c5d05c76c75e84bdbf7"
+  version = "v1.3.2"
 
 [[projects]]
   digest = "1:0bfbe13936953a98ae3cfe8ed6670d396ad81edf069a806d2f6515d7bb6950df"
@@ -227,11 +228,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:41bfd4219241b7f7d6e6fdb13fc712576f1337e68e6b895136283b76928fdd66"
+  digest = "1:a6181aca1fd5e27103f9a920876f29ac72854df7345a39f3b01e61c8c94cc8af"
   name = "github.com/google/gofuzz"
   packages = ["."]
   pruneopts = "UT"
-  revision = "44d81051d367757e1c7c6a5a86423ece9afcf63c"
+  revision = "f140a6486e521aad38f5917de355cbf147cc0496"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:d1a3774c1f8336a21669d6da87a7bafb4d6171a84752268b7011e767d6722c2b"
@@ -265,12 +267,12 @@
   revision = "a8b993ba6abdb0e0c12b0125c603323a71c7790c"
 
 [[projects]]
-  digest = "1:3e260afa138eab6492b531a3b3d10ab4cb70512d423faa78b8949dec76e66a21"
+  digest = "1:a0cefd27d12712af4b5018dc7046f245e1e3b5760e2e848c30b171b570708f9b"
   name = "github.com/imdario/mergo"
   packages = ["."]
   pruneopts = "UT"
-  revision = "9316a62528ac99aaecb4e47eadd6dc8aa6533d58"
-  version = "v0.3.5"
+  revision = "7c29201646fa3de8506f701213473dd407f19646"
+  version = "v0.3.7"
 
 [[projects]]
   digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
@@ -289,31 +291,39 @@
   revision = "d14ea06fba99483203c19d92cfcd13ebe73135f4"
 
 [[projects]]
-  digest = "1:eaefc85d32c03e5f0c2b88ea2f79fce3d993e2c78316d21319575dd4ea9153ca"
+  digest = "1:709cd2a2c29cc9b89732f6c24846bbb9d6270f28ef5ef2128cc73bd0d6d7bff9"
   name = "github.com/json-iterator/go"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ab8a2e0c74be9d3be70b3184d9acc634935ded82"
-  version = "1.1.4"
+  revision = "27518f6661eba504be5a7a9a9f6d9460d892ade3"
+  version = "v1.1.7"
 
 [[projects]]
-  digest = "1:ae5f4d0779a45e2cb3075d8b3ece6c623e171407f4aac83521392ff06d188871"
+  digest = "1:fd7f169f32c221b096c74e756bda16fe22d3bb448bbf74042fd0700407a1f92f"
   name = "github.com/kevinburke/ssh_config"
   packages = ["."]
   pruneopts = "UT"
-  revision = "81db2a75821ed34e682567d48be488a1c3121088"
-  version = "0.5"
+  revision = "6cfae18c12b8934b1afba3ce8159476fdef666ba"
+  version = "1.0"
+
+[[projects]]
+  digest = "1:31e761d97c76151dde79e9d28964a812c46efc5baee4085b86f68f0c654450de"
+  name = "github.com/konsorten/go-windows-terminal-sequences"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f55edac94c9bbba5d6182a4be46d86a2c9b5b50e"
+  version = "v1.0.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:fbdb40af1fa09f652994cdea0c295f99e29f55a917c6b57f582641f2d4718621"
+  digest = "1:e3477bf3ebb6a18e1b58323df56f1eb285ae6681495e6dee257ea577c68cf2dd"
   name = "github.com/kyma-incubator/octopus"
   packages = [
     "pkg/apis",
     "pkg/apis/testing/v1alpha1",
   ]
   pruneopts = "UT"
-  revision = "c919e4aed88265c9c6f3e8dd7105c014d78afb7a"
+  revision = "dee8148261ee04a32fedd107e5aa045faed6509f"
 
 [[projects]]
   digest = "1:c658e84ad3916da105a761660dcaeb01e63416c8ec7bc62256a9b411a05fcd67"
@@ -324,12 +334,12 @@
   version = "v0.0.9"
 
 [[projects]]
-  digest = "1:0981502f9816113c9c8c4ac301583841855c8cf4da8c72f696b3ebedf6d0e4e5"
+  digest = "1:9b90c7639a41697f3d4ad12d7d67dfacc9a7a4a6e0bbfae4fc72d0da57c28871"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
   pruneopts = "UT"
-  revision = "6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c"
-  version = "v0.0.4"
+  revision = "1311e847b0cb909da63b5fecfb5370aa66236465"
+  version = "v0.0.8"
 
 [[projects]]
   digest = "1:0356f3312c9bd1cbeda81505b7fd437501d8e778ab66998ef69f00d7f9b3a0d7"
@@ -364,12 +374,12 @@
   version = "1.0.3"
 
 [[projects]]
-  digest = "1:c56ad36f5722eb07926c979d5e80676ee007a9e39e7808577b9d87ec92b00460"
+  digest = "1:e32bdbdb7c377a07a9a46378290059822efdce5c8d96fe71940d87cb4f918855"
   name = "github.com/modern-go/reflect2"
   packages = ["."]
   pruneopts = "UT"
-  revision = "94122c33edd36123c84d5368cfb2b69df93a0ec8"
-  version = "v1.0.1"
+  revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
+  version = "1.0.1"
 
 [[projects]]
   digest = "1:abcdbf03ca6ca13d3697e2186edc1f33863bbdac2b3a44dfa39015e8903f7409"
@@ -399,19 +409,12 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:eecbbd6bfbfbe1acdad4b22c4fd530ab569df1634deef359e40d2ee4f85057f9"
+  digest = "1:38ee335aedf4626620f3cf8f605661e71abdcce7b40b38921962beb3980f0a20"
   name = "github.com/opencontainers/runc"
   packages = ["libcontainer/user"]
   pruneopts = "UT"
-  revision = "96ec2177ae841256168fcf76954f7177af9446eb"
-
-[[projects]]
-  digest = "1:b2ee62e09bec113cf086d2ce0769efcc7bf79481aba8373fd8f7884e94df3462"
-  name = "github.com/pelletier/go-buffruneio"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "c37440a7cf42ac63b919c752ca73a85067e05992"
-  version = "v0.2.0"
+  revision = "baf6536d6259209c3edfa2b22237af82942d3dfa"
+  version = "v0.1.1"
 
 [[projects]]
   branch = "master"
@@ -454,20 +457,20 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:d867dfa6751c8d7a435821ad3b736310c2ed68945d05b50fb9d23aee0540c8cc"
+  digest = "1:04457f9f6f3ffc5fea48e71d62f2ca256637dee0a04d710288e27e05c8b41976"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
   pruneopts = "UT"
-  revision = "3e01752db0189b9157070a0e1668a620f9a85da2"
-  version = "v1.0.6"
+  revision = "839c75faf7f98a33d445d181f3018b5c3409a45e"
+  version = "v1.4.2"
 
 [[projects]]
-  digest = "1:645cabccbb4fa8aab25a956cbcbdf6a6845ca736b2c64e197ca7cbb9d210b939"
+  digest = "1:e096613fb7cf34743d49af87d197663cfccd61876e2219853005a57baedfa562"
   name = "github.com/spf13/cobra"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
-  version = "v0.0.3"
+  revision = "f2b07da1e2c38d5f12845a4f607e2e1018cbb1f5"
+  version = "v0.0.5"
 
 [[projects]]
   digest = "1:c1b1102241e7f645bc8e0c22ae352e8f0dc6484b6cb4d132fa9f24174e0119e2"
@@ -510,38 +513,8 @@
   version = "v0.2.1"
 
 [[projects]]
-  digest = "1:a5158647b553c61877aa9ae74f4015000294e47981e6b8b07525edcbb0747c81"
-  name = "go.uber.org/atomic"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "df976f2515e274675050de7b3f42545de80594fd"
-  version = "v1.4.0"
-
-[[projects]]
-  digest = "1:60bf2a5e347af463c42ed31a493d817f8a72f102543060ed992754e689805d1a"
-  name = "go.uber.org/multierr"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "3c4937480c32f4c13a875a1829af76c98ca3d40a"
-  version = "v1.1.0"
-
-[[projects]]
-  digest = "1:676160e6a4722b08e0e26b11521d575c2cb2b6f0c679e1ee6178c5d8dee51e5e"
-  name = "go.uber.org/zap"
-  packages = [
-    ".",
-    "buffer",
-    "internal/bufferpool",
-    "internal/color",
-    "internal/exit",
-    "zapcore",
-  ]
-  pruneopts = "UT"
-  revision = "27376062155ad36be76b0f12cf1572a221d3a48c"
-  version = "v1.10.0"
-
-[[projects]]
-  digest = "1:dfcb1b2db354cafa48fc3cdafe4905a08bec4a9757919ab07155db0ca23855b4"
+  branch = "master"
+  digest = "1:2d4cab5a9ea650aa99394d7e768e280f0cfc1d0b7c0fa08f2447391ab1eb5480"
   name = "golang.org/x/crypto"
   packages = [
     "cast5",
@@ -563,24 +536,28 @@
     "ssh/terminal",
   ]
   pruneopts = "UT"
-  revision = "de0752318171da717af4ce24d0a2e8626afaeb11"
+  revision = "4def268fd1a49955bfb3dda92fe3db4f924f2285"
 
 [[projects]]
-  branch = "release-branch.go1.10"
-  digest = "1:bdc99a0ff03b87c7fe65dce8cfd5f7db86d65446850b2c655db7bc740f16aded"
+  branch = "master"
+  digest = "1:3fa9cdf9e0e7f1b1d888b55a710bc90ce5ab1f27feac343cebee6e0b7f31e2d4"
   name = "golang.org/x/net"
   packages = [
     "context",
+    "context/ctxhttp",
+    "http/httpguts",
     "http2",
     "http2/hpack",
     "idna",
-    "lex/httplex",
+    "internal/socks",
+    "proxy",
   ]
   pruneopts = "UT"
-  revision = "0ed95abb35c445290478a5348a7b38bb154135fd"
+  revision = "ca1201d0de80cfde86cb01aea620983605dfe99b"
 
 [[projects]]
-  digest = "1:ad764db92ed977f803ff0f59a7a957bf65cc4e8ae9dfd08228e1f54ea40392e0"
+  branch = "master"
+  digest = "1:31e33f76456ccf54819ab4a646cf01271d1a99d7712ab84bf1a9e7b61cd2031b"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
@@ -590,27 +567,30 @@
     "jwt",
   ]
   pruneopts = "UT"
-  revision = "a6bd8cefa1811bd24b86f8902872e4e8225f74c4"
+  revision = "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33"
 
 [[projects]]
   branch = "master"
-  digest = "1:72f402ba458cb14ed7964c8b9a38d992f27834b3cf3479f3b08ea9e5334811b3"
+  digest = "1:afce8593ac5918df05a46499b04b8c4e46a91e99566055e4a8ba829a8f389a09"
   name = "golang.org/x/sys"
   packages = [
+    "cpu",
     "unix",
     "windows",
   ]
   pruneopts = "UT"
-  revision = "770c60269bf0ef965e9e7ac8bedcb6bca2a1cefd"
+  revision = "51ab0e2deafac1f46c46ad59cf0921be2f180c3d"
 
 [[projects]]
-  digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
+  digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"
   name = "golang.org/x/text"
   packages = [
     "collate",
     "collate/build",
     "internal/colltab",
     "internal/gen",
+    "internal/language",
+    "internal/language/compact",
     "internal/tag",
     "internal/triegen",
     "internal/ucd",
@@ -623,19 +603,20 @@
     "unicode/rangetable",
   ]
   pruneopts = "UT"
-  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
-  version = "v0.3.0"
-
-[[projects]]
-  digest = "1:d37b0ef2944431fe9e8ef35c6fffc8990d9e2ca300588df94a6890f3649ae365"
-  name = "golang.org/x/time"
-  packages = ["rate"]
-  pruneopts = "UT"
-  revision = "f51c12702a4d776e4c1fa9b0fabab841babae631"
+  revision = "342b2e1fbaa52c93f31447ad2c6abc048c63e475"
+  version = "v0.3.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:da76817708f332e4a6a161581de588bbd420d020e976759408b3321f39f1a48d"
+  digest = "1:9fdc2b55e8e0fafe4b41884091e51e77344f7dc511c5acedcfd98200003bff90"
+  name = "golang.org/x/time"
+  packages = ["rate"]
+  pruneopts = "UT"
+  revision = "9d24e82272b4f38b78bc8cff74fa936d31ccd8ef"
+
+[[projects]]
+  branch = "master"
+  digest = "1:a45ec3bb7c73e52430410dff3e0a5534ce518f72a8eb4355bc8502c546b91ecc"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
@@ -644,10 +625,10 @@
     "go/types/typeutil",
   ]
   pruneopts = "UT"
-  revision = "16909d206f00da7d0d5ba28cd9dc7fb223648ecf"
+  revision = "b346f7fd45de50e7e5dd5d24a7a009c3c8d8ec61"
 
 [[projects]]
-  digest = "1:fa026a5c59bd2df343ec4a3538e6288dcf4e2ec5281d743ae82c120affe6926a"
+  digest = "1:498b722d33dde4471e7d6e5d88a5e7132d2a8306fea5ff5ee82d1f418b4f41ed"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -662,19 +643,41 @@
     "urlfetch",
   ]
   pruneopts = "UT"
-  revision = "e9657d882bb81064595ca3b56cbe2546bbabf7b1"
-  version = "v1.4.0"
+  revision = "b2f4a3cf3c67576a2ee09e1fe62656a5086ce880"
+  version = "v1.6.1"
 
 [[projects]]
-  digest = "1:ef72505cf098abdd34efeea032103377bec06abb61d8a06f002d5d296a4b1185"
+  branch = "master"
+  digest = "1:583a0c80f5e3a9343d33aea4aead1e1afcc0043db66fdf961ddd1fe8cd3a4faf"
+  name = "google.golang.org/genproto"
+  packages = ["googleapis/rpc/status"]
+  pruneopts = "UT"
+  revision = "fa694d86fc64c7654a660f8908de4e879866748d"
+
+[[projects]]
+  digest = "1:0e90ae3c56ff4376ffa146d252b206a2041a8ddf9d95b7ab74788f1cfbe6cea5"
+  name = "google.golang.org/grpc"
+  packages = [
+    "codes",
+    "connectivity",
+    "grpclog",
+    "internal",
+    "status",
+  ]
+  pruneopts = "UT"
+  revision = "045159ad57f3781d409358e3ade910a018c16b30"
+  version = "v1.22.1"
+
+[[projects]]
+  digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
   name = "gopkg.in/inf.v0"
   packages = ["."]
   pruneopts = "UT"
-  revision = "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4"
-  version = "v0.9.0"
+  revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
+  version = "v0.9.1"
 
 [[projects]]
-  digest = "1:866df945fc92cd221d2b384dca7de5f3131a6113b9f72a7a8019ae5046abe828"
+  digest = "1:eb27cfcaf8d7e4155224dd0a209f1d0ab19784fef01be142638b78b7b6becd6b"
   name = "gopkg.in/src-d/go-billy.v4"
   packages = [
     ".",
@@ -684,11 +687,11 @@
     "util",
   ]
   pruneopts = "UT"
-  revision = "982626487c60a5252e7d0b695ca23fb0fa2fd670"
-  version = "v4.3.0"
+  revision = "780403cfc1bc95ff4d07e7b26db40a6186c5326e"
+  version = "v4.3.2"
 
 [[projects]]
-  digest = "1:7fcf8681ff737e3fa6b387448717283c2053058c5d7344c22a9a025b0dc5be4a"
+  digest = "1:b2ad0a18676cd4d5b4b180709c1ea34dbabd74b3d7db0cc01e6d287d5f1e3a99"
   name = "gopkg.in/src-d/go-git.v4"
   packages = [
     ".",
@@ -734,8 +737,8 @@
     "utils/merkletrie/noder",
   ]
   pruneopts = "UT"
-  revision = "aa6f288c256ff8baf8a7745546a9752323dc0d89"
-  version = "v4.11.0"
+  revision = "0d1a009cbb604db18be960db5f1525b99a55d727"
+  version = "v4.13.1"
 
 [[projects]]
   digest = "1:78d374b493e747afa9fbb2119687e3740a7fb8d0ebabddfef0a012593aaecbb3"
@@ -791,7 +794,7 @@
     "storage/v1beta1",
   ]
   pruneopts = "UT"
-  revision = "6db15a15d2d3874a6c3ddb2140ac9f3bc7058428"
+  revision = "ee9c4073cffa1a3cce1aad02aa46d3d3e691923d"
 
 [[projects]]
   digest = "1:65a48eb4149e0fc885493a0b6657e2ef20eadfd519024692c7c256878331e981"
@@ -841,7 +844,7 @@
   version = "kubernetes-1.12.3"
 
 [[projects]]
-  digest = "1:2016b778840cfa015ddeea77b09827c9df36843c2100141708a0e62b709eae9e"
+  digest = "1:654f6e64d08002f4a466ca8f77b2d2ec17dacfc5f154601b3a6bbb2afde9de0c"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -920,7 +923,6 @@
     "plugin/pkg/client/auth/gcp",
     "rest",
     "rest/watch",
-    "restmapper",
     "testing",
     "third_party/forked/golang/template",
     "tools/auth",
@@ -948,21 +950,15 @@
   name = "k8s.io/kube-openapi"
   packages = ["pkg/util/proto"]
   pruneopts = "UT"
-  revision = "db7b694dc208eead64d38030265f702db593fcf2"
+  revision = "5e22f3d471e6f24ca20becfdffdc6206c7cecac8"
 
 [[projects]]
-  digest = "1:0fa36a3b628957b84f36eed75e16c048262206b1e3e8fb1410e42649eb881f9f"
+  digest = "1:84a8609383bec11b71d52dd813f33f1d16614b91966940bdc2aa79bea864fa25"
   name = "sigs.k8s.io/controller-runtime"
-  packages = [
-    "pkg/client",
-    "pkg/client/apiutil",
-    "pkg/client/config",
-    "pkg/runtime/log",
-    "pkg/runtime/scheme",
-  ]
+  packages = ["pkg/runtime/scheme"]
   pruneopts = "UT"
-  revision = "f6f0bc9611363b43664d08fb097ab13243ef621d"
-  version = "v0.1.9"
+  revision = "f1eaba5087d69cebb154c6a48193e6667f5b512c"
+  version = "v0.1.12"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -987,16 +983,15 @@
     "k8s.io/api/rbac/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/runtime",
-    "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/runtime/serializer",
     "k8s.io/client-go/dynamic",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
+    "k8s.io/client-go/rest",
     "k8s.io/client-go/testing",
     "k8s.io/client-go/tools/clientcmd",
-    "sigs.k8s.io/controller-runtime/pkg/client",
-    "sigs.k8s.io/controller-runtime/pkg/client/config",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -12,7 +12,15 @@ required = [
 
 [[constraint]]
   name = "github.com/fsouza/go-dockerclient"
-  version = "1.3.5"
+  version = "1.4.1"
+
+# one of our dependencies (gopkg.in/inf.v0@v0.9.1) is trying to download docker 1.13 and it is incompatible with go-dockerclient
+# This override fixes that.
+# We can't use any verison because docker stopped doing releases on 2017, but they keep committing to master.
+
+[[override]]
+  name = "github.com/docker/docker"
+  revision = "ae0c0cdffdf24c2424abaf8d67fe0e0d27c06ccd"
 
 [[constraint]]
   name = "github.com/pkg/errors"
@@ -20,7 +28,7 @@ required = [
 
 [[constraint]]
   name = "github.com/spf13/cobra"
-  version = "0.0.3"
+  version = "0.0.5"
 
 [[constraint]]
   name = "gopkg.in/yaml.v2"
@@ -29,10 +37,6 @@ required = [
 [[override]]
   name = "k8s.io/apimachinery"
   version = "kubernetes-1.12.3"
-
-[[constraint]]
-  name = "sigs.k8s.io/controller-runtime"
-  version = "v0.1.1"
 
 [[constraint]]
   name = "k8s.io/client-go"

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -53,7 +53,7 @@ func NewFromConfigWithTimeout(url, file string, t time.Duration) (KymaKube, erro
 		return nil, err
 	}
 
-	octClient, err := octopus.NewOctopusRESTClient(2 * time.Second)
+	octClient, err := octopus.NewFromConfig(config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/octopus/mock.go
+++ b/pkg/api/octopus/mock.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	oct "github.com/kyma-incubator/octopus/pkg/apis/testing/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type MockedOctopusRestClient struct {
@@ -18,22 +19,22 @@ func NewMockedOctopusRestClient(testDefs *oct.TestDefinitionList, testSuites *oc
 	}
 }
 
-func (m *MockedOctopusRestClient) ListTestDefinitions() (*oct.TestDefinitionList, error) {
+func (m *MockedOctopusRestClient) ListTestDefinitions(opts metav1.ListOptions) (result *oct.TestDefinitionList, err error) {
 	return m.testDefs, nil
 }
 
-func (m *MockedOctopusRestClient) ListTestSuites() (*oct.ClusterTestSuiteList, error) {
+func (m *MockedOctopusRestClient) ListTestSuites(opts metav1.ListOptions) (result *oct.ClusterTestSuiteList, err error) {
 	return m.testSuites, nil
 }
 
-func (m *MockedOctopusRestClient) CreateTestSuite(cts *oct.ClusterTestSuite) error {
+func (m *MockedOctopusRestClient) CreateTestSuite(cts *oct.ClusterTestSuite) (result *oct.ClusterTestSuite, err error) {
 	m.testSuites.Items = append(m.testSuites.Items, *cts)
-	return nil
+	return cts, nil
 }
 
-func (m *MockedOctopusRestClient) DeleteTestSuite(cts *oct.ClusterTestSuite) error {
+func (m *MockedOctopusRestClient) DeleteTestSuite(name string, options metav1.DeleteOptions) error {
 	for i := 0; i < len(m.testSuites.Items); i++ {
-		if m.testSuites.Items[i].GetName() == cts.GetName() {
+		if m.testSuites.Items[i].GetName() == name {
 			m.testSuites.Items = append(m.testSuites.Items[i:],
 				m.testSuites.Items[i+1:]...)
 			return nil
@@ -42,7 +43,7 @@ func (m *MockedOctopusRestClient) DeleteTestSuite(cts *oct.ClusterTestSuite) err
 	return fmt.Errorf("test not found")
 }
 
-func (m *MockedOctopusRestClient) GetTestSuiteByName(name string) (*oct.ClusterTestSuite, error) {
+func (m *MockedOctopusRestClient) GetTestSuite(name string, options metav1.GetOptions) (result *oct.ClusterTestSuite, err error) {
 	for i := 0; i < len(m.testSuites.Items); i++ {
 		if m.testSuites.Items[i].GetName() == name {
 			return &m.testSuites.Items[i], nil

--- a/pkg/kyma/cmd/test/common.go
+++ b/pkg/kyma/cmd/test/common.go
@@ -4,11 +4,10 @@ import (
 	"io"
 
 	oct "github.com/kyma-incubator/octopus/pkg/apis/testing/v1alpha1"
+	"github.com/kyma-project/cli/pkg/api/octopus"
 	"github.com/olekukonko/tablewriter"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-const NamespaceForTests = "kyma-system"
 
 func NewTestSuite(name string) *oct.ClusterTestSuite {
 	return &oct.ClusterTestSuite{
@@ -18,7 +17,7 @@ func NewTestSuite(name string) *oct.ClusterTestSuite {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: NamespaceForTests,
+			Namespace: octopus.NamespaceForTests,
 		},
 	}
 }

--- a/pkg/kyma/cmd/test/common_test.go
+++ b/pkg/kyma/cmd/test/common_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	oct "github.com/kyma-incubator/octopus/pkg/apis/testing/v1alpha1"
+	"github.com/kyma-project/cli/pkg/api/octopus"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -24,7 +25,7 @@ func Test_NewTestSuite(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test1",
-					Namespace: NamespaceForTests,
+					Namespace: octopus.NamespaceForTests,
 				},
 			},
 		},

--- a/pkg/kyma/cmd/test/definitions/cmd.go
+++ b/pkg/kyma/cmd/test/definitions/cmd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kyma-project/cli/pkg/kyma/core"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type command struct {
@@ -53,7 +54,7 @@ func (cmd *command) Run() error {
 }
 
 func listTestDefinitionNames(cli octopus.OctopusInterface) ([]string, error) {
-	defs, err := cli.ListTestDefinitions()
+	defs, err := cli.ListTestDefinitions(metav1.ListOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to list test definitions")
 	}

--- a/pkg/kyma/cmd/test/delete/cmd.go
+++ b/pkg/kyma/cmd/test/delete/cmd.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kyma-project/cli/pkg/kyma/core"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type command struct {
@@ -63,7 +64,7 @@ func (cmd *command) Run(args []string) error {
 }
 
 func deleteTestSuite(cli octopus.OctopusInterface, testName string) error {
-	if err := cli.DeleteTestSuite(test.NewTestSuite(testName)); err != nil {
+	if err := cli.DeleteTestSuite(test.NewTestSuite(testName).GetName(), metav1.DeleteOptions{}); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Unable to delete test suite '%s'",
 			testName))
 	}

--- a/pkg/kyma/cmd/test/list/cmd.go
+++ b/pkg/kyma/cmd/test/list/cmd.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kyma-project/cli/pkg/kyma/core"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type command struct {
@@ -39,7 +40,7 @@ func (cmd *command) Run() error {
 		return errors.Wrap(err, "Could not initialize the Kubernetes client. Make sure that your kubeconfig is valid.")
 	}
 
-	testSuites, err := cmd.K8s.Octopus().ListTestSuites()
+	testSuites, err := cmd.K8s.Octopus().ListTestSuites(metav1.ListOptions{})
 	if err != nil {
 		return errors.Wrap(err, "Unable to get list of test suites")
 	}

--- a/pkg/kyma/cmd/test/run/cmd.go
+++ b/pkg/kyma/cmd/test/run/cmd.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kyma-project/cli/pkg/kyma/core"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type command struct {
@@ -71,7 +72,7 @@ func (cmd *command) Run(args []string) error {
 		return fmt.Errorf("Test suite '%s' already exists", testSuiteName)
 	}
 
-	clusterTestDefs, err := cmd.K8s.Octopus().ListTestDefinitions()
+	clusterTestDefs, err := cmd.K8s.Octopus().ListTestDefinitions(metav1.ListOptions{})
 	if err != nil {
 		return errors.Wrap(err, "Unable to get the list of test definitions")
 	}
@@ -93,7 +94,7 @@ func (cmd *command) Run(args []string) error {
 		return err
 	}
 
-	if err := cmd.K8s.Octopus().CreateTestSuite(testResource); err != nil {
+	if _, err := cmd.K8s.Octopus().CreateTestSuite(testResource); err != nil {
 		return err
 	}
 
@@ -141,7 +142,7 @@ func generateTestsResource(testName string, numberOfExecutions,
 }
 
 func listTestSuiteNames(cli octopus.OctopusInterface) ([]string, error) {
-	suites, err := cli.ListTestSuites()
+	suites, err := cli.ListTestSuites(metav1.ListOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to list test suites")
 	}

--- a/pkg/kyma/cmd/test/run/cmd_test.go
+++ b/pkg/kyma/cmd/test/run/cmd_test.go
@@ -5,7 +5,6 @@ import (
 
 	oct "github.com/kyma-incubator/octopus/pkg/apis/testing/v1alpha1"
 	"github.com/kyma-project/cli/pkg/api/octopus"
-	"github.com/kyma-project/cli/pkg/kyma/cmd/test"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -117,7 +116,7 @@ func Test_generateTestsResource(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "TestOneProper",
-					Namespace: test.NamespaceForTests,
+					Namespace: octopus.NamespaceForTests,
 				},
 				Spec: oct.TestSuiteSpec{
 					Count:       1,

--- a/pkg/kyma/cmd/test/status/cmd.go
+++ b/pkg/kyma/cmd/test/status/cmd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type command struct {
@@ -56,14 +57,14 @@ func (cmd *command) Run(args []string) error {
 
 	switch len(args) {
 	case 1:
-		testSuite, err := cmd.K8s.Octopus().GetTestSuiteByName(args[0])
+		testSuite, err := cmd.K8s.Octopus().GetTestSuite(args[0], metav1.GetOptions{})
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("unable to get test suite '%s'",
 				args[0]))
 		}
 		return cmd.printTestSuiteStatus(testSuite, cmd.opts.OutputFormat)
 	case 0:
-		testList, err := cmd.K8s.Octopus().ListTestSuites()
+		testList, err := cmd.K8s.Octopus().ListTestSuites(metav1.ListOptions{})
 		if err != nil {
 			return errors.Wrap(err, "unable to list test suites")
 		}
@@ -193,7 +194,7 @@ func generateRerunCommand(testSuite *oct.ClusterTestSuite) string {
 }
 
 func listTestSuitesByName(cli octopus.OctopusInterface, names []string) ([]oct.ClusterTestSuite, error) {
-	suites, err := cli.ListTestSuites()
+	suites, err := cli.ListTestSuites(metav1.ListOptions{})
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to list test suites")
 	}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Attempted upgrade to k8s client-go 1.15 but octopus is blocking it.
- Octopus k8s rest client now uses the same approach as the standard k8s API.
- Remove dependency to `controller-runtime`.
- Updated some dependencies.
- This change makes future upgrades easier.

**Related issue(s)**
#188
