### PR TITLE
Upgrade default kubernetes version for minikube and GCP

### DIFF
--- a/cmd/kyma/provision/gcp/cmd.go
+++ b/cmd/kyma/provision/gcp/cmd.go
@@ -41,7 +41,7 @@ NOTE: To access the provisioned cluster, make sure you get authenticated by Goog
 	cmd.Flags().StringVarP(&o.Name, "name", "n", "", "Name of the GKE cluster to provision. (required)")
 	cmd.Flags().StringVarP(&o.Project, "project", "p", "", "Name of the GCP Project where you provision the GKE cluster. (required)")
 	cmd.Flags().StringVarP(&o.CredentialsFile, "credentials", "c", "", "Path to the GCP service account key file. (required)")
-	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.14", "Kubernetes version of the cluster.")
+	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.15", "Kubernetes version of the cluster.")
 	cmd.Flags().StringVarP(&o.Location, "location", "l", "europe-west3-a", "Location of the cluster.")
 	cmd.Flags().StringVarP(&o.MachineType, "type", "t", "n1-standard-4", "Machine type used for the cluster.")
 	cmd.Flags().IntVar(&o.DiskSizeGB, "disk-size", 30, "Disk size (in GB) of the cluster.")

--- a/cmd/kyma/provision/gcp/cmd_test.go
+++ b/cmd/kyma/provision/gcp/cmd_test.go
@@ -17,7 +17,7 @@ func TestProvisionGCPFlags(t *testing.T) {
 	require.Equal(t, "", o.Name, "Default value for the name flag not as expected.")
 	require.Equal(t, "", o.Project, "Default value for the project flag not as expected.")
 	require.Equal(t, "", o.CredentialsFile, "Default value for the credentials flag not as expected.")
-	require.Equal(t, "1.14", o.KubernetesVersion, "Default value for the kube-version flag not as expected.")
+	require.Equal(t, "1.15", o.KubernetesVersion, "Default value for the kube-version flag not as expected.")
 	require.Equal(t, "europe-west3-a", o.Location, "Default value for the location flag not as expected.")
 	require.Equal(t, "n1-standard-4", o.MachineType, "Default value for the type flag not as expected.")
 	require.Equal(t, 30, o.DiskSizeGB, "Default value for the disk-size flag not as expected.")

--- a/cmd/kyma/provision/minikube/cmd.go
+++ b/cmd/kyma/provision/minikube/cmd.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	kubernetesVersion  string = "1.14.6"
+	kubernetesVersion  string = "1.16.3"
 	bootstrapper       string = "kubeadm"
 	vmDriverHyperkit   string = "hyperkit"
 	vmDriverHyperv     string = "hyperv"

--- a/docs/gen-docs/kyma_provision_gcp.md
+++ b/docs/gen-docs/kyma_provision_gcp.md
@@ -16,7 +16,7 @@ kyma provision gcp [flags]
 ```
   -c, --credentials string    Path to the GCP service account key file. (required)
       --disk-size int         Disk size (in GB) of the cluster. (default 30)
-  -k, --kube-version string   Kubernetes version of the cluster. (default "1.14")
+  -k, --kube-version string   Kubernetes version of the cluster. (default "1.15")
   -l, --location string       Location of the cluster. (default "europe-west3-a")
   -n, --name string           Name of the GKE cluster to provision. (required)
       --nodes int             Number of cluster nodes. (default 3)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Upgrade default kubernetes version for minikube and GCP

Changes proposed in this pull request:

- upgrade minikube default kubernetes version to 1.16.3
- upgrade GCP kubernetes version to 1.15

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also: 
kyma-project/test-infra#1963
