### PR TITLE
Expose kubernetes version for Minikube

### DIFF
--- a/cmd/kyma/provision/minikube/cmd.go
+++ b/cmd/kyma/provision/minikube/cmd.go
@@ -20,7 +20,6 @@ import (
 )
 
 const (
-	kubernetesVersion  string = "1.16.3"
 	bootstrapper       string = "kubeadm"
 	vmDriverHyperkit   string = "hyperkit"
 	vmDriverHyperv     string = "hyperv"
@@ -73,6 +72,7 @@ func NewCmd(o *Options) *cobra.Command {
 	cmd.Flags().StringVar(&o.Profile, "profile", "", "Specifies the Minikube profile.")
 	cmd.Flags().DurationVar(&o.Timeout, "timeout", 5*time.Minute, `Maximum time during which the provisioning takes place, where "0" means "infinite". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`)
 	cmd.Flags().BoolVar(&o.UseVPNKitSock, "use-hyperkit-vpnkit-sock", false, `Uses vpnkit sock provided by Docker. This is useful when DNS Port (53) is being used by some other program like dns-proxy (eg. provided by Cisco Umbrella. This flag works only on Mac OS).`)
+	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.16.3", "Kubernetes version of the cluster.")
 	return cmd
 }
 
@@ -233,7 +233,7 @@ func (c *command) startMinikube() error {
 		"--extra-config=apiserver.service-account-signing-key-file=/var/lib/minikube/certs/sa.key",
 		"--extra-config=apiserver.service-account-issuer=kubernetes/serviceaccount",
 		"--extra-config=apiserver.service-account-api-audiences=api",
-		"--kubernetes-version=v" + kubernetesVersion,
+		"--kubernetes-version=v" + c.opts.KubernetesVersion,
 		"--vm-driver", c.opts.VMDriver,
 		"--disk-size", c.opts.DiskSize,
 		"-b", bootstrapper,

--- a/cmd/kyma/provision/minikube/cmd.go
+++ b/cmd/kyma/provision/minikube/cmd.go
@@ -72,7 +72,7 @@ func NewCmd(o *Options) *cobra.Command {
 	cmd.Flags().StringVar(&o.Profile, "profile", "", "Specifies the Minikube profile.")
 	cmd.Flags().DurationVar(&o.Timeout, "timeout", 5*time.Minute, `Maximum time during which the provisioning takes place, where "0" means "infinite". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`)
 	cmd.Flags().BoolVar(&o.UseVPNKitSock, "use-hyperkit-vpnkit-sock", false, `Uses vpnkit sock provided by Docker. This is useful when DNS Port (53) is being used by some other program like dns-proxy (eg. provided by Cisco Umbrella. This flag works only on Mac OS).`)
-	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.16.3", "Kubernetes version of the cluster.")
+	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.16.15", "Kubernetes version of the cluster.")
 	return cmd
 }
 

--- a/cmd/kyma/provision/minikube/opts.go
+++ b/cmd/kyma/provision/minikube/opts.go
@@ -17,6 +17,7 @@ type Options struct {
 	Profile             string
 	UseVPNKitSock       bool
 	Timeout             time.Duration
+	KubernetesVersion   string
 }
 
 //NewOptions creates options with default values

--- a/docs/gen-docs/kyma_provision_minikube.md
+++ b/docs/gen-docs/kyma_provision_minikube.md
@@ -18,6 +18,7 @@ kyma provision minikube [flags]
       --cpus string                  Specifies the number of CPUs used for installation. (default "4")
       --disk-size string             Specifies the disk size used for installation. (default "30g")
       --hypervVirtualSwitch string   Specifies the Hyper-V switch version if you choose Hyper-V as the driver.
+  -k, --kube-version string          Kubernetes version of the cluster. (default "1.16.3")
       --memory string                Specifies RAM reserved for installation. (default "8192")
       --profile string               Specifies the Minikube profile.
       --timeout duration             Maximum time during which the provisioning takes place, where "0" means "infinite". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". (default 5m0s)

--- a/docs/gen-docs/kyma_provision_minikube.md
+++ b/docs/gen-docs/kyma_provision_minikube.md
@@ -18,7 +18,7 @@ kyma provision minikube [flags]
       --cpus string                  Specifies the number of CPUs used for installation. (default "4")
       --disk-size string             Specifies the disk size used for installation. (default "30g")
       --hypervVirtualSwitch string   Specifies the Hyper-V switch version if you choose Hyper-V as the driver.
-  -k, --kube-version string          Kubernetes version of the cluster. (default "1.16.3")
+  -k, --kube-version string          Kubernetes version of the cluster. (default "1.16.15")
       --memory string                Specifies RAM reserved for installation. (default "8192")
       --profile string               Specifies the Minikube profile.
       --timeout duration             Maximum time during which the provisioning takes place, where "0" means "infinite". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". (default 5m0s)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add a flag to allow the user to specify a kubernetes version when provisioning Minikube
- Update documentation to have the new flag

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#620 