### PR TITLE
Remote cluster provision verbosity configurable

### DIFF
--- a/cmd/kyma/provision/aks/cmd.go
+++ b/cmd/kyma/provision/aks/cmd.go
@@ -79,7 +79,7 @@ func (c *command) Run() error {
 			cluster, err = hf.Provision(cluster, provider, types.WithDataDir(home), types.Persistent())
 			return err
 		},
-		retry.Attempts(3))
+		retry.Attempts(3), retry.LastErrorOnly(!c.opts.Verbose))
 
 	if err != nil {
 		s.Failure()

--- a/cmd/kyma/provision/gardener/aws/cmd.go
+++ b/cmd/kyma/provision/gardener/aws/cmd.go
@@ -85,7 +85,7 @@ func (c *command) Run() error {
 			cluster, err = hf.Provision(cluster, provider, types.WithDataDir(home), types.Persistent())
 			return err
 		},
-		retry.Attempts(3))
+		retry.Attempts(3), retry.LastErrorOnly(!c.opts.Verbose))
 
 	if err != nil {
 		s.Failure()

--- a/cmd/kyma/provision/gardener/az/cmd.go
+++ b/cmd/kyma/provision/gardener/az/cmd.go
@@ -84,7 +84,7 @@ func (c *command) Run() error {
 			cluster, err = hf.Provision(cluster, provider, types.WithDataDir(home), types.Persistent())
 			return err
 		},
-		retry.Attempts(3))
+		retry.Attempts(3), retry.LastErrorOnly(!c.opts.Verbose))
 
 	if err != nil {
 		s.Failure()

--- a/cmd/kyma/provision/gardener/gcp/cmd.go
+++ b/cmd/kyma/provision/gardener/gcp/cmd.go
@@ -85,7 +85,7 @@ func (c *command) Run() error {
 			cluster, err = hf.Provision(cluster, provider, types.WithDataDir(home), types.Persistent())
 			return err
 		},
-		retry.Attempts(3))
+		retry.Attempts(3), retry.LastErrorOnly(!c.opts.Verbose))
 
 	if err != nil {
 		s.Failure()

--- a/cmd/kyma/provision/gke/cmd.go
+++ b/cmd/kyma/provision/gke/cmd.go
@@ -79,7 +79,7 @@ func (c *command) Run() error {
 			cluster, err = hf.Provision(cluster, provider, types.WithDataDir(home), types.Persistent())
 			return err
 		},
-		retry.Attempts(3))
+		retry.Attempts(3), retry.LastErrorOnly(!c.opts.Verbose))
 
 	if err != nil {
 		s.Failure()


### PR DESCRIPTION


**Description**

Changes proposed in this pull request:

- Verbosity on remote cluster provision is configurable with the -v flag.
    If verbose all 3 retries will be shown, otherwise only the last one.

**Related issue(s)**
#469 