### PR TITLE
Add info about profiles to the CLI docs

### DIFF
--- a/docs/gen-docs/kyma_alpha_deploy.md
+++ b/docs/gen-docs/kyma_alpha_deploy.md
@@ -19,7 +19,7 @@ kyma alpha deploy [flags]
   -c, --components string         Path to the components file. (default "workspace/installation/resources/components.yaml")
   -d, --domain string             Domain used for installation. (default "local.kyma.dev")
       --helm-timeout duration     Timeout for the underlying Helm client. (default 6m0s)
-  -p, --profile string            Kyma deployment profile. Supported profiles are: "evaluation", "production".
+  -p, --profile string            Kyma deployment profile. If not specified, Kyma is installed with the default chart values. The supported profiles are: "evaluation", "production".
       --quit-timeout duration     Time after which the deployment is aborted. Worker goroutines may still be working in the background. This value must be greater than the value for cancel-timeout. (default 20m0s)
   -s, --source string             Installation source.
                                   	- To use a specific release, write "kyma alpha deploy --source=1.17.1".
@@ -48,4 +48,3 @@ kyma alpha deploy [flags]
 ## See also
 
 * [kyma alpha](#kyma-alpha-kyma-alpha)	 - Executes the commands in the alpha testing stage.
-

--- a/docs/gen-docs/kyma_install.md
+++ b/docs/gen-docs/kyma_install.md
@@ -39,7 +39,7 @@ The standard installation uses the minimal configuration. The system performs th
    5. Sets the admin password.
    6. Patches the Minikube IP.
 
-2. Runs Kyma installation until the **installed** status confirms the successful installation. You can override the standard installation settings using the `--override` flag. You can also install Kyma with one of the predefined [profiles](https://kyma-project.io/docs/master/root/kyma/#installation-overview-profiles) using the `--profile` flag. 
+2. Runs Kyma installation until the **installed** status confirms the successful installation. You can override the standard installation settings using the `--override` flag. You can also install Kyma with one of the predefined [profiles](https://kyma-project.io/docs/master/root/kyma/#installation-overview-profiles) using the `--profile` flag. If the `--profile` flag is not specified, Kyma is installed with the default chart values.
 
 ```bash
 kyma install [flags]
@@ -55,7 +55,7 @@ kyma install [flags]
   -n, --no-wait                Determines if the command should wait for Kyma installation to complete.
   -o, --override stringArray   Path to a YAML file with parameters to override.
   -p, --password string        Predefined cluster password.
-      --profile string         Kyma installation profile (evaluation|production). If not specified, Kyma is installed with the default chart values.
+      --profile string         Kyma installation profile (evaluation|production).
   -s, --source string          Installation source.
                                	- To use a specific release, write "kyma install --source=1.15.1".
                                	- To use the master branch, write "kyma install --source=master".

--- a/docs/gen-docs/kyma_install.md
+++ b/docs/gen-docs/kyma_install.md
@@ -39,7 +39,7 @@ The standard installation uses the minimal configuration. The system performs th
    5. Sets the admin password.
    6. Patches the Minikube IP.
 
-2. Runs Kyma installation until the **installed** status confirms the successful installation. You can override the standard installation settings using the `--override` flag. You can also install Kyma with one of the [predefined profiles](https://kyma-project.io/docs/master/root/kyma/#installation-overview-profiles) using the `--profile` flag. 
+2. Runs Kyma installation until the **installed** status confirms the successful installation. You can override the standard installation settings using the `--override` flag. You can also install Kyma with one of the predefined [profiles](https://kyma-project.io/docs/master/root/kyma/#installation-overview-profiles) using the `--profile` flag. 
 
 ```bash
 kyma install [flags]

--- a/docs/gen-docs/kyma_install.md
+++ b/docs/gen-docs/kyma_install.md
@@ -22,14 +22,14 @@ The standard installation uses the minimal configuration. The system performs th
 1. Deploys and configures the Kyma Installer. At this point, steps differ depending on the installation type.
 
    When you install Kyma locally **from release**, the system:
-   
+
    1. Fetches the latest or specified release along with configuration.
    2. Deploys the Kyma Installer on the cluster.
    3. Applies downloaded or defined configuration.
    4. Applies overrides, if applicable.
    5. Sets the admin password.
    6. Patches the Minikube IP.
-	
+
    When you install Kyma locally **from sources**, the system:
 
    1. Fetches the configuration yaml files from the local sources.
@@ -38,10 +38,8 @@ The standard installation uses the minimal configuration. The system performs th
    4. Applies overrides, if applicable.
    5. Sets the admin password.
    6. Patches the Minikube IP.
-    
-2. Runs Kyma installation until the **installed** status confirms the successful installation. You can override the standard installation settings using the `--override` flag.
 
-
+2. Runs Kyma installation until the **installed** status confirms the successful installation. You can override the standard installation settings using the `--override` flag. You can also install Kyma with one of the [predefined profiles](https://kyma-project.io/docs/master/root/kyma/#installation-overview-profiles) using the `--profile` flag. 
 
 ```bash
 kyma install [flags]
@@ -57,8 +55,8 @@ kyma install [flags]
   -n, --no-wait                Determines if the command should wait for Kyma installation to complete.
   -o, --override stringArray   Path to a YAML file with parameters to override.
   -p, --password string        Predefined cluster password.
-      --profile string         Kyma installation profile (evaluation|production).
-  -s, --source string          Installation source. 
+      --profile string         Kyma installation profile (evaluation|production). If not specified, Kyma is installed with the default chart values.
+  -s, --source string          Installation source.
                                	- To use a specific release, write "kyma install --source=1.15.1".
                                	- To use the master branch, write "kyma install --source=master".
                                	- To use a commit, write "kyma install --source=34edf09a".
@@ -84,4 +82,3 @@ kyma install [flags]
 ## See also
 
 * [kyma](#kyma-kyma)	 - Controls a Kyma cluster.
-

--- a/docs/gen-docs/kyma_upgrade.md
+++ b/docs/gen-docs/kyma_upgrade.md
@@ -6,7 +6,7 @@ Upgrades Kyma
 
 ## Synopsis
 
-Use this command to upgrade the Kyma version on a cluster.
+Use this command to upgrade the Kyma version on a cluster. During upgrade, you can set one of the predefined [profiles](https://kyma-project.io/docs/master/root/kyma/#installation-overview-profiles) for your Kyma deployment. If the `--profile` flag is not specified, Kyma is deployed with the default chart values.
 
 ```bash
 kyma upgrade [flags]
@@ -23,7 +23,7 @@ kyma upgrade [flags]
   -o, --override stringArray   Path to a YAML file with parameters to override.
   -p, --password string        Predefined cluster password.
       --profile string         Kyma installation profile (evaluation|production).
-  -s, --source string          Upgrade source. 
+  -s, --source string          Upgrade source.
                                	- To use a specific release, write "kyma upgrade --source=1.3.0".
                                	- To use the master branch, write "kyma install --source=master".
                                	- To use a commit, write "kyma upgrade --source=34edf09a".
@@ -48,4 +48,3 @@ kyma upgrade [flags]
 ## See also
 
 * [kyma](#kyma-kyma)	 - Controls a Kyma cluster.
-


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Since both evaluation and production profiles have been [described in a generic way](https://kyma-project.io/docs/master/root/kyma/#installation-overview-profiles) in the documentation, it would be nice to mention and link them in the document describing the `kyma install`, `kyma upgrade` and `kyma alpha deploy` commands. Also, as noticed by fellow colleagues, there is no info on what happens when the `--profiles` flag is not specified. 

Changes proposed in this pull request:

- Add a link to the document about profiles
- Add info on what happens when the `--profiles` flag is not specified

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
