### PR TITLE
Finalized minikube profile support

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -407,6 +407,7 @@ golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a/go.mod h1:jcCCGcm9btYwXyDq
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e/go.mod h1:kS+toOQn6AQKjmKJ7gzohV1XkqsFehRA2FbsbkopSuQ=

--- a/internal/minikube/minikube.go
+++ b/internal/minikube/minikube.go
@@ -16,7 +16,13 @@ const (
 )
 
 //RunCmd executes a minikube command with given arguments
-func RunCmd(verbose bool, args ...string) (string, error) {
+func RunCmd(verbose bool, profile string, rawArgs ...string) (string, error) {
+	args := []string{}
+	if profile != "" {
+		args = append(args, "--profile")
+		args = append(args, profile)
+	}
+	args = append(args, rawArgs...)
 	cmd := exec.Command("minikube", args...)
 	out, err := cmd.CombinedOutput()
 	unquotedOut := strings.Replace(string(out), "'", "", -1)
@@ -35,7 +41,7 @@ func RunCmd(verbose bool, args ...string) (string, error) {
 
 //CheckVersion checks whether minikube version is supported
 func CheckVersion(verbose bool) (string, error) {
-	versionText, err := RunCmd(verbose, "version")
+	versionText, err := RunCmd(verbose, "", "version")
 	if err != nil {
 		return "", err
 	}
@@ -61,8 +67,8 @@ func CheckVersion(verbose bool) (string, error) {
 }
 
 //DockerClient creates a docker client based on minikube "docker-env" configuration
-func DockerClient(verbose bool) (*docker.Client, error) {
-	envOut, err := RunCmd(verbose, "docker-env")
+func DockerClient(verbose bool, profile string) (*docker.Client, error) {
+	envOut, err := RunCmd(verbose, profile, "docker-env")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

**Description**
With https://github.com/kyma-project/cli/pull/242 support for minikube profile was added to the provision command. Unfortunately the support was not introduced fully.

Changes proposed in this pull request:

- Applying profile flag to all minikube commands consistently
- Saving profile in cluster info configmap
- Using profile from cluster info for docker-env call as part of kyma installation

**Related issue(s)**
https://github.com/kyma-project/cli/pull/242
