### PR TITLE
Default --kubeconfig flag value improved

### DIFF
--- a/cmd/kyma/kyma.go
+++ b/cmd/kyma/kyma.go
@@ -1,6 +1,8 @@
 package kyma
 
 import (
+	"os"
+
 	"github.com/kyma-project/cli/cmd/kyma/completion"
 	"github.com/kyma-project/cli/cmd/kyma/console"
 	"github.com/kyma-project/cli/cmd/kyma/install"
@@ -37,9 +39,9 @@ For more information, see: https://github.com/kyma-project/cli
 
 	cmd.PersistentFlags().BoolVarP(&o.Verbose, "verbose", "v", false, "Displays details of actions triggered by the command.")
 	cmd.PersistentFlags().BoolVar(&o.NonInteractive, "non-interactive", false, "Enables the non-interactive shell mode.")
-	cmd.PersistentFlags().StringVar(&o.KubeconfigPath, "kubeconfig", clientcmd.RecommendedHomeFile, "Specifies the path to the kubeconfig file.")
+	cmd.PersistentFlags().StringVar(&o.KubeconfigPath, "kubeconfig", defaultKubeconfig(), "Specifies the path to the kubeconfig file.")
 	cmd.Flags().Bool("help", false, "Displays help for the command.")
-	
+
 	provisionCmd := provision.NewCmd()
 	provisionCmd.AddCommand(minikube.NewCmd(minikube.NewOptions(o)))
 
@@ -62,4 +64,14 @@ For more information, see: https://github.com/kyma-project/cli
 	cmd.AddCommand(testCmd)
 
 	return cmd
+}
+
+func defaultKubeconfig() string {
+	env := os.Getenv("KUBECONFIG")
+
+	if env == "" {
+		return clientcmd.RecommendedHomeFile
+	}
+
+	return env
 }

