### PR TITLE
disabling upgrade command

### DIFF
--- a/cmd/kyma/kyma.go
+++ b/cmd/kyma/kyma.go
@@ -21,7 +21,6 @@ import (
 	"github.com/kyma-project/cli/cmd/kyma/version"
 
 	"github.com/kyma-project/cli/cmd/kyma/provision"
-	"github.com/kyma-project/cli/cmd/kyma/upgrade"
 	"github.com/kyma-project/cli/internal/cli"
 	"github.com/spf13/cobra"
 )
@@ -64,7 +63,8 @@ For more information, see: https://github.com/kyma-project/cli
 		install.NewCmd(install.NewOptions(o)),
 		provisionCmd,
 		console.NewCmd(console.NewOptions(o)),
-		upgrade.NewCmd(upgrade.NewOptions(o)),
+		// upgrade command is disabled for now and will be enabled in the next release (1.16) after testing it on the upgrade prow jobs
+		// upgrade.NewCmd(upgrade.NewOptions(o)),
 	)
 
 	testCmd := test.NewCmd()

--- a/cmd/kyma/kyma.go
+++ b/cmd/kyma/kyma.go
@@ -63,8 +63,6 @@ For more information, see: https://github.com/kyma-project/cli
 		install.NewCmd(install.NewOptions(o)),
 		provisionCmd,
 		console.NewCmd(console.NewOptions(o)),
-		// upgrade command is disabled for now and will be enabled in the next release (1.16) after testing it on the upgrade prow jobs
-		// upgrade.NewCmd(upgrade.NewOptions(o)),
 	)
 
 	testCmd := test.NewCmd()

--- a/cmd/kyma/kyma_test.go
+++ b/cmd/kyma/kyma_test.go
@@ -36,5 +36,5 @@ func TestKymaSubcommands(t *testing.T) {
 
 	sub := c.Commands()
 
-	require.Equal(t, 8, len(sub), "Number of Kyma subcommands not as expected")
+	require.Equal(t, 7, len(sub), "Number of Kyma subcommands not as expected")
 }

--- a/docs/gen-docs/kyma.md
+++ b/docs/gen-docs/kyma.md
@@ -29,6 +29,5 @@ For more information, see: https://github.com/kyma-project/cli
 * [kyma install](#kyma-install-kyma-install)	 - Installs Kyma on a running Kubernetes cluster.
 * [kyma provision](#kyma-provision-kyma-provision)	 - Provisions a cluster for Kyma installation.
 * [kyma test](#kyma-test-kyma-test)	 - Runs tests on a provisioned Kyma cluster.
-* [kyma upgrade](#kyma-upgrade-kyma-upgrade)	 - Upgrades Kyma to match  the CLI version.
 * [kyma version](#kyma-version-kyma-version)	 - Displays the version of Kyma CLI and the connected Kyma cluster.
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- upgrade command is disabled for now and will be enabled in the next release (1.16) after testing it on the upgrade prow jobs

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#174 