### PR TITLE
Change default workspace for deployment

### DIFF
--- a/cmd/kyma/alpha/deploy/cmd.go
+++ b/cmd/kyma/alpha/deploy/cmd.go
@@ -59,11 +59,11 @@ func NewCmd(o *Options) *cobra.Command {
 
 	// default value for workspace flag is set in validateFlags()
 	// to avoid having the actual home directory shown in the auto-generated docs
-	cobraCmd.Flags().StringVarP(&o.WorkspacePath, "workspace", "w", "", `Path to download Kyma sources (default: "$HOME/.kyma/sources")`)
+	cobraCmd.Flags().StringVarP(&o.WorkspacePath, "workspace", "w", "", `Path to download Kyma sources (default "$HOME/.kyma/sources")`)
 	cobraCmd.Flags().BoolVarP(&o.Atomic, "atomic", "a", false, "Set --atomic=true to use atomic deployment, which rolls back any component that could not be installed successfully.")
 	// default value for components-file flag is set in validateFlags()
 	// to avoid having the actual home directory shown in the auto-generated docs
-	cobraCmd.Flags().StringVarP(&o.ComponentsFile, "components-file", "c", "", `Path to the components file (default: "$HOME/.kyma/sources/installation/resources/components.yaml")`)
+	cobraCmd.Flags().StringVarP(&o.ComponentsFile, "components-file", "c", "", `Path to the components file (default "$HOME/.kyma/sources/installation/resources/components.yaml")`)
 	cobraCmd.Flags().StringSliceVarP(&o.Components, "component", "", []string{}, "Provide one or more components to deploy (e.g. --component componentName@namespace)")
 	cobraCmd.Flags().StringSliceVarP(&o.OverridesFiles, "values-file", "f", []string{}, "Path(s) to one or more JSON or YAML files with configuration values")
 	cobraCmd.Flags().StringSliceVarP(&o.Overrides, "value", "", []string{}, "Set one or more configuration values (e.g. --value component.key='the value')")

--- a/cmd/kyma/alpha/deploy/cmd.go
+++ b/cmd/kyma/alpha/deploy/cmd.go
@@ -57,9 +57,13 @@ func NewCmd(o *Options) *cobra.Command {
 		Aliases: []string{"d"},
 	}
 
-	cobraCmd.Flags().StringVarP(&o.WorkspacePath, "workspace", "w", defaultWorkspacePath, `Path to download Kyma sources (default: "$HOME/.kyma/sources")`)
+	// default value for workspace flag is set in validateFlags()
+	// to avoid having the actual home directory shown in the auto-generated docs
+	cobraCmd.Flags().StringVarP(&o.WorkspacePath, "workspace", "w", "", `Path to download Kyma sources (default: "$HOME/.kyma/sources")`)
 	cobraCmd.Flags().BoolVarP(&o.Atomic, "atomic", "a", false, "Set --atomic=true to use atomic deployment, which rolls back any component that could not be installed successfully.")
-	cobraCmd.Flags().StringVarP(&o.ComponentsFile, "components-file", "c", defaultComponentsFile, `Path to the components file (default: "$HOME/.kyma/sources/installation/resources/components.yaml")`)
+	// default value for components-file flag is set in validateFlags()
+	// to avoid having the actual home directory shown in the auto-generated docs
+	cobraCmd.Flags().StringVarP(&o.ComponentsFile, "components-file", "c", "", `Path to the components file (default: "$HOME/.kyma/sources/installation/resources/components.yaml")`)
 	cobraCmd.Flags().StringSliceVarP(&o.Components, "component", "", []string{}, "Provide one or more components to deploy (e.g. --component componentName@namespace)")
 	cobraCmd.Flags().StringSliceVarP(&o.OverridesFiles, "values-file", "f", []string{}, "Path(s) to one or more JSON or YAML files with configuration values")
 	cobraCmd.Flags().StringSliceVarP(&o.Overrides, "value", "", []string{}, "Set one or more configuration values (e.g. --value component.key='the value')")

--- a/cmd/kyma/alpha/deploy/cmd.go
+++ b/cmd/kyma/alpha/deploy/cmd.go
@@ -57,9 +57,9 @@ func NewCmd(o *Options) *cobra.Command {
 		Aliases: []string{"d"},
 	}
 
-	cobraCmd.Flags().StringVarP(&o.WorkspacePath, "workspace", "w", defaultWorkspacePath, `Path to download Kyma sources (default: "workspace")`)
+	cobraCmd.Flags().StringVarP(&o.WorkspacePath, "workspace", "w", defaultWorkspacePath, `Path to download Kyma sources (default: "$HOME/.kyma/sources")`)
 	cobraCmd.Flags().BoolVarP(&o.Atomic, "atomic", "a", false, "Set --atomic=true to use atomic deployment, which rolls back any component that could not be installed successfully.")
-	cobraCmd.Flags().StringVarP(&o.ComponentsFile, "components-file", "c", defaultComponentsFile, `Path to the components file (default: "workspace/installation/resources/components.yaml")`)
+	cobraCmd.Flags().StringVarP(&o.ComponentsFile, "components-file", "c", defaultComponentsFile, `Path to the components file (default: "$HOME/.kyma/sources/installation/resources/components.yaml")`)
 	cobraCmd.Flags().StringSliceVarP(&o.Components, "component", "", []string{}, "Provide one or more components to deploy (e.g. --component componentName@namespace)")
 	cobraCmd.Flags().StringSliceVarP(&o.OverridesFiles, "values-file", "f", []string{}, "Path(s) to one or more JSON or YAML files with configuration values")
 	cobraCmd.Flags().StringSliceVarP(&o.Overrides, "value", "", []string{}, "Set one or more configuration values (e.g. --value component.key='the value')")

--- a/cmd/kyma/alpha/deploy/cmd.go
+++ b/cmd/kyma/alpha/deploy/cmd.go
@@ -59,11 +59,11 @@ func NewCmd(o *Options) *cobra.Command {
 
 	// default value for workspace flag is set in validateFlags()
 	// to avoid having the actual home directory shown in the auto-generated docs
-	cobraCmd.Flags().StringVarP(&o.WorkspacePath, "workspace", "w", "", `Path to download Kyma sources (default "$HOME/.kyma/sources")`)
+	cobraCmd.Flags().StringVarP(&o.WorkspacePath, "workspace", "w", "", `Path to download Kyma sources (default "$HOME/.kyma/sources" or ".kyma-sources")`)
 	cobraCmd.Flags().BoolVarP(&o.Atomic, "atomic", "a", false, "Set --atomic=true to use atomic deployment, which rolls back any component that could not be installed successfully.")
 	// default value for components-file flag is set in validateFlags()
 	// to avoid having the actual home directory shown in the auto-generated docs
-	cobraCmd.Flags().StringVarP(&o.ComponentsFile, "components-file", "c", "", `Path to the components file (default "$HOME/.kyma/sources/installation/resources/components.yaml")`)
+	cobraCmd.Flags().StringVarP(&o.ComponentsFile, "components-file", "c", "", `Path to the components file (default "$HOME/.kyma/sources/installation/resources/components.yaml" or ".kyma-sources/installation/resources/components.yaml")`)
 	cobraCmd.Flags().StringSliceVarP(&o.Components, "component", "", []string{}, "Provide one or more components to deploy (e.g. --component componentName@namespace)")
 	cobraCmd.Flags().StringSliceVarP(&o.OverridesFiles, "values-file", "f", []string{}, "Path(s) to one or more JSON or YAML files with configuration values")
 	cobraCmd.Flags().StringSliceVarP(&o.Overrides, "value", "", []string{}, "Set one or more configuration values (e.g. --value component.key='the value')")

--- a/cmd/kyma/alpha/deploy/opts.go
+++ b/cmd/kyma/alpha/deploy/opts.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kyma-incubator/hydroform/parallel-install/pkg/download"
 	"github.com/kyma-project/cli/internal/cli"
+	"github.com/kyma-project/cli/internal/files"
 )
 
 const (
@@ -21,7 +22,7 @@ var (
 	localSource           = "local"
 	defaultSource         = "main"
 	kymaProfiles          = []string{"evaluation", "production"}
-	defaultWorkspacePath  = filepath.Join(".", "workspace")
+	defaultWorkspacePath  = getDefaultWorkspacePath()
 	defaultComponentsFile = filepath.Join(defaultWorkspacePath, "installation", "resources", "components.yaml")
 )
 
@@ -164,4 +165,12 @@ func (o *Options) pathExists(path string, description string) error {
 
 func (o *Options) workspaceTmpDir() string {
 	return filepath.Join(o.WorkspacePath, "tmp")
+}
+
+func getDefaultWorkspacePath() string {
+	kymaHome, err := files.KymaHome()
+	if err != nil {
+		return filepath.Join(".kyma-sources")
+	}
+	return filepath.Join(kymaHome, "sources")
 }

--- a/cmd/kyma/alpha/deploy/opts.go
+++ b/cmd/kyma/alpha/deploy/opts.go
@@ -133,6 +133,12 @@ func (o *Options) validateFlags() error {
 	if _, err := o.tlsCertAndKeyProvided(); err != nil {
 		return err
 	}
+	if o.WorkspacePath == "" {
+		o.WorkspacePath = defaultWorkspacePath
+	}
+	if o.ComponentsFile == "" {
+		o.ComponentsFile = defaultComponentsFile
+	}
 	if o.ComponentsFile != defaultComponentsFile && len(o.Components) > 0 {
 		return fmt.Errorf(`Provide either "components-file" or "component" flag`)
 	}

--- a/cmd/kyma/alpha/deploy/opts.go
+++ b/cmd/kyma/alpha/deploy/opts.go
@@ -176,7 +176,7 @@ func (o *Options) workspaceTmpDir() string {
 func getDefaultWorkspacePath() string {
 	kymaHome, err := files.KymaHome()
 	if err != nil {
-		return filepath.Join(".kyma-sources")
+		return ".kyma-sources"
 	}
 	return filepath.Join(kymaHome, "sources")
 }

--- a/docs/gen-docs/kyma_alpha_deploy.md
+++ b/docs/gen-docs/kyma_alpha_deploy.md
@@ -17,7 +17,7 @@ kyma alpha deploy [flags]
 ```bash
   -a, --atomic                       Set --atomic=true to use atomic deployment, which rolls back any component that could not be installed successfully.
       --component strings            Provide one or more components to deploy (e.g. --component componentName@namespace)
-  -c, --components-file string       Path to the components file (default: "$HOME/.kyma/sources/installation/resources/components.yaml")
+  -c, --components-file string       Path to the components file (default "$HOME/.kyma/sources/installation/resources/components.yaml")
       --concurrency int              Number of parallel processes (default: 4) (default 4)
   -d, --domain string                Custom domain used for installation
   -p, --profile string               Kyma deployment profile. If not specified, Kyma uses its default configuration. The supported profiles are: "evaluation", "production".
@@ -33,7 +33,7 @@ kyma alpha deploy [flags]
       --tls-key string               TLS key file for the domain used for installation
       --value strings                Set one or more configuration values (e.g. --value component.key='the value')
   -f, --values-file strings          Path(s) to one or more JSON or YAML files with configuration values
-  -w, --workspace string             Path to download Kyma sources (default: "$HOME/.kyma/sources")
+  -w, --workspace string             Path to download Kyma sources (default "$HOME/.kyma/sources")
 ```
 
 ## Flags inherited from parent commands

--- a/docs/gen-docs/kyma_alpha_deploy.md
+++ b/docs/gen-docs/kyma_alpha_deploy.md
@@ -17,7 +17,7 @@ kyma alpha deploy [flags]
 ```bash
   -a, --atomic                       Set --atomic=true to use atomic deployment, which rolls back any component that could not be installed successfully.
       --component strings            Provide one or more components to deploy (e.g. --component componentName@namespace)
-  -c, --components-file string       Path to the components file (default: "workspace/installation/resources/components.yaml") (default "workspace/installation/resources/components.yaml")
+  -c, --components-file string       Path to the components file (default: "$HOME/.kyma/sources/installation/resources/components.yaml") (default "/Users/I531200/.kyma/sources/installation/resources/components.yaml")
       --concurrency int              Number of parallel processes (default: 4) (default 4)
   -d, --domain string                Custom domain used for installation
   -p, --profile string               Kyma deployment profile. If not specified, Kyma uses its default configuration. The supported profiles are: "evaluation", "production".
@@ -33,7 +33,7 @@ kyma alpha deploy [flags]
       --tls-key string               TLS key file for the domain used for installation
       --value strings                Set one or more configuration values (e.g. --value component.key='the value')
   -f, --values-file strings          Path(s) to one or more JSON or YAML files with configuration values
-  -w, --workspace string             Path to download Kyma sources (default: "workspace") (default "workspace")
+  -w, --workspace string             Path to download Kyma sources (default: "$HOME/.kyma/sources") (default "/Users/I531200/.kyma/sources")
 ```
 
 ## Flags inherited from parent commands

--- a/docs/gen-docs/kyma_alpha_deploy.md
+++ b/docs/gen-docs/kyma_alpha_deploy.md
@@ -17,7 +17,7 @@ kyma alpha deploy [flags]
 ```bash
   -a, --atomic                       Set --atomic=true to use atomic deployment, which rolls back any component that could not be installed successfully.
       --component strings            Provide one or more components to deploy (e.g. --component componentName@namespace)
-  -c, --components-file string       Path to the components file (default "$HOME/.kyma/sources/installation/resources/components.yaml")
+  -c, --components-file string       Path to the components file (default "$HOME/.kyma/sources/installation/resources/components.yaml" or ".kyma-sources/installation/resources/components.yaml")
       --concurrency int              Number of parallel processes (default: 4) (default 4)
   -d, --domain string                Custom domain used for installation
   -p, --profile string               Kyma deployment profile. If not specified, Kyma uses its default configuration. The supported profiles are: "evaluation", "production".
@@ -33,7 +33,7 @@ kyma alpha deploy [flags]
       --tls-key string               TLS key file for the domain used for installation
       --value strings                Set one or more configuration values (e.g. --value component.key='the value')
   -f, --values-file strings          Path(s) to one or more JSON or YAML files with configuration values
-  -w, --workspace string             Path to download Kyma sources (default "$HOME/.kyma/sources")
+  -w, --workspace string             Path to download Kyma sources (default "$HOME/.kyma/sources" or ".kyma-sources")
 ```
 
 ## Flags inherited from parent commands

--- a/docs/gen-docs/kyma_alpha_deploy.md
+++ b/docs/gen-docs/kyma_alpha_deploy.md
@@ -17,7 +17,7 @@ kyma alpha deploy [flags]
 ```bash
   -a, --atomic                       Set --atomic=true to use atomic deployment, which rolls back any component that could not be installed successfully.
       --component strings            Provide one or more components to deploy (e.g. --component componentName@namespace)
-  -c, --components-file string       Path to the components file (default: "$HOME/.kyma/sources/installation/resources/components.yaml") (default "/Users/I531200/.kyma/sources/installation/resources/components.yaml")
+  -c, --components-file string       Path to the components file (default: "$HOME/.kyma/sources/installation/resources/components.yaml")
       --concurrency int              Number of parallel processes (default: 4) (default 4)
   -d, --domain string                Custom domain used for installation
   -p, --profile string               Kyma deployment profile. If not specified, Kyma uses its default configuration. The supported profiles are: "evaluation", "production".
@@ -33,7 +33,7 @@ kyma alpha deploy [flags]
       --tls-key string               TLS key file for the domain used for installation
       --value strings                Set one or more configuration values (e.g. --value component.key='the value')
   -f, --values-file strings          Path(s) to one or more JSON or YAML files with configuration values
-  -w, --workspace string             Path to download Kyma sources (default: "$HOME/.kyma/sources") (default "/Users/I531200/.kyma/sources")
+  -w, --workspace string             Path to download Kyma sources (default: "$HOME/.kyma/sources")
 ```
 
 ## Flags inherited from parent commands


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Change default workspace for deployment from `workspace` to `$HOME/.kyma/sources`. `$HOME/.kyma` directory is already used for provisioning terraform clusters. So. it is a good idea to reuse it here and also the directory `workspace` was sometimes colliding with existing directories from the users.
- In case there was an error while trying to get the home directory of the user, then the direcory `.kyma-sources` is used as a fallback.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#854