### PR TITLE
Add --docker-ports flag in order to expose custom ports when running with docker VM driver

### DIFF
--- a/cmd/kyma/provision/minikube/cmd.go
+++ b/cmd/kyma/provision/minikube/cmd.go
@@ -23,6 +23,7 @@ const (
 	bootstrapper       string = "kubeadm"
 	vmDriverHyperkit   string = "hyperkit"
 	vmDriverHyperv     string = "hyperv"
+	vmDriverDocker     string = "docker"
 	vmDriverNone       string = "none"
 	vmDriverVirtualBox string = "virtualbox"
 	sleep                     = 10 * time.Second
@@ -37,7 +38,7 @@ var (
 		vmDriverHyperkit,
 		vmDriverVirtualBox,
 		"kvm2",
-		"docker",
+		vmDriverDocker,
 		"none",
 	}
 	ErrMinikubeRunning = errors.New("Minikube already running")
@@ -66,6 +67,7 @@ func NewCmd(o *Options) *cobra.Command {
 
 	cmd.Flags().StringVar(&o.VMDriver, "vm-driver", defaultVMDriver, "Specifies the VM driver. Possible values: "+strings.Join(drivers, ","))
 	cmd.Flags().StringVar(&o.HypervVirtualSwitch, "hypervVirtualSwitch", "", "Specifies the Hyper-V switch version if you choose Hyper-V as the driver.")
+	cmd.Flags().StringSliceVar(&o.DockerPorts, "docker-ports", []string{}, "List of ports that should be exposed if you choose Docker as the driver.")
 	cmd.Flags().StringVar(&o.DiskSize, "disk-size", "30g", "Specifies the disk size used for installation.")
 	cmd.Flags().StringVar(&o.Memory, "memory", "8192", "Specifies RAM reserved for installation.")
 	cmd.Flags().StringVar(&o.CPUS, "cpus", "4", "Specifies the number of CPUs used for installation.")
@@ -182,6 +184,11 @@ func (c *command) checkRequirements(s step.Step) error {
 		return fmt.Errorf("Specified VMDriver '%s' requires the --hypervVirtualSwitch option", vmDriverHyperv)
 	}
 
+	if len(c.opts.DockerPorts) > 0 && c.opts.VMDriver != vmDriverDocker {
+		s.Failure()
+		return fmt.Errorf("docker-ports flag is applicable only for VMDriver '%s'", vmDriverDocker)
+	}
+
 	versionWarning, err := minikube.CheckVersion(c.opts.Verbose, c.opts.Timeout)
 	if err != nil {
 		s.Failure()
@@ -241,6 +248,12 @@ func (c *command) startMinikube() error {
 
 	if c.opts.VMDriver == vmDriverHyperv {
 		startCmd = append(startCmd, "--hyperv-virtual-switch="+c.opts.HypervVirtualSwitch)
+	}
+
+	if c.opts.VMDriver == vmDriverDocker && len(c.opts.DockerPorts) > 0 {
+		for _, port := range c.opts.DockerPorts {
+			startCmd = append(startCmd, "--ports=" + port)
+		}
 	}
 
 	startCmd, err := osSpecificRun(c, startCmd)

--- a/cmd/kyma/provision/minikube/cmd.go
+++ b/cmd/kyma/provision/minikube/cmd.go
@@ -252,7 +252,7 @@ func (c *command) startMinikube() error {
 
 	if c.opts.VMDriver == vmDriverDocker && len(c.opts.DockerPorts) > 0 {
 		for _, port := range c.opts.DockerPorts {
-			startCmd = append(startCmd, "--ports=" + port)
+			startCmd = append(startCmd, "--ports="+port)
 		}
 	}
 

--- a/cmd/kyma/provision/minikube/cmd_test.go
+++ b/cmd/kyma/provision/minikube/cmd_test.go
@@ -54,6 +54,15 @@ func TestCheckRequirements(t *testing.T) {
 				VMDriver: "hyperv",
 			},
 		},
+		{
+			name:        "--docker-ports require VM Driver docker",
+			shouldFail:  true,
+			expectedErr: "docker-ports flag is applicable only for VMDriver 'docker'",
+			op: Options{
+				VMDriver: "hyperkit",
+				DockerPorts: []string{"8080:8081"},
+			},
+		},
 	}
 	var step step.Factory
 	s := step.NewStep("checking requirements")

--- a/cmd/kyma/provision/minikube/cmd_test.go
+++ b/cmd/kyma/provision/minikube/cmd_test.go
@@ -59,7 +59,7 @@ func TestCheckRequirements(t *testing.T) {
 			shouldFail:  true,
 			expectedErr: "docker-ports flag is applicable only for VMDriver 'docker'",
 			op: Options{
-				VMDriver: "hyperkit",
+				VMDriver:    "hyperkit",
 				DockerPorts: []string{"8080:8081"},
 			},
 		},

--- a/cmd/kyma/provision/minikube/opts.go
+++ b/cmd/kyma/provision/minikube/opts.go
@@ -14,6 +14,7 @@ type Options struct {
 	Memory              string
 	CPUS                string
 	HypervVirtualSwitch string
+	DockerPorts         []string
 	Profile             string
 	UseVPNKitSock       bool
 	Timeout             time.Duration

--- a/docs/gen-docs/kyma_provision_minikube.md
+++ b/docs/gen-docs/kyma_provision_minikube.md
@@ -17,6 +17,7 @@ kyma provision minikube [flags]
 ```bash
       --cpus string                  Specifies the number of CPUs used for installation. (default "4")
       --disk-size string             Specifies the disk size used for installation. (default "30g")
+      --docker-ports strings         List of ports that should be exposed if you choose Docker as the driver.
       --hypervVirtualSwitch string   Specifies the Hyper-V switch version if you choose Hyper-V as the driver.
   -k, --kube-version string          Kubernetes version of the cluster. (default "1.16.15")
       --memory string                Specifies RAM reserved for installation. (default "8192")


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

As of minikube v1.14 you can pass ports to expose when running minikube with docker driver.

This is a feature which we in compass was waiting in order to run locally with docker driver. This PR adopts that flag in kyma cli.

Reference: https://github.com/kubernetes/minikube/pull/9404