--- a/cmd/kyma/kyma_test.go
+++ b/cmd/kyma/kyma_test.go
@@ -2,22 +2,37 @@ package kyma
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
+
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/kyma-project/cli/internal/cli"
 	"github.com/stretchr/testify/require"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 // TestKymaFlags ensures that the provided command flags are stored in the options.
 func TestKymaFlags(t *testing.T) {
 	o := &cli.Options{}
+
+	// test default flag values
+	// KUBECONFIG is set
+	os.Setenv("KUBECONFIG", "/my/kube/path")
 	c := NewCmd(o)
 	c.SetOutput(ioutil.Discard) // not interested in the command's output
 
-	// test default flag values
 	require.NoError(t, c.Execute(), "Command execution must not fail")
-	require.Equal(t, clientcmd.RecommendedHomeFile, o.KubeconfigPath, "kubeconfig path must have the default flag value")
+	require.Equal(t, "/my/kube/path", o.KubeconfigPath, "kubeconfig path must have the value of the KUBECONFIG environment variable")
+	require.False(t, o.Verbose, "Verbose flag must be false")
+	require.False(t, o.NonInteractive, "Non-interactive flag must be false")
+
+	// KUBECONFIG is not set
+	os.Setenv("KUBECONFIG", "")
+	c = NewCmd(o)
+	c.SetOutput(ioutil.Discard) // not interested in the command's output
+
+	require.NoError(t, c.Execute(), "Command execution must not fail")
+	require.Equal(t, clientcmd.RecommendedHomeFile, o.KubeconfigPath, "kubeconfig path must have the value of the k8s recommended path")
 	require.False(t, o.Verbose, "Verbose flag must be false")
 	require.False(t, o.NonInteractive, "Non-interactive flag must be false")
 

--- a/docs/gen-docs/kyma.md
+++ b/docs/gen-docs/kyma.md
@@ -14,7 +14,7 @@ For more information, see: https://github.com/kyma-project/cli
 
 ```
   -h, --help                Displays help for the command.
-      --kubeconfig string   Specifies the path to the kubeconfig file. (default "/$HOME/.kube/config")
+      --kubeconfig string   Specifies the path to the kubeconfig file. (default KUBECONFIG environment variable or "/$HOME/.kube/config" if KUBECONFIG is not set)
       --non-interactive     Enables the non-interactive shell mode.
   -v, --verbose             Displays details of actions triggered by the command.
 ```

--- a/docs/gen-docs/kyma_completion.md
+++ b/docs/gen-docs/kyma_completion.md
@@ -23,7 +23,7 @@ kyma completion [flags]
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig string   Specifies the path to the kubeconfig file. (default "/$HOME/.kube/config")
+      --kubeconfig string   Specifies the path to the kubeconfig file. (default KUBECONFIG environment variable or "/$HOME/.kube/config" if KUBECONFIG is not set)
       --non-interactive     Enables the non-interactive shell mode.
   -v, --verbose             Displays details of actions triggered by the command.
 ```

--- a/docs/gen-docs/kyma_console.md
+++ b/docs/gen-docs/kyma_console.md
@@ -21,7 +21,7 @@ kyma console [flags]
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig string   Specifies the path to the kubeconfig file. (default "/$HOME/.kube/config")
+      --kubeconfig string   Specifies the path to the kubeconfig file. (default KUBECONFIG environment variable or "/$HOME/.kube/config" if KUBECONFIG is not set)
       --non-interactive     Enables the non-interactive shell mode.
   -v, --verbose             Displays details of actions triggered by the command.
 ```

--- a/docs/gen-docs/kyma_install.md
+++ b/docs/gen-docs/kyma_install.md
@@ -76,7 +76,7 @@ kyma install [flags]
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig string   Specifies the path to the kubeconfig file. (default "/$HOME/.kube/config")
+      --kubeconfig string   Specifies the path to the kubeconfig file. (default KUBECONFIG environment variable or "/$HOME/.kube/config" if KUBECONFIG is not set)
       --non-interactive     Enables the non-interactive shell mode.
   -v, --verbose             Displays details of actions triggered by the command.
 ```

--- a/docs/gen-docs/kyma_provision.md
+++ b/docs/gen-docs/kyma_provision.md
@@ -15,7 +15,7 @@ Provisions a cluster for Kyma installation.
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig string   Specifies the path to the kubeconfig file. (default "/$HOME/.kube/config")
+      --kubeconfig string   Specifies the path to the kubeconfig file. (default KUBECONFIG environment variable or "/$HOME/.kube/config" if KUBECONFIG is not set)
       --non-interactive     Enables the non-interactive shell mode.
   -v, --verbose             Displays details of actions triggered by the command.
 ```

--- a/docs/gen-docs/kyma_provision_minikube.md
+++ b/docs/gen-docs/kyma_provision_minikube.md
@@ -24,7 +24,7 @@ kyma provision minikube [flags]
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig string   Specifies the path to the kubeconfig file. (default "/$HOME/.kube/config")
+      --kubeconfig string   Specifies the path to the kubeconfig file. (default KUBECONFIG environment variable or "/$HOME/.kube/config" if KUBECONFIG is not set)
       --non-interactive     Enables the non-interactive shell mode.
   -v, --verbose             Displays details of actions triggered by the command.
 ```

--- a/docs/gen-docs/kyma_test.md
+++ b/docs/gen-docs/kyma_test.md
@@ -15,7 +15,7 @@ Use this command to run tests on a provisioned Kyma cluster.
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig string   Specifies the path to the kubeconfig file. (default "/$HOME/.kube/config")
+      --kubeconfig string   Specifies the path to the kubeconfig file. (default KUBECONFIG environment variable or "/$HOME/.kube/config" if KUBECONFIG is not set)
       --non-interactive     Enables the non-interactive shell mode.
   -v, --verbose             Displays details of actions triggered by the command.
 ```

--- a/docs/gen-docs/kyma_test_definitions.md
+++ b/docs/gen-docs/kyma_test_definitions.md
@@ -19,7 +19,7 @@ kyma test definitions [flags]
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig string   Specifies the path to the kubeconfig file. (default "/$HOME/.kube/config")
+      --kubeconfig string   Specifies the path to the kubeconfig file. (default KUBECONFIG environment variable or "/$HOME/.kube/config" if KUBECONFIG is not set)
       --non-interactive     Enables the non-interactive shell mode.
   -v, --verbose             Displays details of actions triggered by the command.
 ```

--- a/docs/gen-docs/kyma_test_delete.md
+++ b/docs/gen-docs/kyma_test_delete.md
@@ -21,7 +21,7 @@ kyma test delete <test-suite-1> <test-suite-2> ... <test-suite-N> [flags]
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig string   Specifies the path to the kubeconfig file. (default "/$HOME/.kube/config")
+      --kubeconfig string   Specifies the path to the kubeconfig file. (default KUBECONFIG environment variable or "/$HOME/.kube/config" if KUBECONFIG is not set)
       --non-interactive     Enables the non-interactive shell mode.
   -v, --verbose             Displays details of actions triggered by the command.
 ```

--- a/docs/gen-docs/kyma_test_list.md
+++ b/docs/gen-docs/kyma_test_list.md
@@ -19,7 +19,7 @@ kyma test list [flags]
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig string   Specifies the path to the kubeconfig file. (default "/$HOME/.kube/config")
+      --kubeconfig string   Specifies the path to the kubeconfig file. (default KUBECONFIG environment variable or "/$HOME/.kube/config" if KUBECONFIG is not set)
       --non-interactive     Enables the non-interactive shell mode.
   -v, --verbose             Displays details of actions triggered by the command.
 ```

--- a/docs/gen-docs/kyma_test_run.md
+++ b/docs/gen-docs/kyma_test_run.md
@@ -30,7 +30,7 @@ kyma test run <test-definition-1> <test-defintion-2> ... <test-definition-N> [fl
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig string   Specifies the path to the kubeconfig file. (default "/$HOME/.kube/config")
+      --kubeconfig string   Specifies the path to the kubeconfig file. (default KUBECONFIG environment variable or "/$HOME/.kube/config" if KUBECONFIG is not set)
       --non-interactive     Enables the non-interactive shell mode.
   -v, --verbose             Displays details of actions triggered by the command.
 ```

--- a/docs/gen-docs/kyma_test_status.md
+++ b/docs/gen-docs/kyma_test_status.md
@@ -30,7 +30,7 @@ kyma test status <test-suite-1> <test-suite-2> ... <test-suite-N> [flags]
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig string   Specifies the path to the kubeconfig file. (default "/$HOME/.kube/config")
+      --kubeconfig string   Specifies the path to the kubeconfig file. (default KUBECONFIG environment variable or "/$HOME/.kube/config" if KUBECONFIG is not set)
       --non-interactive     Enables the non-interactive shell mode.
   -v, --verbose             Displays details of actions triggered by the command.
 ```

--- a/docs/gen-docs/kyma_uninstall.md
+++ b/docs/gen-docs/kyma_uninstall.md
@@ -30,7 +30,7 @@ kyma uninstall [flags]
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig string   Specifies the path to the kubeconfig file. (default "/$HOME/.kube/config")
+      --kubeconfig string   Specifies the path to the kubeconfig file. (default KUBECONFIG environment variable or "/$HOME/.kube/config" if KUBECONFIG is not set)
       --non-interactive     Enables the non-interactive shell mode.
   -v, --verbose             Displays details of actions triggered by the command.
 ```

--- a/docs/gen-docs/kyma_version.md
+++ b/docs/gen-docs/kyma_version.md
@@ -21,7 +21,7 @@ kyma version [flags]
 ### Options inherited from parent commands
 
 ```
-      --kubeconfig string   Specifies the path to the kubeconfig file. (default "/$HOME/.kube/config")
+      --kubeconfig string   Specifies the path to the kubeconfig file. (default KUBECONFIG environment variable or "/$HOME/.kube/config" if KUBECONFIG is not set)
       --non-interactive     Enables the non-interactive shell mode.
   -v, --verbose             Displays details of actions triggered by the command.
 ```


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Now the default value for the kubeconfig flag is either the KUBECONFIG environment variable or the k8s reccomended path if not set.