### PR TITLE
Fix calc test suite total time

### DIFF
--- a/internal/junitxml/report.go
+++ b/internal/junitxml/report.go
@@ -43,7 +43,12 @@ func (c *Creator) Write(out io.Writer, suite *oct.ClusterTestSuite) error {
 }
 
 func (c *Creator) generateReport(suite *oct.ClusterTestSuite) (JUnitTestSuites, error) {
-	suiteTotalTime := suite.Status.CompletionTime.Sub(suite.Status.StartTime.Time)
+	var suiteTotalTime time.Duration
+	// CompletionTime is not set when test suite is timed out
+	if suite.Status.CompletionTime != nil {
+		suiteTotalTime = suite.Status.CompletionTime.Sub(suite.Status.StartTime.Time)
+	}
+
 	tc, err := c.mapToTestCases(suite.Status.Results)
 	if err != nil {
 		return JUnitTestSuites{}, errors.Wrap(err, "while mapping test results into junit test cases")


### PR DESCRIPTION
**Description**
This PR resolves problem with panic when `CompletionTime`  is not set:

```
goroutine 1 [running]:
github.com/kyma-project/cli/internal/junitxml.(*Creator).generateReport(0xc0006738a0, 0xc00011ac40, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc0006737f8, ...)
	/home/prow/go/src/github.com/kyma-project/cli/internal/junitxml/report.go:46 +0x6f
github.com/kyma-project/cli/internal/junitxml.(*Creator).Write(0xc0006738a0, 0x34920c0, 0xc0000d2008, 0xc00011ac40, 0x0, 0xc0006403c0)
	/home/prow/go/src/github.com/kyma-project/cli/internal/junitxml/report.go:33 +0x4d
github.com/kyma-project/cli/cmd/kyma/test/status.(*command).printTestSuiteStatus(0xc000251140, 0xc00011ac40, 0x7ffcde8f202d, 0x5, 0x0, 0x0)
	/home/prow/go/src/github.com/kyma-project/cli/cmd/kyma/test/status/cmd.go:121 +0x3ad
github.com/kyma-project/cli/cmd/kyma/test/status.(*command).Run(0xc000251140, 0xc00025a040, 0x1, 0x2, 0x0, 0x0)
	/home/prow/go/src/github.com/kyma-project/cli/cmd/kyma/test/status/cmd.go:66 +0x249
github.com/kyma-project/cli/cmd/kyma/test/status.NewCmd.func1(0xc000308f00, 0xc00025a040, 0x1, 0x2, 0x0, 0x0)
	/home/prow/go/src/github.com/kyma-project/cli/cmd/kyma/test/status/cmd.go:44 +0x48
github.com/spf13/cobra.(*Command).execute(0xc000308f00, 0xc0000dffc0, 0x2, 0x2, 0xc000308f00, 0xc0000dffc0)
	/home/prow/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:826 +0x465
github.com/spf13/cobra.(*Command).ExecuteC(0xc00015fb80, 0xc00015fb80, 0xc0005fbf88, 0xc0000b8058)
	/home/prow/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x2fc
github.com/spf13/cobra.(*Command).Execute(...)
	/home/prow/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
```

The `CompletionTime` is not set when test suite is timed out, so total time needs to be calc only if possible.