### PR TITLE
Avoid prompting a second upgrade warning message

### DIFF
--- a/internal/root/root.go
+++ b/internal/root/root.go
@@ -4,15 +4,15 @@ import "fmt"
 
 func PromptUser() bool {
 	for {
-		fmt.Print("Type [Y/n]: ")
+		fmt.Print("Type [y/N]: ")
 		var res string
 		if _, err := fmt.Scanf("%s", &res); err != nil {
 			return false
 		}
 		switch res {
-		case "Yes", "Y", "yes", "y":
+		case "yes", "y":
 			return true
-		case "no", "n":
+		case "No", "N", "no", "n":
 			return false
 		default:
 			continue

--- a/pkg/installation/upgrade.go
+++ b/pkg/installation/upgrade.go
@@ -51,7 +51,7 @@ func (i *Installation) UpgradeKyma() (*Result, error) {
 		}
 
 		// Checking if target Kyma version is a release version
-		isTargetReleaseVersion, targetSemVersion, err := i.checkTargetVersion(targetVersion)
+		isTargetReleaseVersion, targetSemVersion, err := i.checkTargetVersion(targetVersion, isCurrReleaseVersion)
 		if err != nil {
 			s.Failure()
 			return nil, err
@@ -161,12 +161,16 @@ func (i *Installation) checkCurrVersion(currVersion string) (bool, *semver.Versi
 	return isReleaseVersion, currSemVersion, nil
 }
 
-func (i *Installation) checkTargetVersion(targetVersion string) (bool, *semver.Version, error) {
+func (i *Installation) checkTargetVersion(targetVersion string, isCurrReleaseVersion bool) (bool, *semver.Version, error) {
 	isReleaseVersion := true
 	targetSemVersion, err := semver.NewVersion(i.Options.Source)
 	if err != nil {
 		isReleaseVersion = false
-		if !i.Options.NonInteractive {
+		// prompt the warning to the user only if both conditions are met
+		// 1) the non-interactive option is not set
+		// 2) the current kyma version is a release version, since if it was a non-release version, then the user would
+		//    have already accepted the risk from the first warning and no need to prompt a second warning
+		if !i.Options.NonInteractive && isCurrReleaseVersion {
 			promptMsg := fmt.Sprintf("Target Kyma version '%s' is not a release version, so it is not possible to check the upgrade compatibility.\n"+
 				"If you choose to continue the upgrade, you can compromise the functionality of your cluster.\n"+
 				"Are you sure you want to continue? ",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Currently in the upgrade command, if both the current and target kyma versions are non-release versions, the user is prompted with 2 warning messages sequentially. This is not needed, since if the user agrees to take the risk from the first warning, then there is no need to prompt a second one.
- The `PromptUser()` functionality is used when provisioning minikube and when upgrading kyma, and in both cases it is expected that the default value when pressing enter to be `no`. So, `Type [Y/n]` is changed to `Type [y/N]`, since the convention is to have the default value with uppercase letter.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
