### PR TITLE
Fix `source.sourcePath` defaulting for config.yaml

### DIFF
--- a/cmd/kyma/apply/function/function.go
+++ b/cmd/kyma/apply/function/function.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/kyma-incubator/hydroform/function/pkg/client"
@@ -74,6 +75,10 @@ func (c *command) Run() error {
 	if err := yaml.NewDecoder(file).Decode(&configuration); err != nil {
 		step.Failure()
 		return errors.Wrap(err, "Could not decode the configuration file")
+	}
+
+	if configuration.Source.SourcePath == "" {
+		configuration.Source.SourcePath = filepath.Dir(c.opts.Filename)
 	}
 
 	if c.K8s, err = kube.NewFromConfig("", c.KubeconfigPath); err != nil {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Now there is an issue when the value of the `source.sourcePath` field is empty and someone is trying to apply function using `kyma apply function` with `-f` flag. 

For example, if the `config.yaml` looks like this:
```
name: function-lucid-mateusz5
namespace: default
runtime: python38
source:
    sourceType: inline
```

and someone is trying to run:
```
kyma apply function -f /tmp/tmptmp/config.yaml`
```

given error:
```
X Loading configuration...
Error: open handler.py: no such file or directory
```

It's because the path of deps and handler files is made by merging `source.sourcePath` and handler/deps file name.

Changes proposed in this pull request:

- Set the default value (based on the `config.yaml` dir) of the `source. sourcePath` field if this field is empty