### PR TITLE
Allowing non-interactive upgrade

### DIFF
--- a/pkg/installation/upgrade.go
+++ b/pkg/installation/upgrade.go
@@ -64,11 +64,12 @@ func (i *Installation) UpgradeKyma() (*Result, error) {
 				s.Failure()
 				return nil, err
 			}
-
-			// Checking migration guide
-			if err := i.promptMigrationGuide(currSemVersion, targetSemVersion); err != nil {
-				s.Failure()
-				return nil, err
+			if !i.Options.NonInteractive {
+				// prompting migration guide
+				if err := i.promptMigrationGuide(currSemVersion, targetSemVersion); err != nil {
+					s.Failure()
+					return nil, err
+				}
 			}
 		}
 
@@ -147,14 +148,16 @@ func (i *Installation) checkCurrVersion(currVersion string) (bool, *semver.Versi
 	currSemVersion, err := semver.NewVersion(currVersion)
 	if err != nil {
 		isReleaseVersion = false
-		promptMsg := fmt.Sprintf("Current Kyma version '%s' is not a release version, so it is not possible to check the upgrade compatibility.\n"+
-			"If you choose to continue the upgrade, you can compromise the functionality of your cluster.\n"+
-			"Are you sure you want to continue? ",
-			currVersion,
-		)
-		continueUpgrade := i.currentStep.PromptYesNo(promptMsg)
-		if !continueUpgrade {
-			return false, nil, fmt.Errorf("Aborting upgrade")
+		if !i.Options.NonInteractive {
+			promptMsg := fmt.Sprintf("Current Kyma version '%s' is not a release version, so it is not possible to check the upgrade compatibility.\n"+
+				"If you choose to continue the upgrade, you can compromise the functionality of your cluster.\n"+
+				"Are you sure you want to continue? ",
+				currVersion,
+			)
+			continueUpgrade := i.currentStep.PromptYesNo(promptMsg)
+			if !continueUpgrade {
+				return false, nil, fmt.Errorf("Aborting upgrade")
+			}
 		}
 	}
 
@@ -166,14 +169,16 @@ func (i *Installation) checkTargetVersion(targetVersion string) (bool, *semver.V
 	targetSemVersion, err := semver.NewVersion(i.Options.Source)
 	if err != nil {
 		isReleaseVersion = false
-		promptMsg := fmt.Sprintf("Target Kyma version '%s' is not a release version, so it is not possible to check the upgrade compatibility.\n"+
-			"If you choose to continue the upgrade, you can compromise the functionality of your cluster.\n"+
-			"Are you sure you want to continue? ",
-			targetVersion,
-		)
-		continueUpgrade := i.currentStep.PromptYesNo(promptMsg)
-		if !continueUpgrade {
-			return false, nil, fmt.Errorf("Aborting upgrade")
+		if !i.Options.NonInteractive {
+			promptMsg := fmt.Sprintf("Target Kyma version '%s' is not a release version, so it is not possible to check the upgrade compatibility.\n"+
+				"If you choose to continue the upgrade, you can compromise the functionality of your cluster.\n"+
+				"Are you sure you want to continue? ",
+				targetVersion,
+			)
+			continueUpgrade := i.currentStep.PromptYesNo(promptMsg)
+			if !continueUpgrade {
+				return false, nil, fmt.Errorf("Aborting upgrade")
+			}
 		}
 	}
 

--- a/pkg/installation/upgrade.go
+++ b/pkg/installation/upgrade.go
@@ -188,8 +188,6 @@ func (i *Installation) checkTargetVersion(targetVersion string) (bool, *semver.V
 func (i *Installation) checkUpgradeCompatibility(currSemVersion *semver.Version, targetSemVersion *semver.Version) error {
 	if currSemVersion.GreaterThan(targetSemVersion) {
 		return fmt.Errorf("Current Kyma version '%s' is greater than the target version '%s'. Kyma does not support a dedicated downgrade procedure", currSemVersion.String(), targetSemVersion.String())
-	} else if currSemVersion.Equal(targetSemVersion) && i.Options.OverrideConfigs == nil {
-		return fmt.Errorf("Current Kyma version '%s' is already matching the target version '%s'", currSemVersion.String(), targetSemVersion.String())
 	} else if currSemVersion.Major() != targetSemVersion.Major() {
 		return fmt.Errorf("Mismatch between current Kyma version '%s' and target version '%s' is more than one minor version", currSemVersion.String(), targetSemVersion.String())
 	} else if currSemVersion.Minor() != targetSemVersion.Minor() && currSemVersion.Minor()+1 != targetSemVersion.Minor() {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Prompt dialogues in the upgrade process only if the `NonInteractive` option is `false`. The reason for this is to be able to use the upgrade command in prow jobs.
- Always allow to upgrade `Kyma` to the same version even if there are no overrides.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
kyma-project/test-infra#2604
#174 