### PR TITLE
Refactor installation pkg to be testable

### DIFF
--- a/cmd/kyma/install/cmd.go
+++ b/cmd/kyma/install/cmd.go
@@ -116,7 +116,11 @@ func (cmd *command) Run() error {
 	}
 	s.Successf("Cluster type determined")
 
-	i := cmd.configureInstallation(clusterConfig)
+	i, err := cmd.configureInstallation(clusterConfig)
+	if err != nil {
+		return err
+	}
+
 	result, err := i.InstallKyma()
 	if err != nil {
 		return err
@@ -150,8 +154,20 @@ func (cmd *command) Run() error {
 	return nil
 }
 
-func (cmd *command) configureInstallation(clusterConfig installation.ClusterInfo) *installation.Installation {
+func (cmd *command) configureInstallation(clusterConfig installation.ClusterInfo) (*installation.Installation, error) {
+
+	cmp, err := installation.LoadComponentsConfig(cmd.opts.ComponentsConfig)
+	if err != nil {
+		return &installation.Installation{}, errors.Wrap(err, "Could not load component configuration file. Make sure file is a valid YAML and contains a component list")
+	}
+	s, err := installation.NewInstallationService(cmd.K8s.Config(), cmd.opts.Timeout, "", cmp)
+	if err != nil {
+		return &installation.Installation{}, errors.Wrap(err, "Failed to create installation service. Make sure your kubeconfig is valid")
+	}
+
 	return &installation.Installation{
+		K8s:     cmd.K8s,
+		Service: s,
 		Options: &installation.Options{
 			NoWait:           cmd.opts.NoWait,
 			Verbose:          cmd.opts.Verbose,
@@ -177,7 +193,7 @@ func (cmd *command) configureInstallation(clusterConfig installation.ClusterInfo
 				VMDriver: clusterConfig.LocalVMDriver,
 			},
 		},
-	}
+	}, nil
 }
 
 func (cmd *command) importCertificate(ca trust.Certifier) error {

--- a/pkg/installation/upgrade_test.go
+++ b/pkg/installation/upgrade_test.go
@@ -1,0 +1,17 @@
+package installation
+
+import (
+	"testing"
+)
+
+func TestUpgradeKyma(t *testing.T) {
+	// // prepare mocks
+	// i := Installation{
+	// 	Options: &Options{},
+	// }
+
+	// // Happy path
+	// r, err := i.UpgradeKyma()
+	// require.NoError(t, err)
+	// require.NotEmpty(t, r)
+}

--- a/pkg/installation/utils.go
+++ b/pkg/installation/utils.go
@@ -182,31 +182,6 @@ func loadStringContent(installationFiles map[string]*File) (map[string]*File, er
 	return installationFiles, nil
 }
 
-func (i *Installation) loadComponentsConfig() ([]v1alpha1.KymaComponent, error) {
-	if i.Options.ComponentsConfig != "" {
-		data, err := ioutil.ReadFile(i.Options.ComponentsConfig)
-		if err != nil {
-			return nil, err
-		}
-
-		var installationCR v1alpha1.Installation
-		err = yaml.Unmarshal(data, &installationCR)
-		if err != nil || len(installationCR.Spec.Components) < 1 {
-			var config ComponentsConfig
-			err = yaml.Unmarshal(data, &config)
-			if err != nil {
-				return nil, err
-			}
-
-			return config.Components, nil
-		}
-
-		return installationCR.Spec.Components, nil
-	}
-
-	return []v1alpha1.KymaComponent{}, nil
-}
-
 func (i *Installation) loadConfigurations(files map[string]*File) (installationSDK.Configuration, error) {
 	var configuration installationSDK.Configuration
 	var configFileContent string
@@ -254,6 +229,31 @@ func (i *Installation) loadConfigurations(files map[string]*File) (installationS
 	}
 
 	return configuration, nil
+}
+
+func LoadComponentsConfig(cfgFile string) ([]v1alpha1.KymaComponent, error) {
+	if cfgFile != "" {
+		data, err := ioutil.ReadFile(cfgFile)
+		if err != nil {
+			return nil, err
+		}
+
+		var installationCR v1alpha1.Installation
+		err = yaml.Unmarshal(data, &installationCR)
+		if err != nil || len(installationCR.Spec.Components) < 1 {
+			var config ComponentsConfig
+			err = yaml.Unmarshal(data, &config)
+			if err != nil {
+				return nil, err
+			}
+
+			return config.Components, nil
+		}
+
+		return installationCR.Spec.Components, nil
+	}
+
+	return []v1alpha1.KymaComponent{}, nil
 }
 
 func buildDockerImageString(template string, version string) string {

--- a/pkg/installation/utils_test.go
+++ b/pkg/installation/utils_test.go
@@ -112,7 +112,7 @@ func Test_LoadComponentsConfig(t *testing.T) {
 		},
 	}
 
-	components, err := installation.loadComponentsConfig()
+	components, err := LoadComponentsConfig(installation.Options.ComponentsConfig)
 	require.NoError(t, err)
 	require.Equal(t, 6, len(components))
 
@@ -122,7 +122,7 @@ func Test_LoadComponentsConfig(t *testing.T) {
 		},
 	}
 
-	components, err = installation2.loadComponentsConfig()
+	components, err = LoadComponentsConfig(installation2.Options.ComponentsConfig)
 	require.NoError(t, err)
 	require.Equal(t, 8, len(components))
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- The installation package is very tightly coupled with its services, which makes it untestable.
   With this change its dependencies can be mocked and the API is cleaner.

**Related issue(s)**
#492 
