### PR TITLE
Try to use gopath-folder for workspace locally

### DIFF
--- a/cmd/kyma/alpha/deploy/cmd.go
+++ b/cmd/kyma/alpha/deploy/cmd.go
@@ -194,7 +194,7 @@ func (cmd *command) isCompatibleVersion() error {
 }
 
 func (cmd *command) deployKyma(ui asyncui.AsyncUI, overrides *deployment.OverridesBuilder) error {
-	var resourcePath = filepath.Join(cmd.opts.WorkspacePath, "resources")
+	var resourcePath = filepath.Join(cmd.opts.ResolveLocalWorkspacePath(), "resources")
 
 	cmpFile, err := cmd.opts.ResolveComponentsFile()
 	if err != nil {


### PR DESCRIPTION
**Description**

Use gopath-workspace folder when using `--source=local`

**Related issue(s)**

