### PR TITLE
Fix adding missing host from kyma-integration Namespace to /etc/hosts

### DIFF
--- a/cmd/kyma/install/cmd.go
+++ b/cmd/kyma/install/cmd.go
@@ -997,12 +997,19 @@ func (cmd *command) importCertificate(ca trust.Certifier) error {
 func (cmd *command) addDevDomainsToEtcHosts(s step.Step, clusterInfo clusterInfo) error {
 	hostnames := ""
 
-	vsList, err := cmd.K8s.Istio().NetworkingV1alpha3().VirtualServices("kyma-system").List(metav1.ListOptions{})
+	vsListKSystem, err := cmd.K8s.Istio().NetworkingV1alpha3().VirtualServices("kyma-system").List(metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
 
-	for _, v := range vsList.Items {
+	vsListKIntegration, err := cmd.K8s.Istio().NetworkingV1alpha3().VirtualServices("kyma-integration").List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	vsList := append(vsListKSystem.Items, vsListKIntegration.Items...)
+
+	for _, v := range vsList {
 		for _, host := range v.Spec.Hosts {
 			hostnames = hostnames + " " + host
 		}

--- a/cmd/kyma/install/cmd.go
+++ b/cmd/kyma/install/cmd.go
@@ -997,19 +997,12 @@ func (cmd *command) importCertificate(ca trust.Certifier) error {
 func (cmd *command) addDevDomainsToEtcHosts(s step.Step, clusterInfo clusterInfo) error {
 	hostnames := ""
 
-	vsListKSystem, err := cmd.K8s.Istio().NetworkingV1alpha3().VirtualServices("kyma-system").List(metav1.ListOptions{})
+	vsList, err := cmd.K8s.Istio().NetworkingV1alpha3().VirtualServices("").List(metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
 
-	vsListKIntegration, err := cmd.K8s.Istio().NetworkingV1alpha3().VirtualServices("kyma-integration").List(metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-
-	vsList := append(vsListKSystem.Items, vsListKIntegration.Items...)
-
-	for _, v := range vsList {
+	for _, v := range vsList.Items {
 		for _, host := range v.Spec.Hosts {
 			hostnames = hostnames + " " + host
 		}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix adding missing host from the `kyma-integration` Namespace to `/etc/hosts` by fetching Virtual Services from `kyma-integration`.

**Related issue(s)**
See #267
