### PR TITLE
Rename options to flags in docu

### DIFF
--- a/cmd/gendocs/gendocs.go
+++ b/cmd/gendocs/gendocs.go
@@ -111,7 +111,7 @@ func printOptions(buf *bytes.Buffer, cmd *cobra.Command) error {
 	flags := cmd.NonInheritedFlags()
 	flags.SetOutput(buf)
 	if flags.HasAvailableFlags() {
-		buf.WriteString("## Options\n\n```bash\n")
+		buf.WriteString("## Flags\n\n```bash\n")
 		flags.PrintDefaults()
 		buf.WriteString("```\n\n")
 	}
@@ -119,7 +119,7 @@ func printOptions(buf *bytes.Buffer, cmd *cobra.Command) error {
 	parentFlags := cmd.InheritedFlags()
 	parentFlags.SetOutput(buf)
 	if parentFlags.HasAvailableFlags() {
-		buf.WriteString("## Options inherited from parent commands\n\n```bash\n")
+		buf.WriteString("## Flags inherited from parent commands\n\n```bash\n")
 		parentFlags.PrintDefaults()
 		buf.WriteString("```\n\n")
 	}


### PR DESCRIPTION
**Description**

Align wording between CLI help and published docs.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
