### PR TITLE
If core console not found , don't abort the instalation

### DIFF
--- a/cmd/kyma/install/cmd.go
+++ b/cmd/kyma/install/cmd.go
@@ -743,10 +743,12 @@ func (cmd *command) printSummary() error {
 	switch {
 	case apiErrors.IsNotFound(err):
 		consoleURL = "not installed"
+	case err != nil:
+		return err
 	case vs != nil && vs.Spec != nil && len(vs.Spec.Hosts) > 0:
 		consoleURL = fmt.Sprintf("https://%s", vs.Spec.Hosts[0])
 	default:
-		return err
+		return errors.New("Console host could not be obtained.")
 	}
 
 	clusterInfo, err := cmd.Kubectl().RunCmd("cluster-info")

--- a/cmd/kyma/install/cmd.go
+++ b/cmd/kyma/install/cmd.go
@@ -742,11 +742,11 @@ func (cmd *command) printSummary() error {
 	vs, err := cmd.K8s.Istio().NetworkingV1alpha3().VirtualServices("kyma-system").Get("core-console", metav1.GetOptions{})
 	switch {
 	case apiErrors.IsNotFound(err):
-		consoleURL = "not found"
-	case err != nil:
-		return err
-	case vs != nil:
+		consoleURL = "not installed"
+	case vs != nil && vs.Spec != nil && len(vs.Spec.Hosts) > 0:
 		consoleURL = fmt.Sprintf("https://%s", vs.Spec.Hosts[0])
+	default:
+		return err
 	}
 
 	clusterInfo, err := cmd.Kubectl().RunCmd("cluster-info")

--- a/cmd/kyma/install/cmd.go
+++ b/cmd/kyma/install/cmd.go
@@ -758,7 +758,7 @@ func (cmd *command) printSummary() error {
 	fmt.Println(clusterInfo)
 	fmt.Println()
 	fmt.Printf("Kyma is installed in version %s\n", v)
-	fmt.Printf("Kyma console:s\t\t%s\n", consoleURL)
+	fmt.Printf("Kyma console:\t\t%s\n", consoleURL)
 	fmt.Printf("Kyma admin email:\t%s\n", adm.Data["email"])
 	if cmd.opts.Password == "" || cmd.opts.NonInteractive {
 		fmt.Printf("Kyma admin password:\t%s\n", adm.Data["password"])

--- a/cmd/kyma/install/cmd.go
+++ b/cmd/kyma/install/cmd.go
@@ -738,9 +738,15 @@ func (cmd *command) printSummary() error {
 		return err
 	}
 
+	var consoleURL string
 	vs, err := cmd.K8s.Istio().NetworkingV1alpha3().VirtualServices("kyma-system").Get("core-console", metav1.GetOptions{})
-	if err != nil {
+	switch {
+	case apiErrors.IsNotFound(err):
+		consoleURL = "not found"
+	case err != nil:
 		return err
+	case vs != nil:
+		consoleURL = fmt.Sprintf("https://%s", vs.Spec.Hosts[0])
 	}
 
 	clusterInfo, err := cmd.Kubectl().RunCmd("cluster-info")
@@ -752,7 +758,7 @@ func (cmd *command) printSummary() error {
 	fmt.Println(clusterInfo)
 	fmt.Println()
 	fmt.Printf("Kyma is installed in version %s\n", v)
-	fmt.Printf("Kyma console:\t\thttps://%s\n", vs.Spec.Hosts[0])
+	fmt.Printf("Kyma console:s\t\t%s\n", consoleURL)
 	fmt.Printf("Kyma admin email:\t%s\n", adm.Data["email"])
 	if cmd.opts.Password == "" || cmd.opts.NonInteractive {
 		fmt.Printf("Kyma admin password:\t%s\n", adm.Data["password"])


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
CI fails on Kyma `Compass` project, because we don't use`core-console` virtualservice.

Changes proposed in this pull request:
- print message  `Kyma console: 		not found` instead of exiting when `core-console` not found.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
