### PR TITLE
Warn if a region is chosen

### DIFF
--- a/cmd/kyma/provision/gardener/aws/cmd.go
+++ b/cmd/kyma/provision/gardener/aws/cmd.go
@@ -180,6 +180,12 @@ func (c *command) validateFlags() error {
 		errMessage.WriteString("\n Minimum node count cannot be greater than maximum number nodes.")
 	}
 
+	for _, zone := range c.opts.Zones {
+		if !strings.HasPrefix(zone, c.opts.Region) {
+			errMessage.WriteString(fmt.Sprintf("\n Provided zone %s and region %s do not match. Please provide the right region for the zone.", zone, c.opts.Region))
+		}
+	}
+
 	if errMessage.Len() != 0 {
 		return errors.New(errMessage.String())
 	}

--- a/cmd/kyma/provision/gardener/gcp/cmd.go
+++ b/cmd/kyma/provision/gardener/gcp/cmd.go
@@ -181,6 +181,12 @@ func (c *command) validateFlags() error {
 		errMessage.WriteString("\n Minimum node count cannot be greater than maximum number nodes.")
 	}
 
+	for _, zone := range c.opts.Zones {
+		if !strings.HasPrefix(zone, c.opts.Region) {
+			errMessage.WriteString(fmt.Sprintf("\n Provided zone %s and region %s do not match. Please provide the right region for the zone.", zone, c.opts.Region))
+		}
+	}
+
 	if errMessage.Len() != 0 {
 		return errors.New(errMessage.String())
 	}

--- a/cmd/kyma/provision/gke/cmd.go
+++ b/cmd/kyma/provision/gke/cmd.go
@@ -151,14 +151,14 @@ func (c *command) validateFlags() error {
 	}
 
 	if len(strings.Split(c.opts.Location, "-")) <= 2 {
-		var answer bool
 		if !(c.opts.NonInteractive || c.opts.CI) {
-			answer = c.CurrentStep.PromptYesNo(fmt.Sprintf("Since you chose a region (%s) instead of a zone, %d number of nodes will be created on each zone in this region.\n"+
+			answer := c.CurrentStep.PromptYesNo(fmt.Sprintf("Since you chose a region (%s) instead of a zone, %d number of nodes will be created on each zone in this region.\n"+
 				"You can also provide a different number of nodes or specify a zone instead.\n"+
 				"Are you sure you want to continue? ", c.opts.Location, c.opts.NodeCount))
-		}
-		if !(c.opts.NonInteractive || c.opts.CI) && !answer {
-			return fmt.Errorf("Aborting provisioning")
+				
+			if !answer {
+				return fmt.Errorf("Aborting provisioning")
+			}
 		}
 	}
 

--- a/cmd/kyma/provision/gke/cmd.go
+++ b/cmd/kyma/provision/gke/cmd.go
@@ -155,7 +155,7 @@ func (c *command) validateFlags() error {
 			answer := c.CurrentStep.PromptYesNo(fmt.Sprintf("Since you chose a region (%s) instead of a zone, %d number of nodes will be created on each zone in this region.\n"+
 				"You can also provide a different number of nodes or specify a zone instead.\n"+
 				"Are you sure you want to continue? ", c.opts.Location, c.opts.NodeCount))
-				
+
 			if !answer {
 				return fmt.Errorf("Aborting provisioning")
 			}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- The user will be prompted about the number of nodes that will be created if a region is chosen. 
```bash
./bin/kyma-darwin provision gke --location europe-west4
? Since you chose a region (europe-west4) instead of a zone, 3 number of nodes will be created on each zone in this region.
You can also provide a different number of nodes or specify a zone instead.
Are you sure you want to continue? Type [y/N]: 
```
- Check if the provided zones and region match.
```bash
./bin/kyma-darwin provision gardener gcp --region=europe-west2
Error:
 Provided zone europe-west3-a and region europe-west2 do not match. Please provide the right region for the zone.
```

Previously the output was like this: 
```bash
./bin/kyma-darwin provision gardener gcp --zones="europe-west2-a"
X Provisioning Gardener cluster on GCP
Error: unable to provision gardener cluster:
Error: shoots.core.gardener.cloud "sa-test" is forbidden: [spec.provider.workers[0].zones[0]: Unsupported value: "europe-west2-a": supported values: "europe-west3-c", "europe-west3-a", "europe-west3-b"]

  on ../../../../../.kyma/clusters/gardener/berlin/sa-test-42/terraform.tf line 51, in resource "gardener_shoot" "gardener_cluster":
  51: resource "gardener_shoot" "gardener_cluster" {
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See https://github.com/kyma-project/cli/issues/406
