### PR TITLE
Fixing missing logs in prow jobs

### DIFF
--- a/cmd/kyma/test/logs/cmd.go
+++ b/cmd/kyma/test/logs/cmd.go
@@ -99,6 +99,9 @@ func (cmd *command) Run(args []string) error {
 		for scanner.Scan() {
 			logsStep.LogInfo(scanner.Text())
 		}
+		if err := scanner.Err(); err != nil {
+			return errors.Wrap(err, "while scanning logs")
+		}
 	}
 
 	return nil

--- a/cmd/kyma/test/logs/cmd.go
+++ b/cmd/kyma/test/logs/cmd.go
@@ -92,6 +92,10 @@ func (cmd *command) Run(args []string) error {
 		}
 
 		scanner := bufio.NewScanner(strings.NewReader(content))
+		// creating buffer with the initial default size of 4 KB
+		buf := make([]byte, 0, 4*1024)
+		// setting the max size of buffer to be 1 MB
+		scanner.Buffer(buf, 1024*1024)
 		for scanner.Scan() {
 			logsStep.LogInfo(scanner.Text())
 		}

--- a/cmd/kyma/test/logs/cmd.go
+++ b/cmd/kyma/test/logs/cmd.go
@@ -94,7 +94,7 @@ func (cmd *command) Run(args []string) error {
 		scanner := bufio.NewScanner(strings.NewReader(content))
 		// creating buffer with the initial default size of 4 KB
 		buf := make([]byte, 0, 4*1024)
-		// setting the max size of buffer to be 1 MB
+		// setting the max size of buffer to be 1 MB instead of the default max size of only 64 KB
 		scanner.Buffer(buf, 1024*1024)
 		for scanner.Scan() {
 			logsStep.LogInfo(scanner.Text())


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- increase max size of buffer that may be allocated during scanning logs to be 1 MB instead of being only 64 KB
- check if errors occurred during the scanning process of logs to avoid swallowing of errors and silently failing to continue scanning of logs

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#586 