### PR TITLE
Fix behaviour when previous installation state is empty

### DIFF
--- a/pkg/installation/installation.go
+++ b/pkg/installation/installation.go
@@ -105,7 +105,7 @@ func (i *Installation) InstallKyma() (*Result, error) {
 		return nil, err
 	}
 
-	if prevInstallationState == installationSDK.NoInstallationState {
+	if prevInstallationState == installationSDK.NoInstallationState || prevInstallationState == "" {
 		// Validating configurations
 		if err := i.validateConfigurations(); err != nil {
 			s.Failure()
@@ -134,7 +134,7 @@ func (i *Installation) InstallKyma() (*Result, error) {
 	}
 
 	if prevInstallationState != "Installed" && !i.Options.NoWait {
-		if prevInstallationState == installationSDK.NoInstallationState {
+		if prevInstallationState == installationSDK.NoInstallationState || prevInstallationState == "" {
 			i.newStep("Waiting for installation to start")
 		} else {
 			i.newStep("Re-attaching installation status")
@@ -166,7 +166,7 @@ func (i *Installation) checkPrevInstallation() (string, string, error) {
 	}
 
 	var kymaVersion string
-	if prevInstallationState.State != installationSDK.NoInstallationState {
+	if prevInstallationState.State != installationSDK.NoInstallationState && prevInstallationState.State != "" {
 		kymaVersion, err = version.KymaVersion(i.K8s)
 		if err != nil {
 			return "", "", err
@@ -186,9 +186,6 @@ func (i *Installation) getInstallationLogInfo(prevInstallationState string, kyma
 		// when installation is in in "Error" state, it doesn't mean that the installation has failed
 		// Installer might sill recover from the error and install Kyma successfully
 		logInfo = fmt.Sprintf("Installation in version '%s' is already in progress", kymaVersion)
-
-	case "":
-		return "", fmt.Errorf("Failed to get previous installation status")
 	}
 
 	return logInfo, nil

--- a/pkg/installation/installation.go
+++ b/pkg/installation/installation.go
@@ -99,11 +99,7 @@ func (i *Installation) InstallKyma() (*Result, error) {
 		s.Failure()
 		return nil, err
 	}
-	logInfo, err := i.getInstallationLogInfo(prevInstallationState, kymaVersion)
-	if err != nil {
-		s.Failure()
-		return nil, err
-	}
+	logInfo := i.getInstallationLogInfo(prevInstallationState, kymaVersion)
 
 	if prevInstallationState == installationSDK.NoInstallationState || prevInstallationState == "" {
 		// Validating configurations
@@ -176,7 +172,7 @@ func (i *Installation) checkPrevInstallation() (string, string, error) {
 	return prevInstallationState.State, kymaVersion, nil
 }
 
-func (i *Installation) getInstallationLogInfo(prevInstallationState string, kymaVersion string) (string, error) {
+func (i *Installation) getInstallationLogInfo(prevInstallationState string, kymaVersion string) string {
 	var logInfo string
 	switch prevInstallationState {
 	case "Installed":
@@ -188,7 +184,7 @@ func (i *Installation) getInstallationLogInfo(prevInstallationState string, kyma
 		logInfo = fmt.Sprintf("Installation in version '%s' is already in progress", kymaVersion)
 	}
 
-	return logInfo, nil
+	return logInfo
 }
 
 func (i *Installation) validateConfigurations() error {

--- a/pkg/installation/installation_test.go
+++ b/pkg/installation/installation_test.go
@@ -107,12 +107,15 @@ func TestInstallKyma(t *testing.T) {
 	require.Error(t, err)
 	require.Empty(t, r)
 
-	// Empty installation status
+	// Empty installation status will be treated the same way as a cluster with no installation, so we should have a happy path
 	iServiceMock.On("CheckInstallationState", mock.Anything).Return(installSDK.InstallationState{}, nil).Once()
+	iServiceMock.On("TriggerInstallation", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	iServiceMock.On("CheckInstallationState", mock.Anything).Return(installSDK.InstallationState{State: "Installed"}, nil).Once()
+	kymaMock.On("WaitPodStatusByLabel", "kyma-installer", "name", "kyma-installer", v1.PodRunning).Return(nil)
 
 	r, err = i.InstallKyma()
-	require.Error(t, err)
-	require.Empty(t, r)
+	require.NoError(t, err)
+	require.NotEmpty(t, r)
 
 	// Happy path
 	iServiceMock.On("CheckInstallationState", mock.Anything).Return(installSDK.InstallationState{State: installSDK.NoInstallationState}, nil).Once()

--- a/pkg/installation/upgrade.go
+++ b/pkg/installation/upgrade.go
@@ -118,16 +118,13 @@ func (i *Installation) UpgradeKyma() (*Result, error) {
 func (i *Installation) getUpgradeLogInfo(prevInstallationState string, kymaVersion string) (string, error) {
 	var logInfo string
 	switch prevInstallationState {
-	case installationSDK.NoInstallationState:
+	case installationSDK.NoInstallationState, "":
 		return "", fmt.Errorf("It is not possible to upgrade, since Kyma is not installed on the cluster. Run \"kyma install\" to install Kyma")
 
 	case "InProgress", "Error":
 		// when installation is in in "Error" state, it doesn't mean that the installation has failed
 		// Installer might sill recover from the error and install Kyma successfully
-		logInfo = fmt.Sprintf("Installation in version %s is already in progress", kymaVersion)
-
-	case "":
-		return "", fmt.Errorf("Failed to get the installation status")
+		logInfo = fmt.Sprintf("Installation in version '%s' is already in progress", kymaVersion)
 	}
 
 	return logInfo, nil
@@ -210,7 +207,7 @@ func (i *Installation) promptMigrationGuide(currSemVersion *semver.Version, targ
 	}
 	if statusCode == 404 {
 		// no migration guide for this release
-		i.currentStep.LogInfof("No migration guide available for upgrade from version %s to %s", currSemVersion.String(), targetSemVersion.String())
+		i.currentStep.LogInfof("No migration guide available for upgrade from version '%s' to version '%s'", currSemVersion.String(), targetSemVersion.String())
 		return nil
 	}
 	if statusCode != 200 {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- When the previous installation state was empty, the install command used to just print an error to the user `Failed to get previous installation status`. Now, the the install command will treat this case the same way it handles a cluster with no previous Kyma installation, so it will just freshly install Kyma. 

- When the installation state was empty, the upgrade command used to print an error to the user `Failed to get the installation status`. Now, the the upgrade command will treat this case the same way it handles a cluster with no Kyma installation, so it will guide the user to run Run `kyma install` in order to install Kyma. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
