### PR TITLE
Improve defaulting of sourcePath in the function config

### DIFF
--- a/cmd/kyma/init/function/opts.go
+++ b/cmd/kyma/init/function/opts.go
@@ -49,7 +49,6 @@ func (o *Options) setDefaults(defaultNamespace string) (err error) {
 		o.RepositoryName = o.Name
 	}
 
-	setIfZero(&o.SourcePath, o.Dir)
 	setIfZero(&o.Namespace, defaultNamespace)
 	return
 }


### PR DESCRIPTION
*Description*

- Remove source.sourcePath from the config template by default
- Default value (if there is no value for source.sourcePath in the config.yaml) is folder where the config.yaml exists
- User can override this value by adding a custom path (to the source.sourcePath)

Fixes #828
