### PR TITLE
Improve summary and patch configmaps with K8s API

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -88,6 +88,13 @@
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:e921c3d4324ffdcb4fd39d5f47a832f2112d44731a5f21d8ae0ccfe82e608711"
+  name = "github.com/daviddengcn/go-colortext"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "186a3d44e9200d7eb331356ca4864f52708e1399"
+
+[[projects]]
   digest = "1:699aca47d5af672db37b96102bb088edbf26f84f73d3dafff6fa917026eb6971"
   name = "github.com/docker/distribution"
   packages = ["registry/api/errcode"]
@@ -1006,6 +1013,7 @@
   input-imports = [
     "github.com/Masterminds/semver",
     "github.com/briandowns/spinner",
+    "github.com/daviddengcn/go-colortext",
     "github.com/fatih/color",
     "github.com/fsouza/go-dockerclient",
     "github.com/kyma-incubator/octopus/pkg/apis",
@@ -1028,6 +1036,7 @@
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/serializer",
+    "k8s.io/apimachinery/pkg/types",
     "k8s.io/client-go/dynamic",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -49,3 +49,7 @@ required = [
 [[override]]
   name = "github.com/russross/blackfriday"
   version = "1.4.0"  
+
+[[constraint]]
+  name = "github.com/daviddengcn/go-colortext"
+  revision = "186a3d44e9200d7eb331356ca4864f52708e1399"

--- a/cmd/kyma/uninstall/cmd.go
+++ b/cmd/kyma/uninstall/cmd.go
@@ -239,7 +239,7 @@ func (cmd *command) printUninstallSummary() error {
 
 func (cmd *command) waitForInstallerToUninstall() error {
 	currentDesc := ""
-	_ = cmd.NewStep("Waiting for uninstallation to start")
+	cmd.NewStep("Waiting for uninstallation to start")
 
 	status, err := cmd.Kubectl().RunCmd("get", "installation/kyma-installation", "-o", "jsonpath='{.status.state}'")
 	if err != nil {
@@ -259,7 +259,7 @@ func (cmd *command) waitForInstallerToUninstall() error {
 		select {
 		case <-timeout:
 			cmd.CurrentStep.Failure()
-			_ = cmd.printUninstallationErrorLog()
+			cmd.printUninstallationErrorLog()
 			return errors.New("Time-out reached while waiting for Kyma to uninstall")
 		default:
 			status, desc, err := cmd.getUninstallationStatus()

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -10,6 +10,7 @@ import (
 
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	istioNet "github.com/kyma-project/kyma/components/api-controller/pkg/clients/networking.istio.io/clientset/versioned"
@@ -27,6 +28,7 @@ type client struct {
 	dynamic dynamic.Interface
 	octps   octopus.OctopusInterface
 	istio   istioNet.Interface
+	cfg     *rest.Config
 }
 
 // NewFromConfig creates a new Kubernetes client based on the given Kubeconfig either provided by URL (in-cluster config) or via file (out-of-cluster config).
@@ -70,6 +72,7 @@ func NewFromConfigWithTimeout(url, file string, t time.Duration) (KymaKube, erro
 			dynamic: dClient,
 			octps:   octClient,
 			istio:   istioClient,
+			cfg:     config,
 		},
 		nil
 
@@ -89,6 +92,10 @@ func (c *client) Octopus() octopus.OctopusInterface {
 
 func (c *client) Istio() istioNet.Interface {
 	return c.istio
+}
+
+func (c *client) Config() *rest.Config {
+	return c.cfg
 }
 
 func (c *client) IsPodDeployed(namespace, name string) (bool, error) {

--- a/internal/kube/kube.go
+++ b/internal/kube/kube.go
@@ -7,6 +7,7 @@ import (
 	istioNet "github.com/kyma-project/kyma/components/api-controller/pkg/clients/networking.istio.io/clientset/versioned"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 // KymaKube defines the Kyma-enhanced kubernetes API.
@@ -16,6 +17,10 @@ type KymaKube interface {
 	Dynamic() dynamic.Interface
 	Octopus() octopus.OctopusInterface
 	Istio() istioNet.Interface
+
+	// Config provides the configuration of the kubernetes client
+	Config() *rest.Config
+
 	// IsPodDeployed checks if a pod is in the given namespace (independently of its status)
 	IsPodDeployed(namespace, name string) (bool, error)
 

--- a/internal/minikube/minikube.go
+++ b/internal/minikube/minikube.go
@@ -70,7 +70,7 @@ func DockerClient(verbose bool) (*docker.Client, error) {
 	oldEnvs := make(map[string]string)
 	defer func() {
 		for key, val := range oldEnvs {
-			_ = os.Setenv(key, val)
+			os.Setenv(key, val)
 		}
 	}()
 	for _, line := range strings.Split(envOut, "\n") {

--- a/internal/nice/nice.go
+++ b/internal/nice/nice.go
@@ -1,0 +1,25 @@
+// package nice provides nice printing for the CLI
+package nice
+
+import (
+	"fmt"
+
+	ct "github.com/daviddengcn/go-colortext"
+)
+
+// PrintKyma prints the Kyma word with its identity color
+func PrintKyma() {
+	ct.ChangeColor(ct.Cyan, false, ct.None, false)
+	fmt.Print("Kyma")
+	ct.ResetColor()
+}
+
+func PrintImportant(s string) {
+	ct.ChangeColor(ct.Yellow, true, ct.None, false)
+	fmt.Println(s)
+	ct.ResetColor()
+}
+
+func PrintImportantf(format string, a ...interface{}) {
+	PrintImportant(fmt.Sprintf(format, a...))
+}

--- a/internal/step/simple.go
+++ b/internal/step/simple.go
@@ -65,7 +65,7 @@ func (s *simpleStep) LogInfof(format string, args ...interface{}) {
 }
 
 func (s *simpleStep) LogError(msg string) {
-	_, _ = fmt.Fprintf(os.Stderr, "%s%s\n", warningGlyph, msg)
+	fmt.Fprintf(os.Stderr, "%s%s\n", warningGlyph, msg)
 }
 
 func (s *simpleStep) LogErrorf(format string, args ...interface{}) {

--- a/internal/step/spinner.go
+++ b/internal/step/spinner.go
@@ -88,7 +88,7 @@ func (s *stepWithSpinner) LogErrorf(format string, args ...interface{}) {
 func (s *stepWithSpinner) logTof(to io.Writer, format string, args ...interface{}) {
 	isActive := s.spinner.Active()
 	s.spinner.Stop()
-	_, _ = fmt.Fprintf(to, format+"\n", args...)
+	fmt.Fprintf(to, format+"\n", args...)
 	if isActive {
 		s.spinner.Start()
 	}
@@ -97,7 +97,7 @@ func (s *stepWithSpinner) logTof(to io.Writer, format string, args ...interface{
 func (s *stepWithSpinner) logTo(to io.Writer, format string) {
 	isActive := s.spinner.Active()
 	s.spinner.Stop()
-	_, _ = fmt.Fprint(to, format+"\n")
+	fmt.Fprint(to, format+"\n")
 	if isActive {
 		s.spinner.Start()
 	}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Improved the summary after installing Kyma
![Screen Shot 2019-09-09 at 17 38 19](https://user-images.githubusercontent.com/1059661/64545523-2e92c000-d329-11e9-8bee-b56018616cca.png)
- Now configmap patching uses K8s API instead of Kubectl
- The kyma k8s API now exposes the client configuration
- Removed some unnecessary explicitly ignored return values

**Related issue(s)**
A bit of #158
