### PR TITLE
Support comma separated list for override values

### DIFF
--- a/cmd/kyma/alpha/deploy/cmd_test.go
+++ b/cmd/kyma/alpha/deploy/cmd_test.go
@@ -40,6 +40,26 @@ func TestOverrides(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("Comma separated overrides", func(t *testing.T) {
+		command := command{
+			opts: &Options{
+				Overrides: []string{"test.happypath=successful,test.secondpath=also_successful"},
+			},
+		}
+		err := assertValidOverride(t, command, `{"happypath":"successful", "secondpath":"also_successful"}`)
+		require.NoError(t, err)
+	})
+
+	t.Run("Comma separated overrides with space", func(t *testing.T) {
+		command := command{
+			opts: &Options{
+				Overrides: []string{"test.happypath=successful, test.secondpath=also_successful"},
+			},
+		}
+		err := assertValidOverride(t, command, `{"happypath":"successful", "secondpath":"also_successful"}`)
+		require.NoError(t, err)
+	})
+
 	t.Run("No value - invalid", func(t *testing.T) {
 		command := command{
 			opts: &Options{

--- a/docs/gen-docs/kyma_alpha_deploy.md
+++ b/docs/gen-docs/kyma_alpha_deploy.md
@@ -7,7 +7,7 @@ Deploys Kyma on a running Kubernetes cluster.
 ## Synopsis
 
 Use this command to deploy, upgrade, or adapt Kyma on a running Kubernetes cluster.
-		
+
 Usage Examples:
   Deploy Kyma using your own domain name
     You must provide the certificate and key as files.
@@ -80,7 +80,7 @@ kyma alpha deploy [flags]
       --timeout-component duration   Maximum time to deploy the component (default 6m0s)
       --tls-crt string               TLS certificate file for the domain used for installation
       --tls-key string               TLS key file for the domain used for installation
-      --value strings                Set one or more configuration values (e.g. --value component.key='the value')
+      --value strings                Set configuration values. Can specify one or more values, also as a comma-separated list (e.g. --value component.a='1' --value component.b='2' or --value component.a='1',component.b='2').
   -f, --values-file strings          Path(s) to one or more JSON or YAML files with configuration values
   -w, --workspace string             Path to download Kyma sources (default "$HOME/.kyma/sources" or ".kyma-sources")
 ```


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Support comma separated list for override values

Changes proposed in this pull request:

Helm supports setting multiple values in a comma separated list using the `--set` flag. This change adds the same functionality for `kyma alpha deploy`'s `--value` flag and adds a unit test.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves #725
