### PR TITLE
Kubeconfig is now loaded exactly how kubectl does

### DIFF
--- a/cmd/kyma/kyma.go
+++ b/cmd/kyma/kyma.go
@@ -1,8 +1,6 @@
 package kyma
 
 import (
-	"os"
-
 	"github.com/kyma-project/cli/cmd/kyma/completion"
 	"github.com/kyma-project/cli/cmd/kyma/console"
 	"github.com/kyma-project/cli/cmd/kyma/install"
@@ -19,7 +17,6 @@ import (
 	"github.com/kyma-project/cli/cmd/kyma/provision"
 	"github.com/kyma-project/cli/internal/cli"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 //NewCmd creates a new kyma CLI command
@@ -39,7 +36,8 @@ For more information, see: https://github.com/kyma-project/cli
 
 	cmd.PersistentFlags().BoolVarP(&o.Verbose, "verbose", "v", false, "Displays details of actions triggered by the command.")
 	cmd.PersistentFlags().BoolVar(&o.NonInteractive, "non-interactive", false, "Enables the non-interactive shell mode.")
-	cmd.PersistentFlags().StringVar(&o.KubeconfigPath, "kubeconfig", defaultKubeconfig(), "Specifies the path to the kubeconfig file.")
+	// Kubeconfig env var and defualt paths are resolved by the kyma k8s client using the k8s defined resolution strategy.
+	cmd.PersistentFlags().StringVar(&o.KubeconfigPath, "kubeconfig", "", "Specifies the path to the kubeconfig file.")
 	cmd.Flags().Bool("help", false, "Displays help for the command.")
 
 	provisionCmd := provision.NewCmd()
@@ -64,14 +62,4 @@ For more information, see: https://github.com/kyma-project/cli
 	cmd.AddCommand(testCmd)
 
 	return cmd
-}
-
-func defaultKubeconfig() string {
-	env := os.Getenv("KUBECONFIG")
-
-	if env == "" {
-		return clientcmd.RecommendedHomeFile
-	}
-
-	return env
 }

--- a/cmd/kyma/kyma_test.go
+++ b/cmd/kyma/kyma_test.go
@@ -2,10 +2,7 @@ package kyma
 
 import (
 	"io/ioutil"
-	"os"
 	"testing"
-
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/kyma-project/cli/internal/cli"
 	"github.com/stretchr/testify/require"
@@ -14,25 +11,12 @@ import (
 // TestKymaFlags ensures that the provided command flags are stored in the options.
 func TestKymaFlags(t *testing.T) {
 	o := &cli.Options{}
-
-	// test default flag values
-	// KUBECONFIG is set
-	os.Setenv("KUBECONFIG", "/my/kube/path")
 	c := NewCmd(o)
 	c.SetOutput(ioutil.Discard) // not interested in the command's output
 
+	// test default flag values
 	require.NoError(t, c.Execute(), "Command execution must not fail")
-	require.Equal(t, "/my/kube/path", o.KubeconfigPath, "kubeconfig path must have the value of the KUBECONFIG environment variable")
-	require.False(t, o.Verbose, "Verbose flag must be false")
-	require.False(t, o.NonInteractive, "Non-interactive flag must be false")
-
-	// KUBECONFIG is not set
-	os.Setenv("KUBECONFIG", "")
-	c = NewCmd(o)
-	c.SetOutput(ioutil.Discard) // not interested in the command's output
-
-	require.NoError(t, c.Execute(), "Command execution must not fail")
-	require.Equal(t, clientcmd.RecommendedHomeFile, o.KubeconfigPath, "kubeconfig path must have the value of the k8s recommended path")
+	require.Equal(t, "", o.KubeconfigPath, "kubeconfig path must be empty when default")
 	require.False(t, o.Verbose, "Verbose flag must be false")
 	require.False(t, o.NonInteractive, "Non-interactive flag must be false")
 

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -39,8 +39,11 @@ func NewFromConfig(url, file string) (KymaKube, error) {
 // NewFromConfigWithTimeout creates a new Kubernetes client based on the given Kubeconfig either provided by URL (in-cluster config) or via file (out-of-cluster config).
 // Allows to set a custom timeout for the Kubernetes HTTP client.
 func NewFromConfigWithTimeout(url, file string, t time.Duration) (KymaKube, error) {
+	// Default PathOptions gets kubeconfig in this order: the explicit path given, KUBECONFIG current context, recommentded file path
+	po := clientcmd.NewDefaultPathOptions()
+	po.LoadingRules.ExplicitPath = file
 
-	config, err := clientcmd.BuildConfigFromFlags(url, file)
+	config, err := clientcmd.BuildConfigFromKubeconfigGetter(url, po.GetStartingConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/kubectl/wrapper.go
+++ b/internal/kubectl/wrapper.go
@@ -15,7 +15,9 @@ func NewWrapper(verbose bool, kubeconfig string) *Wrapper {
 }
 
 func (w *Wrapper) RunCmd(args ...string) (string, error) {
-	args = append(args, fmt.Sprintf("--kubeconfig=%s", w.kubeconfig))
+	if len(w.kubeconfig) != 0 {
+		args = append(args, fmt.Sprintf("--kubeconfig=%s", w.kubeconfig))
+	}
 	return runCmd(w.verbose, args...)
 }
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Now using the k8s go client package to resolve kubeconfig flag, env var and also default paths. This means we will always follow the standard regarding how kubeconfig is managed.
