### PR TITLE
Add attempts flag for provision commands

### DIFF
--- a/cmd/kyma/provision/aks/cmd.go
+++ b/cmd/kyma/provision/aks/cmd.go
@@ -48,6 +48,7 @@ func NewCmd(o *Options) *cobra.Command {
 	cmd.Flags().IntVar(&o.NodeCount, "nodes", 3, "Number of cluster nodes.")
 	// Temporary disabled flag. To be enabled when hydroform supports TF modules
 	//cmd.Flags().StringSliceVarP(&o.Extra, "extra", "e", nil, "Provide one or more arguments of the form NAME=VALUE to add extra configurations.")
+	cmd.Flags().UintVar(&o.Attempts, "attempts", 3, "Maximum number of attempts to provision the cluster.")
 
 	return cmd
 }
@@ -79,7 +80,7 @@ func (c *command) Run() error {
 			cluster, err = hf.Provision(cluster, provider, types.WithDataDir(home), types.Persistent())
 			return err
 		},
-		retry.Attempts(3), retry.LastErrorOnly(!c.opts.Verbose))
+		retry.Attempts(c.opts.Attempts), retry.LastErrorOnly(!c.opts.Verbose))
 
 	if err != nil {
 		s.Failure()

--- a/cmd/kyma/provision/aks/cmd_test.go
+++ b/cmd/kyma/provision/aks/cmd_test.go
@@ -25,6 +25,7 @@ func TestProvisionAKSFlags(t *testing.T) {
 	require.Equal(t, 3, o.NodeCount, "Default value for the nodes flag not as expected.")
 	// Temporary disable flag. To be enabled when hydroform supports TF modules
 	//require.Empty(t, o.Extra, "Default value for the extra flag not as expected.")
+	require.Equal(t, uint(3), o.Attempts, "Default value for the attempts flag not as expected.")
 
 	// test passing flags
 	err := c.ParseFlags([]string{
@@ -38,6 +39,7 @@ func TestProvisionAKSFlags(t *testing.T) {
 		"--nodes", "7",
 		// Temporary disable flag. To be enabled when hydroform supports TF modules
 		//"--extra", "VAR1=VALUE1,VAR2=VALUE2",
+		"--attempts", "2",
 	})
 	require.NoError(t, err, "Parsing flags should not return an error")
 	require.Equal(t, "my-cluster", o.Name, "The parsed value for the name flag not as expected.")
@@ -50,6 +52,7 @@ func TestProvisionAKSFlags(t *testing.T) {
 	require.Equal(t, 7, o.NodeCount, "The parsed value for the nodes flag not as expected.")
 	// Temporary disable flag. To be enabled when hydroform supports TF modules
 	//require.Equal(t, []string{"VAR1=VALUE1", "VAR2=VALUE2"}, o.Extra, "The parsed value for the extra flag not as expected.")
+	require.Equal(t, uint(2), o.Attempts, "The parsed value for the attempts flag not as expected.")
 }
 
 func TestProvisionAKSSubcommands(t *testing.T) {

--- a/cmd/kyma/provision/aks/opts.go
+++ b/cmd/kyma/provision/aks/opts.go
@@ -14,6 +14,7 @@ type Options struct {
 	DiskSizeGB        int
 	NodeCount         int
 	Extra             []string
+	Attempts          uint
 }
 
 //NewOptions creates options with default values

--- a/cmd/kyma/provision/gardener/aws/cmd.go
+++ b/cmd/kyma/provision/gardener/aws/cmd.go
@@ -53,6 +53,7 @@ Use service account details to create a Secret and store it in Gardener.`,
 	cmd.Flags().IntVar(&o.ScalerMin, "scaler-min", 2, "Minimum autoscale value of the cluster.")
 	cmd.Flags().IntVar(&o.ScalerMax, "scaler-max", 3, "Maximum autoscale value of the cluster.")
 	cmd.Flags().StringSliceVarP(&o.Extra, "extra", "e", nil, "One or more arguments provided as the `NAME=VALUE` key-value pairs to configure additional cluster settings. You can use this flag multiple times or enter the key-value pairs as a comma-separated list.")
+	cmd.Flags().UintVar(&o.Attempts, "attempts", 3, "Maximum number of attempts to provision the cluster.")
 
 	return cmd
 }
@@ -85,7 +86,7 @@ func (c *command) Run() error {
 			cluster, err = hf.Provision(cluster, provider, types.WithDataDir(home), types.Persistent())
 			return err
 		},
-		retry.Attempts(3), retry.LastErrorOnly(!c.opts.Verbose))
+		retry.Attempts(c.opts.Attempts), retry.LastErrorOnly(!c.opts.Verbose))
 
 	if err != nil {
 		s.Failure()

--- a/cmd/kyma/provision/gardener/aws/cmd_test.go
+++ b/cmd/kyma/provision/gardener/aws/cmd_test.go
@@ -28,6 +28,7 @@ func TestProvisionGardenerAWSFlags(t *testing.T) {
 	require.Equal(t, 2, o.ScalerMin, "Default value for the scaler-min flag not as expected.")
 	require.Equal(t, 3, o.ScalerMax, "Default value for the scaler-max flag not as expected.")
 	require.Empty(t, o.Extra, "Default value for the extra flag not as expected.")
+	require.Equal(t, uint(3), o.Attempts, "Default value for the attempts flag not as expected.")
 
 	// test passing flags
 	err := c.ParseFlags([]string{
@@ -44,6 +45,7 @@ func TestProvisionGardenerAWSFlags(t *testing.T) {
 		"--scaler-min", "88",
 		"--scaler-max", "99",
 		"--extra", "VAR1=VALUE1,VAR2=VALUE2",
+		"--attempts", "2",
 	})
 
 	require.NoError(t, err, "Parsing flags should not return an error")
@@ -60,6 +62,7 @@ func TestProvisionGardenerAWSFlags(t *testing.T) {
 	require.Equal(t, 88, o.ScalerMin, "The parsed value for the scaler-min flag not as expected.")
 	require.Equal(t, 99, o.ScalerMax, "The parsed value for the scaler-max flag not as expected.")
 	require.Equal(t, []string{"VAR1=VALUE1", "VAR2=VALUE2"}, o.Extra, "The parsed value for the extra flag not as expected.")
+	require.Equal(t, uint(2), o.Attempts, "The parsed value for the attempts flag not as expected.")
 }
 
 func TestProvisionGardenerAWSSubcommands(t *testing.T) {

--- a/cmd/kyma/provision/gardener/aws/opts.go
+++ b/cmd/kyma/provision/gardener/aws/opts.go
@@ -18,6 +18,7 @@ type Options struct {
 	ScalerMin         int
 	ScalerMax         int
 	Extra             []string
+	Attempts          uint
 }
 
 //NewOptions creates options with default values

--- a/cmd/kyma/provision/gardener/az/cmd.go
+++ b/cmd/kyma/provision/gardener/az/cmd.go
@@ -52,6 +52,7 @@ Create a service account with the ` + "`contributor`" + ` role. Use service acco
 	cmd.Flags().IntVar(&o.ScalerMin, "scaler-min", 2, "Minimum autoscale value of the cluster.")
 	cmd.Flags().IntVar(&o.ScalerMax, "scaler-max", 3, "Maximum autoscale value of the cluster.")
 	cmd.Flags().StringSliceVarP(&o.Extra, "extra", "e", nil, "One or more arguments provided as the `NAME=VALUE` key-value pairs to configure additional cluster settings. You can use this flag multiple times or enter the key-value pairs as a comma-separated list.")
+	cmd.Flags().UintVar(&o.Attempts, "attempts", 3, "Maximum number of attempts to provision the cluster.")
 
 	return cmd
 }
@@ -84,7 +85,7 @@ func (c *command) Run() error {
 			cluster, err = hf.Provision(cluster, provider, types.WithDataDir(home), types.Persistent())
 			return err
 		},
-		retry.Attempts(3), retry.LastErrorOnly(!c.opts.Verbose))
+		retry.Attempts(c.opts.Attempts), retry.LastErrorOnly(!c.opts.Verbose))
 
 	if err != nil {
 		s.Failure()

--- a/cmd/kyma/provision/gardener/az/cmd_test.go
+++ b/cmd/kyma/provision/gardener/az/cmd_test.go
@@ -28,6 +28,7 @@ func TestProvisionGardenerAzureFlags(t *testing.T) {
 	require.Equal(t, 2, o.ScalerMin, "Default value for the scaler-min flag not as expected.")
 	require.Equal(t, 3, o.ScalerMax, "Default value for the scaler-max flag not as expected.")
 	require.Empty(t, o.Extra, "Default value for the extra flag not as expected.")
+	require.Equal(t, uint(3), o.Attempts, "Default value for the attempts flag not as expected.")
 
 	// test passing flags
 	err := c.ParseFlags([]string{
@@ -44,6 +45,7 @@ func TestProvisionGardenerAzureFlags(t *testing.T) {
 		"--scaler-min", "88",
 		"--scaler-max", "99",
 		"--extra", "VAR1=VALUE1,VAR2=VALUE2",
+		"--attempts", "2",
 	})
 
 	require.NoError(t, err, "Parsing flags should not return an error")
@@ -60,6 +62,7 @@ func TestProvisionGardenerAzureFlags(t *testing.T) {
 	require.Equal(t, 88, o.ScalerMin, "The parsed value for the scaler-min flag not as expected.")
 	require.Equal(t, 99, o.ScalerMax, "The parsed value for the scaler-max flag not as expected.")
 	require.Equal(t, []string{"VAR1=VALUE1", "VAR2=VALUE2"}, o.Extra, "The parsed value for the extra flag not as expected.")
+	require.Equal(t, uint(2), o.Attempts, "The parsed value for the attempts flag not as expected.")
 }
 
 func TestProvisionGardenerAzureSubcommands(t *testing.T) {

--- a/cmd/kyma/provision/gardener/az/opts.go
+++ b/cmd/kyma/provision/gardener/az/opts.go
@@ -18,6 +18,7 @@ type Options struct {
 	ScalerMin         int
 	ScalerMax         int
 	Extra             []string
+	Attempts          uint
 }
 
 //NewOptions creates options with default values

--- a/cmd/kyma/provision/gardener/gcp/cmd.go
+++ b/cmd/kyma/provision/gardener/gcp/cmd.go
@@ -53,6 +53,7 @@ Use service account details to create a Secret and store it in Gardener.`,
 	cmd.Flags().IntVar(&o.ScalerMin, "scaler-min", 2, "Minimum autoscale value of the cluster.")
 	cmd.Flags().IntVar(&o.ScalerMax, "scaler-max", 3, "Maximum autoscale value of the cluster.")
 	cmd.Flags().StringSliceVarP(&o.Extra, "extra", "e", nil, "One or more arguments provided as the `NAME=VALUE` key-value pairs to configure additional cluster settings. You can use this flag multiple times or enter the key-value pairs as a comma-separated list.")
+	cmd.Flags().UintVar(&o.Attempts, "attempts", 3, "Maximum number of attempts to provision the cluster.")
 
 	return cmd
 }
@@ -85,7 +86,7 @@ func (c *command) Run() error {
 			cluster, err = hf.Provision(cluster, provider, types.WithDataDir(home), types.Persistent())
 			return err
 		},
-		retry.Attempts(3), retry.LastErrorOnly(!c.opts.Verbose))
+		retry.Attempts(c.opts.Attempts), retry.LastErrorOnly(!c.opts.Verbose))
 
 	if err != nil {
 		s.Failure()

--- a/cmd/kyma/provision/gardener/gcp/cmd_test.go
+++ b/cmd/kyma/provision/gardener/gcp/cmd_test.go
@@ -28,6 +28,7 @@ func TestProvisionGardenerGCPFlags(t *testing.T) {
 	require.Equal(t, 2, o.ScalerMin, "Default value for the scaler-min flag not as expected.")
 	require.Equal(t, 3, o.ScalerMax, "Default value for the scaler-max flag not as expected.")
 	require.Empty(t, o.Extra, "Default value for the extra flag not as expected.")
+	require.Equal(t, uint(3), o.Attempts, "Default value for the attempts flag not as expected.")
 
 	// test passing flags
 	err := c.ParseFlags([]string{
@@ -44,6 +45,7 @@ func TestProvisionGardenerGCPFlags(t *testing.T) {
 		"--scaler-min", "88",
 		"--scaler-max", "99",
 		"--extra", "VAR1=VALUE1,VAR2=VALUE2",
+		"--attempts", "2",
 	})
 
 	require.NoError(t, err, "Parsing flags should not return an error")
@@ -60,6 +62,7 @@ func TestProvisionGardenerGCPFlags(t *testing.T) {
 	require.Equal(t, 88, o.ScalerMin, "The parsed value for the scaler-min flag not as expected.")
 	require.Equal(t, 99, o.ScalerMax, "The parsed value for the scaler-max flag not as expected.")
 	require.Equal(t, []string{"VAR1=VALUE1", "VAR2=VALUE2"}, o.Extra, "The parsed value for the extra flag not as expected.")
+	require.Equal(t, uint(2), o.Attempts, "The parsed value for the attempts flag not as expected.")
 }
 
 func TestProvisionGardenerGCPSubcommands(t *testing.T) {

--- a/cmd/kyma/provision/gardener/gcp/opts.go
+++ b/cmd/kyma/provision/gardener/gcp/opts.go
@@ -18,6 +18,7 @@ type Options struct {
 	ScalerMin         int
 	ScalerMax         int
 	Extra             []string
+	Attempts          uint
 }
 
 //NewOptions creates options with default values

--- a/cmd/kyma/provision/gke/cmd.go
+++ b/cmd/kyma/provision/gke/cmd.go
@@ -48,6 +48,7 @@ NOTE: To access the provisioned cluster, make sure you get authenticated by Goog
 	cmd.Flags().IntVar(&o.NodeCount, "nodes", 3, "Number of cluster nodes.")
 	// Temporary disabled flag. To be enabled when hydroform supports TF modules
 	//cmd.Flags().StringSliceVarP(&o.Extra, "extra", "e", nil, "Provide one or more arguments of the form NAME=VALUE to add extra configurations.")
+	cmd.Flags().UintVar(&o.Attempts, "attempts", 3, "Maximum number of attempts to provision the cluster.")
 
 	return cmd
 }
@@ -82,7 +83,7 @@ func (c *command) Run() error {
 			cluster, err = hf.Provision(cluster, provider, types.WithDataDir(home), types.Persistent())
 			return err
 		},
-		retry.Attempts(3), retry.LastErrorOnly(!c.opts.Verbose))
+		retry.Attempts(c.opts.Attempts), retry.LastErrorOnly(!c.opts.Verbose))
 
 	if err != nil {
 		s.Failure()

--- a/cmd/kyma/provision/gke/cmd_test.go
+++ b/cmd/kyma/provision/gke/cmd_test.go
@@ -25,6 +25,7 @@ func TestProvisionGKEFlags(t *testing.T) {
 	require.Equal(t, 3, o.NodeCount, "Default value for the nodes flag not as expected.")
 	// Temporary disable flag. To be enabled when hydroform supports TF modules
 	//require.Empty(t, o.Extra, "Default value for the extra flag not as expected.")
+	require.Equal(t, uint(3), o.Attempts, "Default value for the attempts flag not as expected.")
 
 	// test passing flags
 	err := c.ParseFlags([]string{
@@ -38,6 +39,7 @@ func TestProvisionGKEFlags(t *testing.T) {
 		"--nodes", "7",
 		// Temporary disable flag. To be enabled when hydroform supports TF modules
 		//"--extra", "VAR1=VALUE1,VAR2=VALUE2",
+		"--attempts", "2",
 	})
 	require.NoError(t, err, "Parsing flags should not return an error")
 	require.Equal(t, "my-cluster", o.Name, "The parsed value for the name flag not as expected.")
@@ -50,6 +52,7 @@ func TestProvisionGKEFlags(t *testing.T) {
 	require.Equal(t, 7, o.NodeCount, "The parsed value for the nodes flag not as expected.")
 	// Temporary disable flag. To be enabled when hydroform supports TF modules
 	//require.Equal(t, []string{"VAR1=VALUE1", "VAR2=VALUE2"}, o.Extra, "The parsed value for the extra flag not as expected.")
+	require.Equal(t, uint(2), o.Attempts, "The parsed value for the attempts flag not as expected.")
 }
 
 func TestProvisionGKESubcommands(t *testing.T) {

--- a/cmd/kyma/provision/gke/opts.go
+++ b/cmd/kyma/provision/gke/opts.go
@@ -14,6 +14,7 @@ type Options struct {
 	DiskSizeGB        int
 	NodeCount         int
 	Extra             []string
+	Attempts          uint
 }
 
 //NewOptions creates options with default values

--- a/docs/gen-docs/kyma_provision_aks.md
+++ b/docs/gen-docs/kyma_provision_aks.md
@@ -16,6 +16,7 @@ kyma provision aks [flags]
 ## Options
 
 ```bash
+      --attempts uint         Maximum number of attempts to provision the cluster. (default 3)
   -c, --credentials string    Path to the TOML file containing the Azure Subscription ID (SUBSCRIPTION_ID), Tenant ID (TENANT_ID), Client ID (CLIENT_ID) and Client Secret (CLIENT_SECRET). (required)
       --disk-size int         Disk size (in GB) of the cluster. (default 50)
   -k, --kube-version string   Kubernetes version of the cluster. (default "1.16.15")

--- a/docs/gen-docs/kyma_provision_gardener_aws.md
+++ b/docs/gen-docs/kyma_provision_gardener_aws.md
@@ -18,6 +18,7 @@ kyma provision gardener aws [flags]
 ## Options
 
 ```bash
+      --attempts uint         Maximum number of attempts to provision the cluster. (default 3)
   -c, --credentials string    Path to the kubeconfig file of the Gardener service account for AWS. (required)
       --disk-size int         Disk size (in GB) of the cluster. (default 50)
       --disk-type string      Type of disk to use on AWS. (default "gp2")

--- a/docs/gen-docs/kyma_provision_gardener_az.md
+++ b/docs/gen-docs/kyma_provision_gardener_az.md
@@ -17,6 +17,7 @@ kyma provision gardener az [flags]
 ## Options
 
 ```bash
+      --attempts uint         Maximum number of attempts to provision the cluster. (default 3)
   -c, --credentials string    Path to the kubeconfig file of the Gardener service account for Azure. (required)
       --disk-size int         Disk size (in GB) of the cluster. (default 50)
       --disk-type string      Type of disk to use on Azure. (default "Standard_LRS")

--- a/docs/gen-docs/kyma_provision_gardener_gcp.md
+++ b/docs/gen-docs/kyma_provision_gardener_gcp.md
@@ -18,6 +18,7 @@ kyma provision gardener gcp [flags]
 ## Options
 
 ```bash
+      --attempts uint         Maximum number of attempts to provision the cluster. (default 3)
   -c, --credentials string    Path to the kubeconfig file of the Gardener service account for GCP. (required)
       --disk-size int         Disk size (in GB) of the cluster. (default 50)
       --disk-type string      Type of disk to use on GCP. (default "pd-standard")

--- a/docs/gen-docs/kyma_provision_gke.md
+++ b/docs/gen-docs/kyma_provision_gke.md
@@ -16,6 +16,7 @@ kyma provision gke [flags]
 ## Options
 
 ```bash
+      --attempts uint         Maximum number of attempts to provision the cluster. (default 3)
   -c, --credentials string    Path to the GCP service account key file. (required)
       --disk-size int         Disk size (in GB) of the cluster. (default 50)
   -k, --kube-version string   Kubernetes version of the cluster. (default "1.16")


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- add `attempts` flag which specifies the max number of retries to provision a cluster.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#442 