### PR TITLE
fix kyma-installer image registry path

### DIFF
--- a/cmd/kyma/install/cmd.go
+++ b/cmd/kyma/install/cmd.go
@@ -58,8 +58,7 @@ const (
 	sleep                       = 10 * time.Second
 	releaseSrcUrlPattern        = "https://raw.githubusercontent.com/kyma-project/kyma/%s/%s"
 	releaseResourcePattern      = "https://raw.githubusercontent.com/kyma-project/kyma/%s/installation/resources/%s"
-	registryReleaseImagePattern = "eu.gcr.io/kyma-project/kyma-installer:%s"
-	registryMasterImagePattern  = "eu.gcr.io/kyma-project/develop/kyma-installer:%s"
+	registryImagePattern = "eu.gcr.io/kyma-project/kyma-installer:%s"
 	localDomain                 = "kyma.local"
 )
 
@@ -299,14 +298,14 @@ func (cmd *command) validateFlags() error {
 		}
 		cmd.opts.ReleaseVersion = fmt.Sprintf("master-%s", latest)
 		cmd.opts.ConfigVersion = "master"
-		cmd.opts.RegistryTemplate = registryMasterImagePattern
+		cmd.opts.RegistryTemplate = registryImagePattern
 		break
 
 	//Install the specific version from release (ex: 1.3.0)
 	case cmd.isSemVer(cmd.opts.Source):
 		cmd.opts.ReleaseVersion = cmd.opts.Source
 		cmd.opts.ConfigVersion = cmd.opts.Source
-		cmd.opts.RegistryTemplate = registryReleaseImagePattern
+		cmd.opts.RegistryTemplate = registryImagePattern
 		break
 
 	//Install the kyma with the specific installer image (docker image URL)

--- a/cmd/kyma/install/cmd_test.go
+++ b/cmd/kyma/install/cmd_test.go
@@ -107,7 +107,7 @@ func Test_ReplaceDockerImageURL(t *testing.T) {
 								"containers": []interface{}{
 									map[interface{}]interface{}{
 										"name":  "kyma-installer-container",
-										"image": "eu.gcr.io/kyma-project/develop/kyma-installer:63f27f76",
+										"image": "eu.gcr.io/kyma-project/kyma-installer:63f27f76",
 									},
 								},
 							},


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

After kyma-operator was migrated to the generic makefile path to the image registry of kyma-installer was changed. Images are not published to develop or pr directory anymore. Instead they are published to the root directory. see https://github.com/kyma-project/test-infra/pull/1549/files#diff-21ffcc30185e47a755c73f2463c98059R31
Changes proposed in this pull request:

- fix kyma-installer image registry path

**Related issue(s)**
see #249
