### PR TITLE
Consistent flag naming

### DIFF
--- a/cmd/kyma/install/cmd.go
+++ b/cmd/kyma/install/cmd.go
@@ -79,10 +79,10 @@ The standard installation uses the minimal configuration. The system performs th
 		Aliases: []string{"i"},
 	}
 
-	cobraCmd.Flags().BoolVarP(&o.NoWait, "noWait", "n", false, "Flag that determines if the command should wait for Kyma installation to complete.")
+	cobraCmd.Flags().BoolVarP(&o.NoWait, "no-wait", "n", false, "Determines if the command should wait for Kyma installation to complete.")
 	cobraCmd.Flags().StringVarP(&o.Domain, "domain", "d", defaultDomain, "Domain used for installation.")
-	cobraCmd.Flags().StringVarP(&o.TLSCert, "tlsCert", "", "", "TLS certificate for the domain used for installation. The certificate must be a base64-encoded value.")
-	cobraCmd.Flags().StringVarP(&o.TLSKey, "tlsKey", "", "", "TLS key for the domain used for installation. The key must be a base64-encoded value.")
+	cobraCmd.Flags().StringVarP(&o.TLSCert, "tls-cert", "", "", "TLS certificate for the domain used for installation. The certificate must be a base64-encoded value.")
+	cobraCmd.Flags().StringVarP(&o.TLSKey, "tls-key", "", "", "TLS key for the domain used for installation. The key must be a base64-encoded value.")
 	cobraCmd.Flags().StringVarP(&o.Source, "source", "s", DefaultKymaVersion, `Installation source. 
 	- To use the specific release, write "kyma install --source=1.15.1".
 	- To use the latest master, write "kyma install --source=latest".
@@ -92,11 +92,11 @@ The standard installation uses the minimal configuration. The system performs th
 	- To use the local sources, write "kyma install --source=local".
 	- To use a custom installer image, write "kyma install --source=user/my-kyma-installer:v1.4.0".`)
 	cobraCmd.Flags().StringVarP(&o.LocalSrcPath, "src-path", "", "", "Absolute path to local sources.")
-	cobraCmd.Flags().DurationVarP(&o.Timeout, "timeout", "", 1*time.Hour, "Time-out after which CLI stops watching the installation progress.")
+	cobraCmd.Flags().DurationVarP(&o.Timeout, "timeout", "", 1*time.Hour, "Timeout after which CLI stops watching the installation progress.")
 	cobraCmd.Flags().StringVarP(&o.Password, "password", "p", "", "Predefined cluster password.")
 	cobraCmd.Flags().StringArrayVarP(&o.OverrideConfigs, "override", "o", nil, "Path to a YAML file with parameters to override.")
-	cobraCmd.Flags().StringVarP(&o.ComponentsConfig, "components", "c", "", "Path to a YAML file with component list to override.")
-	cobraCmd.Flags().IntVar(&o.FallbackLevel, "fallbackLevel", 5, `If "source=latest-published", defines the number of commits from master branch taken into account if artifacts for newer commits do not exist yet`)
+	cobraCmd.Flags().StringVarP(&o.ComponentsConfig, "components", "c", "", "Path to a YAML file with a component list to override.")
+	cobraCmd.Flags().IntVar(&o.FallbackLevel, "fallback-level", 5, `If "source=latest-published", defines the number of commits from master branch taken into account if artifacts for newer commits do not exist yet`)
 	cobraCmd.Flags().StringVarP(&o.CustomImage, "custom-image", "", "", "Full image name including the registry and the tag. Required for installation from local sources to a remote cluster.")
 	return cobraCmd
 }

