### PR TITLE
Greatly reduce unit test execution time

### DIFF
--- a/cmd/kyma/kyma_test.go
+++ b/cmd/kyma/kyma_test.go
@@ -15,15 +15,12 @@ func TestKymaFlags(t *testing.T) {
 	c.SetOutput(ioutil.Discard) // not interested in the command's output
 
 	// test default flag values
-	require.NoError(t, c.Execute(), "Command execution must not fail")
 	require.Equal(t, "", o.KubeconfigPath, "kubeconfig path must be empty when default")
 	require.False(t, o.Verbose, "Verbose flag must be false")
 	require.False(t, o.NonInteractive, "Non-interactive flag must be false")
 
 	// test passing flags
-	c.SetArgs([]string{"--kubeconfig=/some/file", "--non-interactive=true", "--verbose=true"})
-
-	require.NoError(t, c.Execute(), "Command execution must not fail")
+	c.ParseFlags([]string{"--kubeconfig=/some/file", "--non-interactive=true", "--verbose=true"})
 	require.Equal(t, "/some/file", o.KubeconfigPath, "kubeconfig path must be the same as the flag provided")
 	require.True(t, o.Verbose, "Verbose flag must be true")
 	require.True(t, o.NonInteractive, "Non-interactive flag must be true")

--- a/cmd/kyma/uninstall/cmd_test.go
+++ b/cmd/kyma/uninstall/cmd_test.go
@@ -16,14 +16,11 @@ func TestUninstallFlags(t *testing.T) {
 	c.SetOutput(ioutil.Discard) // not interested in the command's output
 
 	// test default flag values
-	require.Error(t, c.Execute(), "Command execution fails") // command fails becuase there is no kyma to uninstall, but it is ok.
 	require.Equal(t, 30*time.Minute, o.Timeout, "Incorrect default uninstall time-out")
 
 	// test passing flags
-	c.SetArgs([]string{"--timeout=60m0s"})
-
-	require.Error(t, c.Execute(), "Command execution fails")
-	require.Equal(t, 60*time.Minute, o.Timeout, "Incorrect default uninstall time-out")
+	c.ParseFlags([]string{"--timeout=60m0s"})
+	require.Equal(t, 60*time.Minute, o.Timeout, "Incorrect specified uninstall time-out")
 }
 
 func TestUninstallSubcommands(t *testing.T) {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Unit tests for flags were executing full commands to just test the flags. Now flags are parsed without running the commands, reducing the test time significantly.