### PR TITLE
Change master to main (leftovers)

### DIFF
--- a/docs/03-04-function-configuration-file.md
+++ b/docs/03-04-function-configuration-file.md
@@ -111,7 +111,7 @@ source:
     sourceType: git
     url: https://github.com/username/public-gitops.git
     repository: my-repo
-    reference: master
+    reference: main
     baseDir: /
     credentialsSecretName: secret2
 ```


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Changed `master` to `main` in docs (leftovers)

**Related issue(s)**
See issue https://github.com/kyma-project/community/issues/515