### PR TITLE
New default namespace for the init function command

### DIFF
--- a/cmd/kyma/init/function/function.go
+++ b/cmd/kyma/init/function/function.go
@@ -9,7 +9,6 @@ import (
 
 const (
 	defaultRuntime   = "nodejs12"
-	defaultNamespace = "default"
 	defaultName      = "first-function"
 	defaultReference = "master"
 	defaultBaseDir   = "/"
@@ -37,7 +36,7 @@ Use the flags to specify the initial configuration for your Function or to choos
 	}
 
 	cmd.Flags().StringVar(&o.Name, "name", defaultName, `Function name.`)
-	cmd.Flags().StringVar(&o.Namespace, "namespace", defaultNamespace, `Namespace to which you want to apply your Function.`)
+	cmd.Flags().StringVar(&o.Namespace, "namespace", "", `Namespace to which you want to apply your Function.`)
 	cmd.Flags().StringVarP(&o.Dir, "dir", "d", "", `Full path to the directory where you want to save the project.`)
 	cmd.Flags().StringVarP(&o.Runtime, "runtime", "r", defaultRuntime, `Flag used to define the environment for running your Function. Use one of these options:
 	- nodejs12
@@ -56,7 +55,7 @@ Use the flags to specify the initial configuration for your Function or to choos
 func (c *command) Run() error {
 	s := c.NewStep("Generating project structure")
 
-	if err := c.opts.setDefaults(); err != nil {
+	if err := c.opts.setDefaults(c.K8s.DefaultNamespace()); err != nil {
 		s.Failure()
 		return err
 	}

--- a/cmd/kyma/init/function/function_test.go
+++ b/cmd/kyma/init/function/function_test.go
@@ -13,7 +13,7 @@ func TestUpgradeFlags(t *testing.T) {
 
 	// test default flag values
 	require.Equal(t, "first-function", o.Name, "Default value for the --name flag not as expected.")
-	require.Equal(t, "default", o.Namespace, "Default value for the --namespace flag not as expected.")
+	require.Equal(t, "", o.Namespace, "Default value for the --namespace flag not as expected.")
 	require.Equal(t, "", o.Dir, "Default value for the --dir flag not as expected.")
 	require.Equal(t, "nodejs12", o.Runtime, "Default value for the --runtime flag not as expected.")
 	require.Equal(t, "", o.URL, "The parsed value for the --url flag not as expected.")

--- a/cmd/kyma/init/function/opts.go
+++ b/cmd/kyma/init/function/opts.go
@@ -29,7 +29,7 @@ func NewOptions(o *cli.Options) *Options {
 	return options
 }
 
-func (o *Options) setDefaults() (err error) {
+func (o *Options) setDefaults(defaultNamespace string) (err error) {
 	if o.Dir == "" {
 		o.Dir, err = os.Getwd()
 		if err != nil {
@@ -38,6 +38,7 @@ func (o *Options) setDefaults() (err error) {
 	}
 
 	setIfZero(&o.SourcePath, o.Dir)
+	setIfZero(&o.Namespace, defaultNamespace)
 	return
 }
 

--- a/docs/gen-docs/kyma_init_function.md
+++ b/docs/gen-docs/kyma_init_function.md
@@ -19,7 +19,7 @@ kyma init function [flags]
       --base-dir string          A directory in the repository containing the Function's sources (default "/")
   -d, --dir string               Full path to the directory where you want to save the project.
       --name string              Function name. (default "first-function")
-      --namespace string         Namespace to which you want to apply your Function. (default "default")
+      --namespace string         Namespace to which you want to apply your Function.
       --reference string         Commit hash or branch name (default "master")
       --repository-name string   The name of the Git repository to be created (default "first-function")
   -r, --runtime string           Flag used to define the environment for running your Function. Use one of these options:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Regarding [this comment](https://github.com/kyma-project/cli/pull/618#discussion_r506119603) I change the value of the namespace to correlate with the DefaultNamespace method from the kyma client.
