### PR TITLE
Append the current commit hash in case of a stable version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ ifndef VERSION
 	VERSION = ${shell git describe --tags --always}
 endif
 
+ifeq ($(VERSION),stable)
+	VERSION = stable-${shell git rev-parse --short HEAD}
+endif
+
 FLAGS = -ldflags '-s -w -X github.com/kyma-project/cli/cmd/kyma/version.Version=$(VERSION) -X github.com/kyma-project/cli/cmd/kyma/install.DefaultKymaVersion=$(KYMA_VERSION) -X github.com/kyma-project/cli/cmd/kyma/upgrade.DefaultKymaVersion=$(KYMA_VERSION)'
 
 .PHONY: resolve


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- append the current commit hash in case of a stable version

**Related issue(s)**
Resolves #594 