### PR TITLE
Disable parallel execution for docker tests

### DIFF
--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -64,7 +64,6 @@ func genConfigFile() *dockerConfigFile.ConfigFile {
 }
 
 func Test_Resolve_happy_path(t *testing.T) {
-	t.Parallel()
 	tmpHome, err := ioutil.TempDir("/tmp", "config-test")
 	assert.NilError(t, err)
 	defer os.RemoveAll(tmpHome)
@@ -124,7 +123,6 @@ func Test_BuildKymaInstaller(t *testing.T) {
 }
 
 func Test_PushKymaInstaller(t *testing.T) {
-	t.Parallel()
 	tmpHome, err := ioutil.TempDir("/tmp", "config-pus-kyma-test")
 	assert.NilError(t, err)
 	defer os.RemoveAll(tmpHome)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Remove parallel execution of docker tests.

## Details
The test creates a file containing the `docker` config that generates the expected auth information:
https://github.com/kyma-project/cli/blob/6eb1c438ccfa37a3a522ef364f8778cb73bfc0d9/pkg/docker/docker_test.go#L128-L132

When this test runs in parallel, the file might be deleted by execution N when execution N+M tries to read it, getting then a different docker config and making the mock crash.

## Solution
Only solution in the current implementation is to disable parallel execution fr this test.

**Related issue(s)**
https://github.com/kyma-project/cli/issues/719
