### PR TITLE
Strip ANSI escape sequences while fetching logs from containers

### DIFF
--- a/internal/logs/fetcher.go
+++ b/internal/logs/fetcher.go
@@ -73,6 +73,7 @@ func (f *FetcherForTestingPods) Logs(result oct.TestResult) (string, error) {
 	return strip(logs.String()), nil
 }
 
+// strip removes ANSI escape sequences from the input string
 func strip(s string) string {
 	re := regexp.MustCompile(ansi)
 	return re.ReplaceAllString(s, "")

--- a/internal/logs/fetcher.go
+++ b/internal/logs/fetcher.go
@@ -70,11 +70,10 @@ func (f *FetcherForTestingPods) Logs(result oct.TestResult) (string, error) {
 		}
 	}
 
-	return strip(logs.String()), nil
+	return stripANSI(logs.String()), nil
 }
 
-// strip removes ANSI escape sequences from the input string
-func strip(s string) string {
+func stripANSI(s string) string {
 	re := regexp.MustCompile(ansi)
 	return re.ReplaceAllString(s, "")
 }

--- a/internal/logs/fetcher.go
+++ b/internal/logs/fetcher.go
@@ -3,6 +3,7 @@ package logs
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	oct "github.com/kyma-incubator/octopus/pkg/apis/testing/v1alpha1"
@@ -11,6 +12,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
+
+const ansi = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
 
 // FetcherForTestingPods provides functionality for fetching logs from test suite results
 type FetcherForTestingPods struct {
@@ -67,5 +70,10 @@ func (f *FetcherForTestingPods) Logs(result oct.TestResult) (string, error) {
 		}
 	}
 
-	return logs.String(), nil
+	return strip(logs.String()), nil
+}
+
+func strip(s string) string {
+	re := regexp.MustCompile(ansi)
+	return re.ReplaceAllString(s, "")
 }

--- a/internal/logs/fetcher_test.go
+++ b/internal/logs/fetcher_test.go
@@ -63,6 +63,7 @@ func Test(t *testing.T) {
 }
 
 func Test_stripANSI(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		Got, Wanted string
 	}{

--- a/internal/logs/fetcher_test.go
+++ b/internal/logs/fetcher_test.go
@@ -1,4 +1,4 @@
-package logs_test
+package logs
 
 import (
 	"context"
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	oct "github.com/kyma-incubator/octopus/pkg/apis/testing/v1alpha1"
-	"github.com/kyma-project/cli/internal/logs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
@@ -45,7 +44,7 @@ func Test(t *testing.T) {
 			fakeCli, cleanup := newFakePodsGetter(t, tc.pod, fixLogsResponse)
 			defer cleanup()
 
-			fetcher := logs.NewFetcherForTestingPods(fakeCli, tc.ignoredCnt)
+			fetcher := NewFetcherForTestingPods(fakeCli, tc.ignoredCnt)
 
 			fix := fixFailedTestResultForPod(tc.pod)
 
@@ -60,6 +59,32 @@ func Test(t *testing.T) {
 			assert.Equal(t, fakeCli.podNamespace, tc.pod.Namespace)
 			assert.NotContains(t, fakeCli.containers, tc.ignoredCnt)
 		})
+	}
+}
+
+func Test_stripANSI(t *testing.T) {
+	testCases := []struct {
+		Got, Wanted string
+	}{
+		{Got: `[?25l[09:33:25]  Verifying Cypress can run /root/.cache/Cypress/4.12.1/Cypress [started]
+[09:33:34]  Verifying Cypress can run /root/.cache/Cypress/4.12.1/Cypress [completed]
+[?25hOne login method detected, trying to login using email...`,
+			Wanted: `[09:33:25]  Verifying Cypress can run /root/.cache/Cypress/4.12.1/Cypress [started]
+[09:33:34]  Verifying Cypress can run /root/.cache/Cypress/4.12.1/Cypress [completed]
+One login method detected, trying to login using email...`,
+		},
+		{
+			Got:    "\u001B[4mUnicorn\u001B[0m",
+			Wanted: "Unicorn",
+		},
+		{
+			Got:    "\u001B[?25hcode is 1",
+			Wanted: "code is 1",
+		},
+	}
+	for _, tc := range testCases {
+		s := stripANSI(tc.Got)
+		assert.Equal(t, tc.Wanted, s)
 	}
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
I have noticed that the logs from the testsuite containers are fetched with the ANSI escape sequences from the console log, which is expected, but XML generator cannot encode ANSI sequences to utf8. This breaks TestGrid and Spyglass JUnit parsing.

I have checked the function on the part of the log https://storage.googleapis.com/kyma-prow-logs/logs/post-master-kyma-gke-integration/1328263533271453697/artifacts/junit_Kyma_octopus-test-suite-1605518975.xml. It should strip the bad stuff properly. If you need unit test for that function then I can sort something out.

Changes proposed in this pull request:

- Add `strip()` function that strips the container log string from the ANSI characters based on the regex.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/test-infra/issues/2900