### PR TITLE
Update AKS default kube version

### DIFF
--- a/cmd/kyma/provision/aks/cmd.go
+++ b/cmd/kyma/provision/aks/cmd.go
@@ -41,7 +41,7 @@ func NewCmd(o *Options) *cobra.Command {
 	cmd.Flags().StringVarP(&o.Name, "name", "n", "", "Name of the AKS cluster to provision. (required)")
 	cmd.Flags().StringVarP(&o.Project, "project", "p", "", "Name of the Azure Resource Group where you provision the AKS cluster. (required)")
 	cmd.Flags().StringVarP(&o.CredentialsFile, "credentials", "c", "", "Path to the TOML file containing the Azure Subscription ID (SUBSCRIPTION_ID), Tenant ID (TENANT_ID), Client ID (CLIENT_ID) and Client Secret (CLIENT_SECRET). (required)")
-	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.16.10", "Kubernetes version of the cluster.")
+	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.16.15", "Kubernetes version of the cluster.")
 	cmd.Flags().StringVarP(&o.Location, "location", "l", "westeurope", "Location of the cluster.")
 	cmd.Flags().StringVarP(&o.MachineType, "type", "t", "Standard_D4_v3", "Machine type used for the cluster.")
 	cmd.Flags().IntVar(&o.DiskSizeGB, "disk-size", 50, "Disk size (in GB) of the cluster.")

--- a/cmd/kyma/provision/aks/cmd_test.go
+++ b/cmd/kyma/provision/aks/cmd_test.go
@@ -17,7 +17,7 @@ func TestProvisionAKSFlags(t *testing.T) {
 	require.Equal(t, "", o.Name, "Default value for the name flag not as expected.")
 	require.Equal(t, "", o.Project, "Default value for the project flag not as expected.")
 	require.Equal(t, "", o.CredentialsFile, "Default value for the credentials flag not as expected.")
-	require.Equal(t, "1.16.10", o.KubernetesVersion, "Default value for the kube-version flag not as expected.")
+	require.Equal(t, "1.16.15", o.KubernetesVersion, "Default value for the kube-version flag not as expected.")
 	require.Equal(t, "westeurope", o.Location, "Default value for the location flag not as expected.")
 	require.Equal(t, "Standard_D4_v3", o.MachineType, "Default value for the type flag not as expected.")
 	require.Equal(t, 50, o.DiskSizeGB, "Default value for the disk-size flag not as expected.")

--- a/docs/gen-docs/kyma_provision_aks.md
+++ b/docs/gen-docs/kyma_provision_aks.md
@@ -18,7 +18,7 @@ kyma provision aks [flags]
 ```bash
   -c, --credentials string    Path to the TOML file containing the Azure Subscription ID (SUBSCRIPTION_ID), Tenant ID (TENANT_ID), Client ID (CLIENT_ID) and Client Secret (CLIENT_SECRET). (required)
       --disk-size int         Disk size (in GB) of the cluster. (default 50)
-  -k, --kube-version string   Kubernetes version of the cluster. (default "1.16.10")
+  -k, --kube-version string   Kubernetes version of the cluster. (default "1.16.15")
   -l, --location string       Location of the cluster. (default "westeurope")
   -n, --name string           Name of the AKS cluster to provision. (required)
       --nodes int             Number of cluster nodes. (default 3)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Update AKS default kube version to 1.16.15

For more info:
https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions#aks-kubernetes-release-calendar