### PR TITLE
treat errors as failure in junit output

### DIFF
--- a/internal/junitxml/report.go
+++ b/internal/junitxml/report.go
@@ -155,8 +155,8 @@ func (c *Creator) newFailedJUnitTestCase(r oct.TestResult, suiteName string) JUn
 			Name: fmt.Sprintf("[%s] %s/%s (executions: %d)", suiteName, r.Namespace, r.Name, len(r.Executions)),
 			Time: c.formatDurationAsSeconds(totalExecutionTime),
 			Failure: &JUnitFailure{
-				Message:  "kyma cli log download failed",
-				Contents: fmt.Sprintf("while fetching logs for %s test", r.Name),
+				Message:  "Failed",
+				Contents: fmt.Sprintf("Cannot display output for %s test. Kyma CLI failed to fetch logs during report generation: %s", r.Name, err),
 			},
 		}
 	}

--- a/internal/junitxml/report.go
+++ b/internal/junitxml/report.go
@@ -50,10 +50,7 @@ func (c *Creator) generateReport(suite *oct.ClusterTestSuite) (JUnitTestSuites, 
 		suiteTotalTime = suite.Status.CompletionTime.Sub(suite.Status.StartTime.Time)
 	}
 
-	tc, err := c.mapToTestCases(suite.Status.Results, suite.Name)
-	if err != nil {
-		return JUnitTestSuites{}, errors.Wrap(err, "while mapping test results into junit test cases")
-	}
+	tc := c.mapToTestCases(suite.Status.Results, suite.Name)
 
 	junitSuite := JUnitTestSuite{
 		Name:       suite.Name,
@@ -95,7 +92,7 @@ func (c *Creator) packageProperties() []JUnitProperty {
 	}
 }
 
-func (c *Creator) mapToTestCases(results []oct.TestResult, suiteName string) ([]JUnitTestCase, error) {
+func (c *Creator) mapToTestCases(results []oct.TestResult, suiteName string) []JUnitTestCase {
 	var cases []JUnitTestCase
 
 	for _, r := range results {
@@ -113,7 +110,7 @@ func (c *Creator) mapToTestCases(results []oct.TestResult, suiteName string) ([]
 		}
 	}
 
-	return cases, nil
+	return cases
 }
 
 func (c *Creator) newSuccessJUnitTestCase(tc oct.TestResult, suiteName string) JUnitTestCase {

--- a/internal/junitxml/report.go
+++ b/internal/junitxml/report.go
@@ -31,10 +31,7 @@ func NewCreator(logsFetcher logsFetcher) *Creator {
 
 // Write creates an XML document for suite and writes it to out.
 func (c *Creator) Write(out io.Writer, suite *oct.ClusterTestSuite) error {
-	report, err := c.generateReport(suite)
-	if err != nil {
-		return errors.Wrap(err, "while generating JUnit XML report")
-	}
+	report := c.generateReport(suite)
 
 	if err := c.write(out, report); err != nil {
 		return errors.Wrap(err, "while writing JUnit XML")
@@ -43,7 +40,7 @@ func (c *Creator) Write(out io.Writer, suite *oct.ClusterTestSuite) error {
 	return nil
 }
 
-func (c *Creator) generateReport(suite *oct.ClusterTestSuite) (JUnitTestSuites, error) {
+func (c *Creator) generateReport(suite *oct.ClusterTestSuite) JUnitTestSuites {
 	var suiteTotalTime time.Duration
 	// CompletionTime is not set when test suite is timed out
 	if suite.Status.CompletionTime != nil {
@@ -63,7 +60,7 @@ func (c *Creator) generateReport(suite *oct.ClusterTestSuite) (JUnitTestSuites, 
 
 	return JUnitTestSuites{
 		Suites: []JUnitTestSuite{junitSuite},
-	}, nil
+	}
 }
 func (c *Creator) formatDurationAsSeconds(d time.Duration) string {
 	return fmt.Sprintf("%f", d.Seconds())


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- put apiserver related issues in the junit output
  previously errors encountered during log fetching resulted in an empty junit output. This pr puts a message in the junit output and tries to fill as much of the output report as possible


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