--- a/cmd/kyma/install/cmd_test.go
+++ b/cmd/kyma/install/cmd_test.go
@@ -37,15 +37,15 @@ func TestInstallFlags(t *testing.T) {
 	err := c.ParseFlags([]string{
 		"-n", "true",
 		"-d", "fake-domain",
-		"--tlsCert", "fake-cert",
-		"--tlsKey", "fake-key",
+		"--tls-cert", "fake-cert",
+		"--tls-key", "fake-key",
 		"-s", "test-registry/test-image:1",
 		"--src-path", "fake/path/to/source",
 		"--timeout", "100s",
 		"-p", "fake-pwd",
 		"-o", "fake/path/to/overrides",
 		"-c", "fake/path/to/components",
-		"--fallbackLevel", "7",
+		"--fallback-level", "7",
 		"--custom-image", "test-registry/test-image:2",
 	})
 	require.NoError(t, err, "Parsing flags should not return an error")

--- a/cmd/kyma/provision/minikube/cmd.go
+++ b/cmd/kyma/provision/minikube/cmd.go
@@ -66,7 +66,7 @@ func NewCmd(o *Options) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&o.VMDriver, "vm-driver", defaultVMDriver, "Specifies the VM driver. Possible values: "+strings.Join(drivers, ","))
-	cmd.Flags().StringVar(&o.HypervVirtualSwitch, "hypervVirtualSwitch", "", "Specifies the Hyper-V switch version if you choose Hyper-V as the driver.")
+	cmd.Flags().StringVar(&o.HypervVirtualSwitch, "hyperv-virtual-switch", "", "Specifies the Hyper-V switch version if you choose Hyper-V as the driver.")
 	cmd.Flags().StringSliceVar(&o.DockerPorts, "docker-ports", []string{}, "List of ports that should be exposed if you choose Docker as the driver.")
 	cmd.Flags().StringVar(&o.DiskSize, "disk-size", "30g", "Specifies the disk size used for installation.")
 	cmd.Flags().StringVar(&o.Memory, "memory", "8192", "Specifies RAM reserved for installation.")

