### PR TITLE
Silence skipping or updating installation configmap

### DIFF
--- a/cmd/kyma/install/cmd.go
+++ b/cmd/kyma/install/cmd.go
@@ -1056,7 +1056,6 @@ func (cmd *command) patchMinikubeIP(minikubeIP string) error {
 func (cmd *command) createOwnDomainConfigMap() error {
 	cm, err := cmd.K8s.Static().CoreV1().ConfigMaps("kyma-installer").Get("owndomain-overrides", metav1.GetOptions{})
 	if err == nil && cm != nil {
-		fmt.Println("ConfigMap already exists")
 		if cm.Data == nil {
 			cm.Data = make(map[string]string)
 		}

--- a/cmd/kyma/provision/minikube/cmd.go
+++ b/cmd/kyma/provision/minikube/cmd.go
@@ -348,7 +348,6 @@ func driverSupported(driver string) bool {
 func (c *command) createClusterInfoConfigMap() error {
 	cm, err := c.K8s.Static().CoreV1().ConfigMaps("kube-system").Get("kyma-cluster-info", metav1.GetOptions{})
 	if err == nil && cm != nil {
-		fmt.Println("ConfigMap already exists")
 		return nil
 	} else if err != nil && !strings.Contains(err.Error(), "not found") {
 		return err


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Silence the update or skipping of minikube installation configmap on existing cluster.

**Related issue(s)**
#248 
