### PR TITLE
add --force flag for docker driver

### DIFF
--- a/cmd/kyma/provision/minikube/cmd.go
+++ b/cmd/kyma/provision/minikube/cmd.go
@@ -251,6 +251,7 @@ func (c *command) startMinikube() error {
 	}
 
 	if c.opts.VMDriver == vmDriverDocker && len(c.opts.DockerPorts) > 0 {
+		startCmd = append(startCmd, "--force")
 		for _, port := range c.opts.DockerPorts {
 			startCmd = append(startCmd, "--ports="+port)
 		}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- add `--force` flag for docker driver. When executing tests on PR on Minikube with docker driver the following error occurs `Exiting due to DRV_AS_ROOT: The "docker" driver should not be used with root privileges.` The practical issue is that when `sudo minikube` is run the config ends up unreadable i.e. you will have files created by root, under `~/.minikube`. So the next command will be unable to read e.g. config unless it is run with root privileges. So you end up having to sudo everything, even dashboard and kubectl.  As there is only the root user on the VM and each command is run with root privileges this is not an issue. The `--force` flag allows Minikube to be provisioned with docker driver by the root user. If the flag is used by no-root user there are no side efects.