### PR TITLE
Rename flag server-arg to server-args

### DIFF
--- a/cmd/kyma/alpha/provision/k3s/cmd.go
+++ b/cmd/kyma/alpha/provision/k3s/cmd.go
@@ -37,7 +37,7 @@ func NewCmd(o *Options) *cobra.Command {
 	//cmd.Flags().StringVar(&o.EnableRegistry, "enable-registry", "", "Enables registry for the created k8s cluster.")
 	cmd.Flags().StringVar(&o.Name, "name", "kyma", "Name of the Kyma cluster.")
 	cmd.Flags().IntVar(&o.Workers, "workers", 1, "Number of worker nodes.")
-	cmd.Flags().StringSliceVarP(&o.ServerArgs, "server-arg", "s", []string{}, "Argument passed to the Kubernetes server (e.g. --server-arg='--alsologtostderr').")
+	cmd.Flags().StringSliceVarP(&o.ServerArgs, "server-args", "s", []string{}, "Arguments passed to the Kubernetes server (e.g. --server-args='--alsologtostderr').")
 	cmd.Flags().DurationVar(&o.Timeout, "timeout", 5*time.Minute, `Maximum time in minutes during which the provisioning takes place, where "0" means "infinite".`)
 	return cmd
 }

--- a/docs/gen-docs/kyma_alpha_provision_k3s.md
+++ b/docs/gen-docs/kyma_alpha_provision_k3s.md
@@ -15,10 +15,10 @@ kyma alpha provision k3s [flags]
 ## Options
 
 ```bash
-      --name string          Name of the Kyma cluster. (default "kyma")
-  -s, --server-arg strings   Argument passed to the Kubernetes server (e.g. --server-arg='--alsologtostderr').
-      --timeout duration     Maximum time in minutes during which the provisioning takes place, where "0" means "infinite". (default 5m0s)
-      --workers int          Number of worker nodes. (default 1)
+      --name string           Name of the Kyma cluster. (default "kyma")
+  -s, --server-args strings   Arguments passed to the Kubernetes server (e.g. --server-args='--alsologtostderr').
+      --timeout duration      Maximum time in minutes during which the provisioning takes place, where "0" means "infinite". (default 5m0s)
+      --workers int           Number of worker nodes. (default 1)
 ```
 
 ## Options inherited from parent commands


### PR DESCRIPTION

**Description**

Adjust name of flag `server-arg` to `server-args` as it can be set multiple times.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
