### PR TITLE
Add compiler flags to reduce binary size

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,7 @@ builds:
 - env:
   - CGO_ENABLED=0
   - KYMA_VERSION=master
-  ldflags: -X github.com/kyma-project/cli/cmd/kyma/version.Version={{.Version}} -X github.com/kyma-project/cli/cmd/kyma/install.DefaultKymaVersion={{.Env.KYMA_VERSION}}
+  ldflags: -s -w -X github.com/kyma-project/cli/cmd/kyma/version.Version={{.Version}} -X github.com/kyma-project/cli/cmd/kyma/install.DefaultKymaVersion={{.Env.KYMA_VERSION}}
   main: ./cmd/
   goos:
     - darwin

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ifndef VERSION
 	VERSION = ${shell git describe --tags --always}
 endif
 
-FLAGS = -ldflags '-X github.com/kyma-project/cli/cmd/kyma/version.Version=$(VERSION) -X github.com/kyma-project/cli/cmd/kyma/install.DefaultKymaVersion=$(KYMA_VERSION)'
+FLAGS = -ldflags '-s -w -X github.com/kyma-project/cli/cmd/kyma/version.Version=$(VERSION) -X github.com/kyma-project/cli/cmd/kyma/install.DefaultKymaVersion=$(KYMA_VERSION)'
 
 .PHONY: resolve
 resolve: 


### PR DESCRIPTION


**Description**

Changes proposed in this pull request:

- Add compiler flags to strip debugging DWARF tables from the CLI binary.
This reduces the size of the binary by ~20%

**More info**
https://golang.org/cmd/link/