--- a/cmd/kyma/provision/minikube/cmd.go
+++ b/cmd/kyma/provision/minikube/cmd.go
@@ -181,7 +181,7 @@ func (c *command) checkRequirements(s step.Step) error {
 	}
 	if c.opts.VMDriver == vmDriverHyperv && c.opts.HypervVirtualSwitch == "" {
 		s.Failure()
-		return fmt.Errorf("Specified VMDriver '%s' requires the --hypervVirtualSwitch option", vmDriverHyperv)
+		return fmt.Errorf("Specified VMDriver '%s' requires the --hyperv-virtual-switch option", vmDriverHyperv)
 	}
 
 	if len(c.opts.DockerPorts) > 0 && c.opts.VMDriver != vmDriverDocker {

--- a/cmd/kyma/provision/minikube/cmd_test.go
+++ b/cmd/kyma/provision/minikube/cmd_test.go
@@ -49,7 +49,7 @@ func TestCheckRequirements(t *testing.T) {
 		{
 			name:        "VM Driver requires hypervVirtualSwitch",
 			shouldFail:  true,
-			expectedErr: "Specified VMDriver 'hyperv' requires the --hypervVirtualSwitch option",
+			expectedErr: "Specified VMDriver 'hyperv' requires the --hyperv-virtual-switch option",
 			op: Options{
 				VMDriver: "hyperv",
 			},

--- a/cmd/kyma/upgrade/cmd.go
+++ b/cmd/kyma/upgrade/cmd.go
@@ -38,9 +38,10 @@ func NewCmd(o *Options) *cobra.Command {
 		RunE:  func(_ *cobra.Command, _ []string) error { return cmd.Run() },
 	}
 
-	cobraCmd.Flags().BoolVarP(&o.NoWait, "noWait", "n", false, "Determines if the command should wait for the Kyma upgrade to complete.")
+	cobraCmd.Flags().BoolVarP(&o.NoWait, "no-wait", "n", false, "Determines if the command should wait for the Kyma upgrade to complete.")
 	cobraCmd.Flags().StringVarP(&o.Domain, "domain", "d", defaultDomain, "Domain used for the upgrade.")
-	cobraCmd.Flags().StringVarP(&o.TLSCert, "tlsCert", "", "", "TLS certificate for the domain used for the upgrade. The certificate must be a base64-encoded value.")
+	cobraCmd.Flags().StringVarP(&o.TLSCert, "tls-cert", "", "", "TLS certificate for the domain used for the upgrade. The certificate must be a base64-encoded value.")
+	cobraCmd.Flags().StringVarP(&o.TLSKey, "tls-key", "", "", "TLS key for the domain used for the upgrade. The key must be a base64-encoded value.")
 	cobraCmd.Flags().StringVarP(&o.Source, "source", "s", DefaultKymaVersion, `Upgrade source. 
 	- To use the specific release, write "kyma upgrade --source=1.3.0".
 	- To use the latest master, write "kyma upgrade --source=latest".
@@ -49,12 +50,11 @@ func NewCmd(o *Options) *cobra.Command {
 	- To use the local sources, write "kyma upgrade --source=local".
 	- To use a custom installer image, write "kyma upgrade --source=user/my-kyma-installer:v1.4.0".`)
 	cobraCmd.Flags().StringVarP(&o.LocalSrcPath, "src-path", "", "", "Absolute path to local sources.")
-	cobraCmd.Flags().StringVarP(&o.TLSKey, "tlsKey", "", "", "TLS key for the domain used for the upgrade. The key must be a base64-encoded value.")
 	cobraCmd.Flags().DurationVarP(&o.Timeout, "timeout", "", 1*time.Hour, "Timeout after which CLI stops watching the upgrade progress.")
 	cobraCmd.Flags().StringVarP(&o.Password, "password", "p", "", "Predefined cluster password.")
 	cobraCmd.Flags().StringArrayVarP(&o.OverrideConfigs, "override", "o", nil, "Path to a YAML file with parameters to override.")
 	cobraCmd.Flags().StringVarP(&o.ComponentsConfig, "components", "c", "", "Path to a YAML file with a component list to override.")
-	cobraCmd.Flags().IntVar(&o.FallbackLevel, "fallbackLevel", 5, `If "source=latest-published", defines the number of commits from master branch taken into account if artifacts for newer commits do not exist yet`)
+	cobraCmd.Flags().IntVar(&o.FallbackLevel, "fallback-level", 5, `If "source=latest-published", defines the number of commits from master branch taken into account if artifacts for newer commits do not exist yet`)
 	cobraCmd.Flags().StringVarP(&o.CustomImage, "custom-image", "", "", "Full image name including the registry and the tag. Required for upgrading a remote cluster from local sources.")
 	return cobraCmd
 }

--- a/cmd/kyma/upgrade/cmd_test.go
+++ b/cmd/kyma/upgrade/cmd_test.go
@@ -32,15 +32,15 @@ func TestUpgradeFlags(t *testing.T) {
 	err := c.ParseFlags([]string{
 		"-n", "true",
 		"-d", "fake-domain",
-		"--tlsCert", "fake-cert",
-		"--tlsKey", "fake-key",
+		"--tls-cert", "fake-cert",
+		"--tls-key", "fake-key",
 		"-s", "test-registry/test-image:1",
 		"--src-path", "fake/path/to/source",
 		"--timeout", "100s",
 		"-p", "fake-pwd",
 		"-o", "fake/path/to/overrides",
 		"-c", "fake/path/to/components",
-		"--fallbackLevel", "7",
+		"--fallback-level", "7",
 		"--custom-image", "test-registry/test-image:2",
 	})
 	require.NoError(t, err, "Parsing flags should not return an error")

--- a/docs/03-02-examples.md
+++ b/docs/03-02-examples.md
@@ -24,7 +24,7 @@ kyma provision minikube
 To install Kyma using your own domain, run:
 
 ```bash
-kyma install --domain {DOMAIN} --tlsCert {TLS_CERT} --tlsKey {TLS_KEY}
+kyma install --domain {DOMAIN} --tls-cert {TLS_CERT} --tls-key {TLS_KEY}
 ```
 - `{TLS_CERT}` and `{TLS_KEY}` are the TLS certificate and TLS key for the domain used. Note that both of them must be encoded in base64. You can use [OpenSSL](https://www.openssl.org/) (which is installed by default with macOS) to convert your TLS certificate and TLS key to base64-encoded values.
 - To simplify the process:
@@ -36,7 +36,7 @@ kyma install --domain {DOMAIN} --tlsCert {TLS_CERT} --tlsKey {TLS_KEY}
   - `{TLS_CERT_FILE_PATH}` is the path to the file containing the TLS certificate and `{TLS_KEY_FILE_PATH}` is the path to the file containing the TLS key.
   - Now, you can use these environment variables to install Kyma with your own domain `{DOMAIN}` as shown below:
   - ```bash
-    kyma install --domain {DOMAIN} --tlsCert $TLS_CERT --tlsKey $TLS_KEY
+    kyma install --domain {DOMAIN} --tls-cert $TLS_CERT --tls-key $TLS_KEY
     ```
 
 To install Kyma from the latest `master` branch, run:

--- a/docs/gen-docs/kyma_install.md
+++ b/docs/gen-docs/kyma_install.md
@@ -50,11 +50,11 @@ kyma install [flags]
 ## Options
 
 ```bash
-  -c, --components string      Path to a YAML file with component list to override.
+  -c, --components string      Path to a YAML file with a component list to override.
       --custom-image string    Full image name including the registry and the tag. Required for installation from local sources to a remote cluster.
   -d, --domain string          Domain used for installation. (default "kyma.local")
-      --fallbackLevel int      If "source=latest-published", defines the number of commits from master branch taken into account if artifacts for newer commits do not exist yet (default 5)
-  -n, --noWait                 Flag that determines if the command should wait for Kyma installation to complete.
+      --fallback-level int     If "source=latest-published", defines the number of commits from master branch taken into account if artifacts for newer commits do not exist yet (default 5)
+  -n, --no-wait                Determines if the command should wait for Kyma installation to complete.
   -o, --override stringArray   Path to a YAML file with parameters to override.
   -p, --password string        Predefined cluster password.
   -s, --source string          Installation source. 
@@ -66,9 +66,9 @@ kyma install [flags]
                                	- To use the local sources, write "kyma install --source=local".
                                	- To use a custom installer image, write "kyma install --source=user/my-kyma-installer:v1.4.0".
       --src-path string        Absolute path to local sources.
-      --timeout duration       Time-out after which CLI stops watching the installation progress. (default 1h0m0s)
-      --tlsCert string         TLS certificate for the domain used for installation. The certificate must be a base64-encoded value.
-      --tlsKey string          TLS key for the domain used for installation. The key must be a base64-encoded value.
+      --timeout duration       Timeout after which CLI stops watching the installation progress. (default 1h0m0s)
+      --tls-cert string        TLS certificate for the domain used for installation. The certificate must be a base64-encoded value.
+      --tls-key string         TLS key for the domain used for installation. The key must be a base64-encoded value.
 ```
 
 ## Options inherited from parent commands

--- a/docs/gen-docs/kyma_provision_minikube.md
+++ b/docs/gen-docs/kyma_provision_minikube.md
@@ -15,16 +15,16 @@ kyma provision minikube [flags]
 ## Options
 
 ```bash
-      --cpus string                  Specifies the number of CPUs used for installation. (default "4")
-      --disk-size string             Specifies the disk size used for installation. (default "30g")
-      --docker-ports strings         List of ports that should be exposed if you choose Docker as the driver.
-      --hypervVirtualSwitch string   Specifies the Hyper-V switch version if you choose Hyper-V as the driver.
-  -k, --kube-version string          Kubernetes version of the cluster. (default "1.16.15")
-      --memory string                Specifies RAM reserved for installation. (default "8192")
-      --profile string               Specifies the Minikube profile.
-      --timeout duration             Maximum time during which the provisioning takes place, where "0" means "infinite". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". (default 5m0s)
-      --use-hyperkit-vpnkit-sock     Uses vpnkit sock provided by Docker. This is useful when DNS Port (53) is being used by some other program like dns-proxy (eg. provided by Cisco Umbrella. This flag works only on Mac OS).
-      --vm-driver string             Specifies the VM driver. Possible values: vmwarefusion,kvm,xhyve,hyperv,hyperkit,virtualbox,kvm2,docker,none (default "hyperkit")
+      --cpus string                    Specifies the number of CPUs used for installation. (default "4")
+      --disk-size string               Specifies the disk size used for installation. (default "30g")
+      --docker-ports strings           List of ports that should be exposed if you choose Docker as the driver.
+      --hyperv-virtual-switch string   Specifies the Hyper-V switch version if you choose Hyper-V as the driver.
+  -k, --kube-version string            Kubernetes version of the cluster. (default "1.16.15")
+      --memory string                  Specifies RAM reserved for installation. (default "8192")
+      --profile string                 Specifies the Minikube profile.
+      --timeout duration               Maximum time during which the provisioning takes place, where "0" means "infinite". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". (default 5m0s)
+      --use-hyperkit-vpnkit-sock       Uses vpnkit sock provided by Docker. This is useful when DNS Port (53) is being used by some other program like dns-proxy (eg. provided by Cisco Umbrella. This flag works only on Mac OS).
+      --vm-driver string               Specifies the VM driver. Possible values: vmwarefusion,kvm,xhyve,hyperv,hyperkit,virtualbox,kvm2,docker,none (default "hyperkit")
 ```
 
 ## Options inherited from parent commands

--- a/docs/gen-docs/kyma_upgrade.md
+++ b/docs/gen-docs/kyma_upgrade.md
@@ -18,8 +18,8 @@ kyma upgrade [flags]
   -c, --components string      Path to a YAML file with a component list to override.
       --custom-image string    Full image name including the registry and the tag. Required for upgrading a remote cluster from local sources.
   -d, --domain string          Domain used for the upgrade. (default "kyma.local")
-      --fallbackLevel int      If "source=latest-published", defines the number of commits from master branch taken into account if artifacts for newer commits do not exist yet (default 5)
-  -n, --noWait                 Determines if the command should wait for the Kyma upgrade to complete.
+      --fallback-level int     If "source=latest-published", defines the number of commits from master branch taken into account if artifacts for newer commits do not exist yet (default 5)
+  -n, --no-wait                Determines if the command should wait for the Kyma upgrade to complete.
   -o, --override stringArray   Path to a YAML file with parameters to override.
   -p, --password string        Predefined cluster password.
   -s, --source string          Upgrade source. 
@@ -31,8 +31,8 @@ kyma upgrade [flags]
                                	- To use a custom installer image, write "kyma upgrade --source=user/my-kyma-installer:v1.4.0".
       --src-path string        Absolute path to local sources.
       --timeout duration       Timeout after which CLI stops watching the upgrade progress. (default 1h0m0s)
-      --tlsCert string         TLS certificate for the domain used for the upgrade. The certificate must be a base64-encoded value.
-      --tlsKey string          TLS key for the domain used for the upgrade. The key must be a base64-encoded value.
+      --tls-cert string        TLS certificate for the domain used for the upgrade. The certificate must be a base64-encoded value.
+      --tls-key string         TLS key for the domain used for the upgrade. The key must be a base64-encoded value.
 ```
 
 ## Options inherited from parent commands

--- a/pkg/installation/installation.go
+++ b/pkg/installation/installation.go
@@ -262,10 +262,10 @@ func (i *Installation) validateConfigurations() error {
 		return fmt.Errorf("failed to parse the source flag. It can take one of the following: 'local', 'latest', 'latest-published', release version (e.g. 1.4.1), commit hash (e.g. 34edf09a) or installer image")
 	}
 
-	// If one of the --domain, --tlsKey, or --tlsCert is specified, the others must be specified as well (XOR logic used below)
+	// If one of the --domain, --tls-key, or --tls-cert is specified, the others must be specified as well (XOR logic used below)
 	if ((i.Options.Domain != defaultDomain && i.Options.Domain != "") || i.Options.TLSKey != "" || i.Options.TLSCert != "") &&
 		!((i.Options.Domain != defaultDomain && i.Options.Domain != "") && i.Options.TLSKey != "" && i.Options.TLSCert != "") {
-		return pkgErrors.New("You specified one of the --domain, --tlsKey, or --tlsCert without specifying the others. They must be specified together")
+		return pkgErrors.New("You specified one of the --domain, --tls-key, or --tls-cert without specifying the others. They must be specified together")
 	}
 
 	return nil

--- a/pkg/installation/installation_test.go
+++ b/pkg/installation/installation_test.go
@@ -152,7 +152,7 @@ func TestValidateConfigurations(t *testing.T) {
 	}
 
 	err := i.validateConfigurations()
-	require.EqualError(t, err, "You specified one of the --domain, --tlsKey, or --tlsCert without specifying the others. They must be specified together")
+	require.EqualError(t, err, "You specified one of the --domain, --tls-key, or --tls-cert without specifying the others. They must be specified together")
 
 	// Domain, certificate, and key are passed
 	i = &Installation{


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- avoid using camelCase naming for flags in order to have consistency in the naming style
- `noWait`, `tlsCert` , `tlsKey` , `FallbackLevel` and `hypervVirtualSwitch` flags are changed to `no-wait`, `tls-cert`, `tls-key`, `fallback-level` and `hyperv-virtual-switch` respectively.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#431