### PR TITLE
Create system: Add default namespace resolution

### DIFF
--- a/cmd/kyma/create/system/system.go
+++ b/cmd/kyma/create/system/system.go
@@ -3,7 +3,6 @@ package system
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -66,13 +65,13 @@ func (c *command) Run(args []string) error {
 		np.PrintImportant("WARNING: This command is experimental and might change in its final version.")
 	}
 
-	if err := c.validateFlags(); err != nil {
-		return err
-	}
-
 	var err error
 	if c.K8s, err = kube.NewFromConfigWithTimeout("", c.KubeconfigPath, c.opts.Timeout); err != nil {
 		return errors.Wrap(err, "Could not initialize the Kubernetes client. Make sure your kubeconfig is valid")
+	}
+
+	if c.opts.Namespace == "" {
+		c.opts.Namespace = c.K8s.DefaultNamespace()
 	}
 
 	// validate cluster state
@@ -170,19 +169,6 @@ func (c *command) Run(args []string) error {
 		nicePrint.PrintImportant(url)
 	}
 
-	return nil
-}
-
-func (c *command) validateFlags() error {
-	var errMessage strings.Builder
-	// mandatory flags
-	if c.opts.Namespace == "" {
-		errMessage.WriteString("\nRequired flag `namespace` has not been set.")
-	}
-
-	if errMessage.Len() != 0 {
-		return errors.New(errMessage.String())
-	}
 	return nil
 }
 

--- a/cmd/kyma/create/system/system_test.go
+++ b/cmd/kyma/create/system/system_test.go
@@ -34,21 +34,6 @@ func TestValidateArgs(t *testing.T) {
 	require.Error(t, err, "Validate args should return an error if too many args are given.")
 }
 
