### PR TITLE
Add hint about hosts file if local.kyma.dev not resolvable

### DIFF
--- a/internal/hosts/domains.go
+++ b/internal/hosts/domains.go
@@ -12,23 +12,29 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func GetVirtualServiceHostnames(kymaKube kube.KymaKube) ([]string, error) {
+	vsList, err := kymaKube.Istio().NetworkingV1alpha3().VirtualServices("").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	hostnames := []string{}
+	for _, v := range vsList.Items {
+		hostnames = append(hostnames, v.Spec.Hosts...)
+	}
+
+	return hostnames, nil
+}
+
 func AddDevDomainsToEtcHosts(
 	s step.Step, clusterInfo installation.ClusterInfo, kymaKube kube.KymaKube, verbose bool, timeout time.Duration, domain string) error {
-	hostnames := ""
-
-	vsList, err := kymaKube.Istio().NetworkingV1alpha3().VirtualServices("").List(context.Background(), metav1.ListOptions{})
+	vsHostnames, err := GetVirtualServiceHostnames(kymaKube)
 	if err != nil {
 		return err
 	}
+	hostnames := strings.Join(vsHostnames, " ")
 
-	for _, v := range vsList.Items {
-		for _, host := range v.Spec.Hosts {
-			hostnames = hostnames + " " + host
-		}
-	}
-
-	hostAlias := "127.0.0.1" + hostnames
-
+	hostAlias := "127.0.0.1 " + hostnames
 	if clusterInfo.LocalVMDriver != "none" {
 		_, err := minikube.RunCmd(verbose, clusterInfo.Profile, timeout, "ssh", "sudo /bin/sh -c 'echo \""+hostAlias+"\" >> /etc/hosts'")
 		if err != nil {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

The k3s deployment shoud use *.local.kyma.dev for services that is
directed to 127.0.0.1. Resolving this domain does not work if DNS rebind
protection is active. The change detection this situation after
deploying Kyma and gives a hint to configure an /etc/hosts entry
alternatively.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves https://github.com/kyma-project/kyma/issues/10881