### PR TITLE
Add links to generated command docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,23 +49,7 @@ To install Kyma CLI on Windows, download and unzip the [artifact](https://github
 
 ## Usage
 
-### Commands
-
-Kyma CLI comes with a set of commands:
-
-|     Command        | Child commands   |  Description  | Example |
-|--------------------|----------------|---------------|---------|
-| `completion`| None| Generates and displays the bash or zsh completion script. | `kyma completion`|
-| `console`| None| Launches Kyma Console in a browser window. | `kyma console` |
-| `install`| None| Installs Kyma on a cluster based on the current or specified release. | `kyma install`|
-| `provision`| `provision minikube`<br> `provision gardener` <br> `provision gcp`| Provisions a new cluster on a platform of your choice. Currently, this command supports cluster provisioning on GCP, Gardener, and Minikube. | `kyma provision minikube`|
-| `test`|`test definitions`<br> `test delete` <br> `test list` <br> `test run` <br> `test status`<br> `test logs`<br> | Runs and manages tests on a provisioned Kyma cluster. Using child commands, you can run tests, view test definitions, list and delete test suites, display test status, and fetch the logs of the tests.| `kyma test run` |
-| `uninstall`|None| Uninstalls all Kyma-related resources from a cluster. | `kyma uninstall` |
-| `version`|None| Shows the cluster version and the Kyma CLI version.|`kyma version`|
-
-For details on particular commands and options, see [this](https://github.com/kyma-project/cli/tree/master/docs/gen-docs) list.
-
-### Use Kyma CLI
+### Syntax
 
 Use the following syntax to run the commands from your terminal:
 
@@ -75,13 +59,32 @@ kyma {COMMAND} {FLAGS}
 where:
 
 * **{COMMAND}** specifies the operation you want to perform.
-* **{FLAGS}** specify optional flags. For example, use `-v` or `--verbose` for additional information on performed operations.
+* **{FLAGS}** specify optional flags. 
 
 Example:
+```
+kyma install --source=latest
+```
 
-```
-kyma install --verbose
-```
+
+### Commands
+
+Kyma CLI comes with a set of commands, each of which has its own specific set of flags. 
+
+>**NOTE:** For the full list of commands and flags, see [this](https://github.com/kyma-project/cli/tree/master/docs/gen-docs) document. 
+
+|     Command        | Child commands   |  Description  | Example |
+|--------------------|----------------|---------------|---------|
+| [`completion`](/docs/gen-docs/kyma_completion.md)| None| Generates and displays the bash or zsh completion script. | `kyma completion`|
+| [`console`](/docs/gen-docs/kyma_console.md)| None| Launches Kyma Console in a browser window. | `kyma console` |
+| [`install`](/docs/gen-docs/kyma_install.md)| None| Installs Kyma on a cluster based on the current or specified release. | `kyma install`|
+| [`provision`](/docs/gen-docs/kyma_provision.md)| [`provision minikube`](/docs/gen-docs/kyma_provision_minikube.md)<br> [`provision gardener`](/docs/gen-docs/kyma_provision_gardener.md) <br> [`provision gcp`](/docs/gen-docs/kyma_provision_gcp.md)| Provisions a new cluster on a platform of your choice. Currently, this command supports cluster provisioning on GCP, Gardener, and Minikube. | `kyma provision minikube`|
+| [`test`](/docs/gen-docs/kyma_test.md)|[`test definitions`](/docs/gen-docs/kyma_test_definitions.md)<br> [`test delete`](/docs/gen-docs/kyma_test_delete.md) <br> [`test list`](/docs/gen-docs/kyma_test_list.md) <br> [`test run`](/docs/gen-docs/kyma_test_run.md) <br> [`test status`](/docs/gen-docs/kyma_test_status.md)<br> [`test logs`](/docs/gen-docs/kyma_test_logs.md) <br> | Runs and manages tests on a provisioned Kyma cluster. Using child commands, you can run tests, view test definitions, list and delete test suites, display test status, and fetch the logs of the tests.| `kyma test run` |
+| [`uninstall`](/docs/gen-docs/kyma_uninstall.md)|None| Uninstalls all Kyma-related resources from a cluster. | `kyma uninstall` |
+| [`version`](/docs/gen-docs/kyma_version.md)|None| Shows the cluster version and the Kyma CLI version.|`kyma version`|
+
+
+### Usage examples
 
 Further usage examples include:
 
@@ -96,7 +99,6 @@ Further usage examples include:
 
     ```bash
     kyma provision minikube
-    # follow instructions to add hosts
     kyma install
     ```
 
@@ -104,9 +106,10 @@ Further usage examples include:
 
     ```bash
     kyma provision minikube --vm-driver hyperv --hypervVirtualSwitch {YOUR_SWITCH_NAME}
-    # follow instructions to add hosts
     kyma install
+
     ```
+## Development
 
 ### Kyma CLI as a kubectl plugin
 


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

In the README.md file: 
- Added links to generated docs
- Improved the structure 
**Related issue(s)**
See also #301