-func TestValidateFlags(t *testing.T) {
-	c := command{
-		opts: NewOptions(nil),
-	}
-
-	// no flags
-	err := c.validateFlags()
-	require.Error(t, err, "Mandatory flags have not been set, error is expected.")
-
-	// mandatory flags set
-	c.opts.Namespace = "test"
-	err = c.validateFlags()
-	require.NoError(t, err, "Mandatory flags have been set, no error is expected.")
-}
-
 func TestSteps(t *testing.T) {
 	c := command{
 		Command: cli.Command{

--- a/cmd/kyma/install/cmd.go
+++ b/cmd/kyma/install/cmd.go
@@ -163,7 +163,7 @@ func (cmd *command) configureInstallation(clusterConfig installation.ClusterInfo
 	if err != nil {
 		return &installation.Installation{}, errors.Wrap(err, "Could not load component configuration file. Make sure file is a valid YAML and contains a component list")
 	}
-	s, err := installation.NewInstallationService(cmd.K8s.Config(), cmd.opts.Timeout, "", cmp)
+	s, err := installation.NewInstallationService(cmd.K8s.RestConfig(), cmd.opts.Timeout, "", cmp)
 	if err != nil {
 		return &installation.Installation{}, errors.Wrap(err, "Failed to create installation service. Make sure your kubeconfig is valid")
 	}

--- a/cmd/kyma/upgrade/cmd.go
+++ b/cmd/kyma/upgrade/cmd.go
@@ -115,7 +115,7 @@ func (cmd *command) configureInstallation(clusterConfig installation.ClusterInfo
 	if err != nil {
 		return &installation.Installation{}, errors.Wrap(err, "Could not load component configuration file. Make sure file is a valid YAML and contains a component list")
 	}
-	s, err := installation.NewInstallationService(cmd.K8s.Config(), cmd.opts.Timeout, "", cmp)
+	s, err := installation.NewInstallationService(cmd.K8s.RestConfig(), cmd.opts.Timeout, "", cmp)
 	if err != nil {
 		return &installation.Installation{}, errors.Wrap(err, "Failed to create installation service. Make sure your kubeconfig is valid")
 	}

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -44,7 +44,7 @@ func NewFromConfig(url, file string) (KymaKube, error) {
 // NewFromConfigWithTimeout creates a new Kubernetes client based on the given Kubeconfig either provided by URL (in-cluster config) or via file (out-of-cluster config).
 // Allows to set a custom timeout for the Kubernetes HTTP client.
 func NewFromConfigWithTimeout(url, file string, t time.Duration) (KymaKube, error) {
-	config, err := RestConfig(url, file)
+	config, err := restConfig(url, file)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func NewFromConfigWithTimeout(url, file string, t time.Duration) (KymaKube, erro
 		return nil, err
 	}
 
-	kubeConfig, err := KubeConfig(url, file)
+	kubeConfig, err := kubeConfig(file)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/kube/config.go
+++ b/internal/kube/config.go
@@ -6,9 +6,9 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 )
 
-// RestConfig loads the rest configuration needed by k8s clients to interact with clusters based on the kubeconfig.
+// restConfig loads the rest configuration needed by k8s clients to interact with clusters based on the kubeconfig.
 // Loading rules are based on standard defined kubernetes config loading.
-func RestConfig(url, file string) (*rest.Config, error) {
+func restConfig(url, file string) (*rest.Config, error) {
 	// Default PathOptions gets kubeconfig in this order: the explicit path given, KUBECONFIG current context, recommentded file path
 	po := clientcmd.NewDefaultPathOptions()
 	po.LoadingRules.ExplicitPath = file
@@ -16,9 +16,9 @@ func RestConfig(url, file string) (*rest.Config, error) {
 	return clientcmd.BuildConfigFromKubeconfigGetter(url, po.GetStartingConfig)
 }
 
-// KubeConfig loads a structured representation of the Kubeconfig.
+// kubeConfig loads a structured representation of the Kubeconfig.
 // Loading rules are based on standard defined kubernetes config loading.
-func KubeConfig(url, file string) (*api.Config, error) {
+func kubeConfig(file string) (*api.Config, error) {
 	// Default PathOptions gets kubeconfig in this order: the explicit path given, KUBECONFIG current context, recommentded file path
 	po := clientcmd.NewDefaultPathOptions()
 	po.LoadingRules.ExplicitPath = file

--- a/internal/kube/config.go
+++ b/internal/kube/config.go
@@ -3,16 +3,27 @@ package kube
 import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
 )
 
-// Kubeconfig loads the rest configuration needed by k8s clients to interact with clusters.
+// RestConfig loads the rest configuration needed by k8s clients to interact with clusters based on the kubeconfig.
 // Loading rules are based on standard defined kubernetes config loading.
-func Kubeconfig(url, file string) (*rest.Config, error) {
+func RestConfig(url, file string) (*rest.Config, error) {
 	// Default PathOptions gets kubeconfig in this order: the explicit path given, KUBECONFIG current context, recommentded file path
 	po := clientcmd.NewDefaultPathOptions()
 	po.LoadingRules.ExplicitPath = file
 
 	return clientcmd.BuildConfigFromKubeconfigGetter(url, po.GetStartingConfig)
+}
+
+// KubeConfig loads a structured representation of the Kubeconfig.
+// Loading rules are based on standard defined kubernetes config loading.
+func KubeConfig(url, file string) (*api.Config, error) {
+	// Default PathOptions gets kubeconfig in this order: the explicit path given, KUBECONFIG current context, recommentded file path
+	po := clientcmd.NewDefaultPathOptions()
+	po.LoadingRules.ExplicitPath = file
+
+	return po.GetStartingConfig()
 }
 
 // Append adds the provided kubeconfig in the []byte to the Kubeconfig in the target path without altering other existing conifgs.

--- a/internal/kube/kube.go
+++ b/internal/kube/kube.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd/api"
 )
 
 //go:generate mockery --name KymaKube
@@ -22,8 +23,16 @@ type KymaKube interface {
 	Octopus() octopus.Interface
 	Istio() istio.Interface
 
-	// Config provides the configuration of the kubernetes client
-	Config() *rest.Config
+	// RestConfig provides the REST configuration of the kubernetes client
+	RestConfig() *rest.Config
+
+	// KubeConfig provides the currently used kubeconfig
+	KubeConfig() *api.Config
+
+	// DefaultNamespace finds out what the default namespace is based on:
+	// 1. Default namespace on the Kubeconfig
+	// 2. Default cluster namespace constant
+	DefaultNamespace() string
 
 	// IsPodDeployed checks if a pod is in the given namespace (independently of its status)
 	IsPodDeployed(namespace, name string) (bool, error)

--- a/internal/kube/mocks/KymaKube.go
+++ b/internal/kube/mocks/KymaKube.go
@@ -4,6 +4,7 @@ package mocks
 
 import (
 	dynamic "k8s.io/client-go/dynamic"
+	api "k8s.io/client-go/tools/clientcmd/api"
 
 	kubernetes "k8s.io/client-go/kubernetes"
 
@@ -27,17 +28,15 @@ type KymaKube struct {
 	mock.Mock
 }
 
-// Config provides a mock function with given fields:
-func (_m *KymaKube) Config() *rest.Config {
+// DefaultNamespace provides a mock function with given fields:
+func (_m *KymaKube) DefaultNamespace() string {
 	ret := _m.Called()
 
-	var r0 *rest.Config
-	if rf, ok := ret.Get(0).(func() *rest.Config); ok {
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
 		r0 = rf()
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*rest.Config)
-		}
+		r0 = ret.Get(0).(string)
 	}
 
 	return r0
@@ -117,6 +116,22 @@ func (_m *KymaKube) Istio() versioned.Interface {
 	return r0
 }
 
+// KubeConfig provides a mock function with given fields:
+func (_m *KymaKube) KubeConfig() *api.Config {
+	ret := _m.Called()
+
+	var r0 *api.Config
+	if rf, ok := ret.Get(0).(func() *api.Config); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*api.Config)
+		}
+	}
+
+	return r0
+}
+
 // Octopus provides a mock function with given fields:
 func (_m *KymaKube) Octopus() octopus.Interface {
 	ret := _m.Called()
@@ -127,6 +142,22 @@ func (_m *KymaKube) Octopus() octopus.Interface {
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(octopus.Interface)
+		}
+	}
+
+	return r0
+}
+
+// RestConfig provides a mock function with given fields:
+func (_m *KymaKube) RestConfig() *rest.Config {
+	ret := _m.Called()
+
+	var r0 *rest.Config
+	if rf, ok := ret.Get(0).(func() *rest.Config); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*rest.Config)
 		}
 	}
 

--- a/pkg/installation/installation.go
+++ b/pkg/installation/installation.go
@@ -151,7 +151,7 @@ func (i *Installation) InstallKyma() (*Result, error) {
 }
 
 func (i *Installation) checkPrevInstallation() (string, string, error) {
-	prevInstallationState, err := i.Service.CheckInstallationState(i.K8s.Config())
+	prevInstallationState, err := i.Service.CheckInstallationState(i.K8s.RestConfig())
 	if err != nil {
 		installErr := installationSDK.InstallationError{}
 		if errors.As(err, &installErr) {
@@ -364,7 +364,7 @@ func (i *Installation) waitForInstaller() error {
 		select {
 		case <-timeout:
 			i.currentStep.Failure()
-			if _, err := i.Service.CheckInstallationState(i.K8s.Config()); err != nil {
+			if _, err := i.Service.CheckInstallationState(i.K8s.RestConfig()); err != nil {
 				installationError := installationSDK.InstallationError{}
 				if ok := errors.As(err, &installationError); ok {
 					i.currentStep.LogErrorf("Installation error occurred while installing Kyma: %s. Details: %s", installationError.Error(), installationError.Details())
@@ -372,7 +372,7 @@ func (i *Installation) waitForInstaller() error {
 			}
 			return errors.New("Timeout reached while waiting for installation to complete")
 		default:
-			installationState, err := i.Service.CheckInstallationState(i.K8s.Config())
+			installationState, err := i.Service.CheckInstallationState(i.K8s.RestConfig())
 			if err != nil {
 				if !errorOccured {
 					errorOccured = true
@@ -418,7 +418,7 @@ func (i *Installation) waitForInstaller() error {
 func (i *Installation) buildResult(duration time.Duration) (*Result, error) {
 	// In case that noWait flag is set, check that Kyma was actually installed before building the Result
 	if i.Options.NoWait {
-		installationState, err := i.Service.CheckInstallationState(i.K8s.Config())
+		installationState, err := i.Service.CheckInstallationState(i.K8s.RestConfig())
 		if err != nil {
 			return nil, err
 		}
@@ -457,7 +457,7 @@ func (i *Installation) buildResult(duration time.Duration) (*Result, error) {
 
 	return &Result{
 		KymaVersion:   v,
-		Host:          i.K8s.Config().Host,
+		Host:          i.K8s.RestConfig().Host,
 		Console:       consoleURL,
 		AdminEmail:    string(adm.Data["email"]),
 		AdminPassword: string(adm.Data["password"]),

--- a/pkg/installation/installation_test.go
+++ b/pkg/installation/installation_test.go
@@ -83,7 +83,7 @@ func TestInstallKyma(t *testing.T) {
 
 	kymaMock.On("Static").Return(k8sMock)
 	kymaMock.On("Istio").Return(istioMock)
-	kymaMock.On("Config", mock.Anything).Return(&rest.Config{Host: "fake-kubeconfig-host"})
+	kymaMock.On("RestConfig", mock.Anything).Return(&rest.Config{Host: "fake-kubeconfig-host"})
 
 	// There is an existing installation
 	iServiceMock.On("CheckInstallationState", mock.Anything).Return(installSDK.InstallationState{State: "Installed"}, nil).Once()

--- a/pkg/installation/upgrade_test.go
+++ b/pkg/installation/upgrade_test.go
@@ -64,7 +64,7 @@ func TestUpgradeKyma(t *testing.T) {
 
 	kymaMock.On("Static").Return(k8sMock)
 	kymaMock.On("Istio").Return(istioMock)
-	kymaMock.On("Config", mock.Anything).Return(&rest.Config{Host: "fake-kubeconfig-host"})
+	kymaMock.On("RestConfig", mock.Anything).Return(&rest.Config{Host: "fake-kubeconfig-host"})
 	kymaMock.On("WaitPodStatusByLabel", "kyma-installer", "name", "kyma-installer", v1.PodRunning).Return(nil)
 
 	i := &Installation{


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- The namespace flag now behaves like in `kubectl`.
- It is no longer mandatory and the default namespace is used.
- Default namespace is picked from the `kubeconfig` or the standard is used.
- Added functionality to get the kubeconfig from the kyma interface.

**Related issue(s)**
#588