### PR TITLE
Speed up test execution 

### DIFF
--- a/cmd/kyma/apply/apply_test.go
+++ b/cmd/kyma/apply/apply_test.go
@@ -1,13 +1,15 @@
 package apply
 
 import (
-	"github.com/kyma-project/cli/internal/cli"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"testing"
+
+	"github.com/kyma-project/cli/internal/cli"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSubcommands(t *testing.T) {
+	t.Parallel()
 	c := NewCmd(&cli.Options{})
 	c.SetOutput(ioutil.Discard) // not interested in the command's output
 

--- a/cmd/kyma/apply/function/function_test.go
+++ b/cmd/kyma/apply/function/function_test.go
@@ -1,13 +1,15 @@
 package function
 
 import (
+	"testing"
+
 	"github.com/kyma-project/cli/internal/cli"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
-// TestUpgradeFlags ensures that the provided command flags are stored in the options.
-func TestUpgradeFlags(t *testing.T) {
+// TestFunctionFlags ensures that the provided command flags are stored in the options.
+func TestFunctionFlags(t *testing.T) {
+	t.Parallel()
 	o := NewOptions(&cli.Options{})
 	c := NewCmd(o)
 

--- a/cmd/kyma/create/create_test.go
+++ b/cmd/kyma/create/create_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestSubcommands(t *testing.T) {
+	t.Parallel()
 	c := NewCmd(&cli.Options{})
 	c.SetOutput(ioutil.Discard) // not interested in the command's output
 

--- a/cmd/kyma/create/system/system_test.go
+++ b/cmd/kyma/create/system/system_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestValidateArgs(t *testing.T) {
+	t.Parallel()
 	c := NewCmd(NewOptions(nil))
 
 	// no args
@@ -35,6 +36,7 @@ func TestValidateArgs(t *testing.T) {
 }
 
 func TestSteps(t *testing.T) {
+	t.Parallel()
 	c := command{
 		Command: cli.Command{
 			Options: cli.NewOptions(),
@@ -60,6 +62,7 @@ func TestSteps(t *testing.T) {
 }
 
 func TestCreateSystem(t *testing.T) {
+	t.Parallel()
 	k8s := &mocks.KymaKube{}
 	// mock watch because we can't mock the operator doing changes to the resource in real time
 	k8s.On("WatchResource", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -101,6 +104,7 @@ func TestCreateSystem(t *testing.T) {
 }
 
 func TestBindNamespace(t *testing.T) {
+	t.Parallel()
 	k8s := &mocks.KymaKube{}
 
 	dyn := dynamicK8s(
@@ -122,6 +126,7 @@ func TestBindNamespace(t *testing.T) {
 }
 
 func TestCreateToken(t *testing.T) {
+	t.Parallel()
 	k8s := &mocks.KymaKube{}
 	// mock watch because we can't mock the operator doing changes to the resource in real time
 	k8s.On("WatchResource", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)

--- a/cmd/kyma/init/function/function_test.go
+++ b/cmd/kyma/init/function/function_test.go
@@ -1,13 +1,15 @@
 package function
 
 import (
+	"testing"
+
 	"github.com/kyma-project/cli/internal/cli"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
-// TestUpgradeFlags ensures that the provided command flags are stored in the options.
-func TestUpgradeFlags(t *testing.T) {
+// TestFunctionFlags ensures that the provided command flags are stored in the options.
+func TestFunctionFlags(t *testing.T) {
+	t.Parallel()
 	o := NewOptions(&cli.Options{})
 	c := NewCmd(o)
 

--- a/cmd/kyma/init/init_test.go
+++ b/cmd/kyma/init/init_test.go
@@ -1,13 +1,15 @@
 package init
 
 import (
-	"github.com/kyma-project/cli/internal/cli"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"testing"
+
+	"github.com/kyma-project/cli/internal/cli"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSubcommands(t *testing.T) {
+	t.Parallel()
 	c := NewCmd(&cli.Options{})
 	c.SetOutput(ioutil.Discard) // not interested in the command's output
 

--- a/cmd/kyma/install/cmd_test.go
+++ b/cmd/kyma/install/cmd_test.go
@@ -15,6 +15,7 @@ import (
 
 // TestInstallFlags ensures that the provided command flags are stored in the options.
 func TestInstallFlags(t *testing.T) {
+	t.Parallel()
 	o := NewOptions(&cli.Options{})
 	c := NewCmd(o)
 
@@ -63,6 +64,7 @@ func TestInstallFlags(t *testing.T) {
 }
 
 func TestImportCertificate(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		// params
 		name        string

--- a/cmd/kyma/kyma_test.go
+++ b/cmd/kyma/kyma_test.go
@@ -10,6 +10,7 @@ import (
 
 // TestKymaFlags ensures that the provided command flags are stored in the options.
 func TestKymaFlags(t *testing.T) {
+	t.Parallel()
 	o := &cli.Options{}
 	c := NewCmd(o)
 	c.SetOutput(ioutil.Discard) // not interested in the command's output
@@ -28,6 +29,7 @@ func TestKymaFlags(t *testing.T) {
 }
 
 func TestKymaSubcommands(t *testing.T) {
+	t.Parallel()
 	c := NewCmd(&cli.Options{})
 	c.SetOutput(ioutil.Discard) // not interested in the command's output
 

--- a/cmd/kyma/provision/aks/cmd_test.go
+++ b/cmd/kyma/provision/aks/cmd_test.go
@@ -10,6 +10,7 @@ import (
 
 // TestProvisionAKSFlags ensures that the provided command flags are stored in the options.
 func TestProvisionAKSFlags(t *testing.T) {
+	t.Parallel()
 	o := NewOptions(&cli.Options{})
 	c := NewCmd(o)
 
@@ -52,6 +53,7 @@ func TestProvisionAKSFlags(t *testing.T) {
 }
 
 func TestProvisionAKSSubcommands(t *testing.T) {
+	t.Parallel()
 	o := NewOptions(&cli.Options{})
 	c := NewCmd(o)
 
@@ -61,6 +63,7 @@ func TestProvisionAKSSubcommands(t *testing.T) {
 }
 
 func TestNewCluster(t *testing.T) {
+	t.Parallel()
 	o := &Options{
 		Name:              "mega-cluster",
 		KubernetesVersion: "1.16.0",

--- a/cmd/kyma/provision/gardener/aws/cmd_test.go
+++ b/cmd/kyma/provision/gardener/aws/cmd_test.go
@@ -10,6 +10,7 @@ import (
 
 // TestProvisionGardenerAWSFlags ensures that the provided command flags are stored in the options.
 func TestProvisionGardenerAWSFlags(t *testing.T) {
+	t.Parallel()
 	o := NewOptions(&cli.Options{})
 	c := NewCmd(o)
 
@@ -62,6 +63,7 @@ func TestProvisionGardenerAWSFlags(t *testing.T) {
 }
 
 func TestProvisionGardenerAWSSubcommands(t *testing.T) {
+	t.Parallel()
 	o := NewOptions(&cli.Options{})
 	c := NewCmd(o)
 
@@ -71,6 +73,7 @@ func TestProvisionGardenerAWSSubcommands(t *testing.T) {
 }
 
 func TestNewCluster(t *testing.T) {
+	t.Parallel()
 	o := &Options{
 		Name:              "mega-cluster",
 		KubernetesVersion: "1.16.0",
@@ -90,6 +93,7 @@ func TestNewCluster(t *testing.T) {
 }
 
 func TestNewProvider(t *testing.T) {
+	t.Parallel()
 	o := &Options{
 		Project:         "cool-project",
 		CredentialsFile: "/path/to/credentials",

--- a/cmd/kyma/provision/gardener/az/cmd_test.go
+++ b/cmd/kyma/provision/gardener/az/cmd_test.go
@@ -10,6 +10,7 @@ import (
 
 // TestProvisionGardenerAzureFlags ensures that the provided command flags are stored in the options.
 func TestProvisionGardenerAzureFlags(t *testing.T) {
+	t.Parallel()
 	o := NewOptions(&cli.Options{})
 	c := NewCmd(o)
 
@@ -62,6 +63,7 @@ func TestProvisionGardenerAzureFlags(t *testing.T) {
 }
 
 func TestProvisionGardenerAzureSubcommands(t *testing.T) {
+	t.Parallel()
 	o := NewOptions(&cli.Options{})
 	c := NewCmd(o)
 
@@ -71,6 +73,7 @@ func TestProvisionGardenerAzureSubcommands(t *testing.T) {
 }
 
 func TestNewCluster(t *testing.T) {
+	t.Parallel()
 	o := &Options{
 		Name:              "mega-cluster",
 		KubernetesVersion: "1.16.0",
@@ -90,6 +93,7 @@ func TestNewCluster(t *testing.T) {
 }
 
 func TestNewProvider(t *testing.T) {
+	t.Parallel()
 	o := &Options{
 		Project:         "cool-project",
 		CredentialsFile: "/path/to/credentials",

--- a/cmd/kyma/provision/gardener/gcp/cmd_test.go
+++ b/cmd/kyma/provision/gardener/gcp/cmd_test.go
@@ -10,6 +10,7 @@ import (
 
 // TestProvisionGardenerFlags ensures that the provided command flags are stored in the options.
 func TestProvisionGardenerGCPFlags(t *testing.T) {
+	t.Parallel()
 	o := NewOptions(&cli.Options{})
 	c := NewCmd(o)
 
@@ -62,6 +63,7 @@ func TestProvisionGardenerGCPFlags(t *testing.T) {
 }
 
 func TestProvisionGardenerGCPSubcommands(t *testing.T) {
+	t.Parallel()
 	o := NewOptions(&cli.Options{})
 	c := NewCmd(o)
 
@@ -90,6 +92,7 @@ func TestNewCluster(t *testing.T) {
 }
 
 func TestNewProvider(t *testing.T) {
+	t.Parallel()
 	o := &Options{
 		Project:         "cool-project",
 		CredentialsFile: "/path/to/credentials",

--- a/cmd/kyma/provision/gke/cmd_test.go
+++ b/cmd/kyma/provision/gke/cmd_test.go
@@ -10,6 +10,7 @@ import (
 
 // TestProvisionGKEFlags ensures that the provided command flags are stored in the options.
 func TestProvisionGKEFlags(t *testing.T) {
+	t.Parallel()
 	o := NewOptions(&cli.Options{})
 	c := NewCmd(o)
 
@@ -52,6 +53,7 @@ func TestProvisionGKEFlags(t *testing.T) {
 }
 
 func TestProvisionGKESubcommands(t *testing.T) {
+	t.Parallel()
 	o := NewOptions(&cli.Options{})
 	c := NewCmd(o)
 
@@ -61,6 +63,7 @@ func TestProvisionGKESubcommands(t *testing.T) {
 }
 
 func TestNewCluster(t *testing.T) {
+	t.Parallel()
 	o := &Options{
 		Name:              "mega-cluster",
 		KubernetesVersion: "1.16.0",
@@ -80,6 +83,7 @@ func TestNewCluster(t *testing.T) {
 }
 
 func TestNewProvider(t *testing.T) {
+	t.Parallel()
 	o := &Options{
 		Project:         "cool-project",
 		CredentialsFile: "/path/to/credentials",

--- a/cmd/kyma/provision/minikube/cmd_test.go
+++ b/cmd/kyma/provision/minikube/cmd_test.go
@@ -12,6 +12,7 @@ import (
 
 // TestProvisionGKEFlags ensures that the provided command flags are stored in the options.
 func TestProvisionMinikubeFlags(t *testing.T) {
+	t.Parallel()
 	o := NewOptions(&cli.Options{})
 	c := NewCmd(o)
 
@@ -30,7 +31,7 @@ func TestProvisionMinikubeFlags(t *testing.T) {
 }
 
 func TestCheckRequirements(t *testing.T) {
-
+	t.Parallel()
 	cases := []struct {
 		name        string
 		shouldFail  bool

--- a/cmd/kyma/sync/function/function_test.go
+++ b/cmd/kyma/sync/function/function_test.go
@@ -7,8 +7,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestUpgradeFlags ensures that the provided command flags are stored in the options.
-func TestUpgradeFlags(t *testing.T) {
+// TestFunctionFlags ensures that the provided command flags are stored in the options.
+func TestFunctionFlags(t *testing.T) {
+	t.Parallel()
 	o := NewOptions(&cli.Options{})
 	c := NewCmd(o)
 

--- a/cmd/kyma/sync/sync_test.go
+++ b/cmd/kyma/sync/sync_test.go
@@ -1,13 +1,15 @@
 package sync
 
 import (
-	"github.com/kyma-project/cli/internal/cli"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"testing"
+
+	"github.com/kyma-project/cli/internal/cli"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSubcommands(t *testing.T) {
+	t.Parallel()
 	c := NewCmd(&cli.Options{
 		KubeconfigPath: "/fakepath",
 	})

--- a/cmd/kyma/test/common_test.go
+++ b/cmd/kyma/test/common_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func Test_NewTestSuite(t *testing.T) {
+	t.Parallel()
 	testData := []struct {
 		testName         string
 		shouldFail       bool
@@ -183,6 +184,7 @@ func Test_NewTestSuite(t *testing.T) {
 }
 
 func Test_ListTestSuitesByName(t *testing.T) {
+	t.Parallel()
 	testData := []struct {
 		testName        string
 		shouldFail      bool

--- a/cmd/kyma/test/definitions/cmd_test.go
+++ b/cmd/kyma/test/definitions/cmd_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func Test_ListTestDefinitionNames(t *testing.T) {
+	t.Parallel()
 	testData := []struct {
 		testName         string
 		shouldFail       bool

--- a/cmd/kyma/test/delete/cmd_test.go
+++ b/cmd/kyma/test/delete/cmd_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func Test_deleteTestSuite(t *testing.T) {
+	t.Parallel()
 	testData := []struct {
 		testName              string
 		shouldFail            bool

--- a/cmd/kyma/test/run/cmd_test.go
+++ b/cmd/kyma/test/run/cmd_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func Test_matchTestDefinitionNames(t *testing.T) {
+	t.Parallel()
 	testData := []struct {
 		testName        string
 		shouldFail      bool
@@ -77,6 +78,7 @@ func Test_matchTestDefinitionNames(t *testing.T) {
 }
 
 func Test_verifyIfTestNotExists(t *testing.T) {
+	t.Parallel()
 	testData := []struct {
 		testName       string
 		inputSuiteName string
@@ -129,6 +131,7 @@ func Test_verifyIfTestNotExists(t *testing.T) {
 }
 
 func Test_ListTestSuiteNames(t *testing.T) {
+	t.Parallel()
 	testData := []struct {
 		testName        string
 		shouldFail      bool
@@ -188,6 +191,7 @@ func Test_ListTestSuiteNames(t *testing.T) {
 }
 
 func Test_WaitForTestSuite(t *testing.T) {
+	t.Parallel()
 	tests := map[string]struct {
 		expMessages      []string
 		statusesSequence []oct.TestSuiteStatus

--- a/cmd/kyma/test/status/cmd_test.go
+++ b/cmd/kyma/test/status/cmd_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func Test_generateRerunCommand(t *testing.T) {
+	t.Parallel()
 	testData := []struct {
 		testName string
 		input    oct.ClusterTestSuite

--- a/cmd/kyma/upgrade/cmd_test.go
+++ b/cmd/kyma/upgrade/cmd_test.go
@@ -10,6 +10,7 @@ import (
 
 // TestUpgradeFlags ensures that the provided command flags are stored in the options.
 func TestUpgradeFlags(t *testing.T) {
+	t.Parallel()
 	o := NewOptions(&cli.Options{})
 	c := NewCmd(o)
 

--- a/internal/cli/command_test.go
+++ b/internal/cli/command_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestNewStep(t *testing.T) {
+	t.Parallel()
 	c := Command{} // uninitialized command
 
 	// test uninitialized command

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestRunCmd(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name           string
 		description    string

--- a/internal/junitxml/report_test.go
+++ b/internal/junitxml/report_test.go
@@ -25,6 +25,7 @@ import (
 // Example:
 //   go test ./internal/junitxml/... -v -test.update-golden
 func TestWriteJUnitXMLReport(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 	}{

--- a/internal/kube/client_test.go
+++ b/internal/kube/client_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestIsPodDeployed(t *testing.T) {
+	t.Parallel()
 	//setup
 	c := fakeClientWithNS()
 	_, err := c.Static().CoreV1().Pods("ns").Create(context.Background(), &corev1.Pod{
@@ -58,6 +59,7 @@ func TestIsPodDeployed(t *testing.T) {
 }
 
 func TestIsPodDeployedByLabel(t *testing.T) {
+	t.Parallel()
 	//setup
 	c := fakeClientWithNS()
 	_, err := c.Static().CoreV1().Pods("ns").Create(context.Background(), &corev1.Pod{
@@ -91,6 +93,7 @@ func TestIsPodDeployedByLabel(t *testing.T) {
 }
 
 func TestWaitPodStatus(t *testing.T) {
+	t.Parallel()
 	// setup
 	c := fakeClientWithNS()
 	pod := &corev1.Pod{
@@ -122,6 +125,7 @@ func TestWaitPodStatus(t *testing.T) {
 }
 
 func TestWaitPodStatusByLabel(t *testing.T) {
+	t.Parallel()
 	// setup
 	c := fakeClientWithNS()
 	pod := &corev1.Pod{
@@ -154,6 +158,7 @@ func TestWaitPodStatusByLabel(t *testing.T) {
 }
 
 func TestWatchResource(t *testing.T) {
+	t.Parallel()
 	c := &client{
 		restCfg: &rest.Config{},
 		dynamic: dynamicK8s(

--- a/internal/logs/fetcher_test.go
+++ b/internal/logs/fetcher_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func Test(t *testing.T) {
+	t.Parallel()
 	const fixLogsResponse = `Lorem ipsum dolor sit amet.`
 
 	tests := map[string]struct {

--- a/internal/net/net_test.go
+++ b/internal/net/net_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestGetAvailablePort(t *testing.T) {
+	t.Parallel()
 	p, err := GetAvailablePort()
 
 	require.True(t, p > 0)
@@ -15,7 +16,7 @@ func TestGetAvailablePort(t *testing.T) {
 }
 
 func TestDoGet(t *testing.T) {
-
+	t.Parallel()
 	// Happy path
 	sc, err := DoGet("http://google.com")
 	require.NoError(t, err)

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func Test_SplitDockerDomain(t *testing.T) {
+	t.Parallel()
 	test1 := "localhost:5000/test/testImage:1"
 	d1, r1 := splitDockerDomain(test1)
 	require.Equal(t, d1, "localhost:5000")
@@ -70,7 +71,7 @@ func genConfigFile() *dockerConfigFile.ConfigFile {
 }
 
 func Test_Resolve_happy_path(t *testing.T) {
-
+	t.Parallel()
 	tmpHome, err := ioutil.TempDir("/tmp", "config-test")
 	assert.NilError(t, err)
 	defer os.RemoveAll(tmpHome)
@@ -91,6 +92,7 @@ func Test_Resolve_happy_path(t *testing.T) {
 }
 
 func Test_BuildKymaInstaller(t *testing.T) {
+	t.Parallel()
 	imageName := "kyma-project-foo"
 	fooLocalSrcPath := "foo"
 
@@ -129,6 +131,7 @@ func Test_BuildKymaInstaller(t *testing.T) {
 }
 
 func Test_PushKymaInstaller(t *testing.T) {
+	t.Parallel()
 	tmpHome, err := ioutil.TempDir("/tmp", "config-pus-kyma-test")
 	assert.NilError(t, err)
 	defer os.RemoveAll(tmpHome)

--- a/pkg/installation/cluster_test.go
+++ b/pkg/installation/cluster_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestGetClusterInfoFromConfigMap(t *testing.T) {
+	t.Parallel()
 	kymaMock := &mocks.KymaKube{}
 
 	// Happy path

--- a/pkg/installation/installation_test.go
+++ b/pkg/installation/installation_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestInstallKyma(t *testing.T) {
+	t.Parallel()
 	// prepare mocks
 	kymaMock := k8sMocks.KymaKube{}
 	iServiceMock := mocks.Service{}
@@ -141,6 +142,7 @@ func TestInstallKyma(t *testing.T) {
 }
 
 func TestValidateConfigurations(t *testing.T) {
+	t.Parallel()
 	// Domain is passed, but certificate and key are missing
 	i := &Installation{
 		Options: &Options{

--- a/pkg/installation/service_test.go
+++ b/pkg/installation/service_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestTriggerInstallation(t *testing.T) {
-
+	t.Parallel()
 	// set all mocked outcomes
 	mockInstaller := &mocks.Installer{}
 
@@ -83,7 +83,7 @@ func TestTriggerInstallation(t *testing.T) {
 }
 
 func TestTriggerUpgrade(t *testing.T) {
-
+	t.Parallel()
 	// set all mocked outcomes
 	mockInstaller := &mocks.Installer{}
 
@@ -151,7 +151,7 @@ func TestTriggerUpgrade(t *testing.T) {
 }
 
 func TestGetInstallationCRModificationFunc(t *testing.T) {
-
+	t.Parallel()
 	comps := []v1alpha1.KymaComponent{
 		{
 			Name: "Comp 1",

--- a/pkg/installation/upgrade_test.go
+++ b/pkg/installation/upgrade_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestUpgradeKyma(t *testing.T) {
+	t.Parallel()
 	// prepare mocks
 	kymaMock := k8sMocks.KymaKube{}
 	iServiceMock := mocks.Service{}

--- a/pkg/installation/utils_test.go
+++ b/pkg/installation/utils_test.go
@@ -10,18 +10,21 @@ import (
 )
 
 func Test_GetMasterHash(t *testing.T) {
+	t.Parallel()
 	h, err := getMasterHash()
 	require.NoError(t, err)
 	require.True(t, isHex(h))
 }
 
 func Test_GetLatestAvailableMasterHash(t *testing.T) {
+	t.Parallel()
 	h, err := getLatestAvailableMasterHash(&stepMocks.Step{}, 5)
 	require.NoError(t, err)
 	require.True(t, isHex(h))
 }
 
 func Test_LoadInstallationFiles(t *testing.T) {
+	t.Parallel()
 	localInstallation := Installation{
 		Options: &Options{
 			IsLocal:          true,
@@ -54,6 +57,7 @@ func Test_LoadInstallationFiles(t *testing.T) {
 }
 
 func Test_LoadConfigurations(t *testing.T) {
+	t.Parallel()
 	domain := "test.kyma"
 	tlsCert := "testCert"
 	tlsKey := "testKey"
@@ -103,6 +107,7 @@ func Test_LoadConfigurations(t *testing.T) {
 }
 
 func Test_LoadComponentsConfig(t *testing.T) {
+	t.Parallel()
 	installation := &Installation{
 		Options: &Options{
 			ComponentsConfig: path.Join("../../internal/testdata", "components.yaml"),
@@ -125,6 +130,7 @@ func Test_LoadComponentsConfig(t *testing.T) {
 }
 
 func Test_GetInstallerImage(t *testing.T) {
+	t.Parallel()
 	const image = "eu.gcr.io/kyma-project/kyma-installer:63f27f76"
 	testData := File{Content: []map[string]interface{}{{
 		"apiVersion": "installer.kyma-project.io/v1alpha1",
@@ -152,6 +158,7 @@ func Test_GetInstallerImage(t *testing.T) {
 }
 
 func Test_ReplaceDockerImageURL(t *testing.T) {
+	t.Parallel()
 	const replacedWithData = "testImage!"
 	testData := []struct {
 		testName       string
@@ -216,6 +223,7 @@ func Test_ReplaceDockerImageURL(t *testing.T) {
 }
 
 func Test_IsDockerImage(t *testing.T) {
+	t.Parallel()
 	ok := isDockerImage("testRegistry/testImage:tag")
 	require.True(t, ok)
 
@@ -224,6 +232,7 @@ func Test_IsDockerImage(t *testing.T) {
 }
 
 func Test_IsSemVer(t *testing.T) {
+	t.Parallel()
 	ok := isSemVer("1.2.3")
 	require.True(t, ok)
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- By setting up tests to run in parallel, execution time went down by ~20%
- On Prow (more CPU cores), execution went down ~60%.