### PR TITLE
updating kubernetes versions for provisioning commands

### DIFF
--- a/cmd/kyma/provision/gardener/aws/cmd.go
+++ b/cmd/kyma/provision/gardener/aws/cmd.go
@@ -22,7 +22,7 @@ Use service account details to create a Secret and store it in Gardener.`,
 	cmd.Flags().StringVarP(&o.Project, "project", "p", "", "Name of the Gardener project where you provision the cluster. (required)")
 	cmd.Flags().StringVarP(&o.CredentialsFile, "credentials", "c", "", "Path to the kubeconfig file of the Gardener service account for AWS. (required)")
 	cmd.Flags().StringVarP(&o.Secret, "secret", "s", "", "Name of the Gardener secret used to access AWS. (required)")
-	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.19", "Kubernetes version of the cluster.")
+	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.20", "Kubernetes version of the cluster.")
 	cmd.Flags().StringVarP(&o.Region, "region", "r", "eu-west-3", "Region of the cluster.")
 	cmd.Flags().StringSliceVarP(&o.Zones, "zones", "z", []string{"eu-west-3a"}, "Zones specify availability zones that are used to evenly distribute the worker pool. eg. --zones=\"europe-west3-a,europe-west3-b\"")
 	cmd.Flags().StringVarP(&o.MachineType, "type", "t", "m5.xlarge", "Machine type used for the cluster.")

--- a/cmd/kyma/provision/gardener/aws/cmd_test.go
+++ b/cmd/kyma/provision/gardener/aws/cmd_test.go
@@ -19,7 +19,7 @@ func TestProvisionGardenerAWSFlags(t *testing.T) {
 	require.Equal(t, "", o.Project, "Default value for the project flag not as expected.")
 	require.Equal(t, "", o.CredentialsFile, "Default value for the credentials flag not as expected.")
 	require.Equal(t, "", o.Secret, "The parsed value for the secret flag not as expected.")
-	require.Equal(t, "1.19", o.KubernetesVersion, "Default value for the kube-version flag not as expected.")
+	require.Equal(t, "1.20", o.KubernetesVersion, "Default value for the kube-version flag not as expected.")
 	require.Equal(t, "eu-west-3", o.Region, "Default value for the region flag not as expected.")
 	require.Equal(t, []string{"eu-west-3a"}, o.Zones, "Default value for the zone flag not as expected.")
 	require.Equal(t, "m5.xlarge", o.MachineType, "Default value for the type flag not as expected.")

--- a/cmd/kyma/provision/gardener/az/cmd.go
+++ b/cmd/kyma/provision/gardener/az/cmd.go
@@ -22,7 +22,7 @@ Create a service account with the ` + "`contributor`" + ` role. Use service acco
 	cmd.Flags().StringVarP(&o.Project, "project", "p", "", "Name of the Gardener project where you provision the cluster. (required)")
 	cmd.Flags().StringVarP(&o.CredentialsFile, "credentials", "c", "", "Path to the kubeconfig file of the Gardener service account for Azure. (required)")
 	cmd.Flags().StringVarP(&o.Secret, "secret", "s", "", "Name of the Gardener secret used to access Azure. (required)")
-	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.19", "Kubernetes version of the cluster.")
+	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.20", "Kubernetes version of the cluster.")
 	cmd.Flags().StringVarP(&o.Region, "region", "r", "westeurope", "Region of the cluster.")
 	cmd.Flags().StringSliceVarP(&o.Zones, "zones", "z", []string{"1"}, "Zones specify availability zones that are used to evenly distribute the worker pool. eg. --zones=\"europe-west3-a,europe-west3-b\"")
 	cmd.Flags().StringVarP(&o.MachineType, "type", "t", "Standard_D4_v3", "Machine type used for the cluster.")

--- a/cmd/kyma/provision/gardener/az/cmd_test.go
+++ b/cmd/kyma/provision/gardener/az/cmd_test.go
@@ -19,7 +19,7 @@ func TestProvisionGardenerAzureFlags(t *testing.T) {
 	require.Equal(t, "", o.Project, "Default value for the project flag not as expected.")
 	require.Equal(t, "", o.CredentialsFile, "Default value for the credentials flag not as expected.")
 	require.Equal(t, "", o.Secret, "The parsed value for the secret flag not as expected.")
-	require.Equal(t, "1.19", o.KubernetesVersion, "Default value for the kube-version flag not as expected.")
+	require.Equal(t, "1.20", o.KubernetesVersion, "Default value for the kube-version flag not as expected.")
 	require.Equal(t, "westeurope", o.Region, "Default value for the region flag not as expected.")
 	require.Equal(t, []string{"1"}, o.Zones, "Default value for the zone flag not as expected.")
 	require.Equal(t, "Standard_D4_v3", o.MachineType, "Default value for the type flag not as expected.")

--- a/cmd/kyma/provision/gardener/gcp/cmd.go
+++ b/cmd/kyma/provision/gardener/gcp/cmd.go
@@ -23,7 +23,7 @@ Use service account details to create a Secret and store it in Gardener.`,
 	cmd.Flags().StringVarP(&o.Project, "project", "p", "", "Name of the Gardener project where you provision the cluster. (required)")
 	cmd.Flags().StringVarP(&o.CredentialsFile, "credentials", "c", "", "Path to the kubeconfig file of the Gardener service account for GCP. (required)")
 	cmd.Flags().StringVarP(&o.Secret, "secret", "s", "", "Name of the Gardener secret used to access GCP. (required)")
-	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.19", "Kubernetes version of the cluster.")
+	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.20", "Kubernetes version of the cluster.")
 	cmd.Flags().StringVarP(&o.Region, "region", "r", "europe-west3", "Region of the cluster.")
 	cmd.Flags().StringSliceVarP(&o.Zones, "zones", "z", []string{"europe-west3-a"}, "Zones specify availability zones that are used to evenly distribute the worker pool. eg. --zones=\"europe-west3-a,europe-west3-b\"")
 	cmd.Flags().StringVarP(&o.MachineType, "type", "t", "n1-standard-4", "Machine type used for the cluster.")

--- a/cmd/kyma/provision/gardener/gcp/cmd_test.go
+++ b/cmd/kyma/provision/gardener/gcp/cmd_test.go
@@ -19,7 +19,7 @@ func TestProvisionGardenerGCPFlags(t *testing.T) {
 	require.Equal(t, "", o.Project, "Default value for the project flag not as expected.")
 	require.Equal(t, "", o.CredentialsFile, "Default value for the credentials flag not as expected.")
 	require.Equal(t, "", o.Secret, "The parsed value for the secret flag not as expected.")
-	require.Equal(t, "1.19", o.KubernetesVersion, "Default value for the kube-version flag not as expected.")
+	require.Equal(t, "1.20", o.KubernetesVersion, "Default value for the kube-version flag not as expected.")
 	require.Equal(t, "europe-west3", o.Region, "Default value for the region flag not as expected.")
 	require.Equal(t, []string{"europe-west3-a"}, o.Zones, "Default value for the zone flag not as expected.")
 	require.Equal(t, "n1-standard-4", o.MachineType, "Default value for the type flag not as expected.")

--- a/cmd/kyma/provision/gke/cmd.go
+++ b/cmd/kyma/provision/gke/cmd.go
@@ -20,7 +20,7 @@ NOTE: To access the provisioned cluster, make sure you get authenticated by Goog
 	cmd.Flags().StringVarP(&o.Name, "name", "n", "", "Name of the GKE cluster to provision. (required)")
 	cmd.Flags().StringVarP(&o.Project, "project", "p", "", "Name of the GCP Project where you provision the GKE cluster. (required)")
 	cmd.Flags().StringVarP(&o.CredentialsFile, "credentials", "c", "", "Path to the GCP service account key file. (required)")
-	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.18", "Kubernetes version of the cluster.")
+	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.19", "Kubernetes version of the cluster.")
 	cmd.Flags().StringVarP(&o.Location, "location", "l", "europe-west3-a", "Location of the cluster.")
 	cmd.Flags().StringVarP(&o.MachineType, "type", "t", "n1-standard-4", "Machine type used for the cluster.")
 	cmd.Flags().IntVar(&o.DiskSizeGB, "disk-size", 50, "Disk size (in GB) of the cluster.")

--- a/cmd/kyma/provision/gke/cmd_test.go
+++ b/cmd/kyma/provision/gke/cmd_test.go
@@ -18,7 +18,7 @@ func TestProvisionGKEFlags(t *testing.T) {
 	require.Equal(t, "", o.Name, "Default value for the name flag not as expected.")
 	require.Equal(t, "", o.Project, "Default value for the project flag not as expected.")
 	require.Equal(t, "", o.CredentialsFile, "Default value for the credentials flag not as expected.")
-	require.Equal(t, "1.18", o.KubernetesVersion, "Default value for the kube-version flag not as expected.")
+	require.Equal(t, "1.19", o.KubernetesVersion, "Default value for the kube-version flag not as expected.")
 	require.Equal(t, "europe-west3-a", o.Location, "Default value for the location flag not as expected.")
 	require.Equal(t, "n1-standard-4", o.MachineType, "Default value for the type flag not as expected.")
 	require.Equal(t, 50, o.DiskSizeGB, "Default value for the disk-size flag not as expected.")

--- a/docs/gen-docs/kyma_provision_gardener_aws.md
+++ b/docs/gen-docs/kyma_provision_gardener_aws.md
@@ -23,7 +23,7 @@ kyma provision gardener aws [flags]
       --disk-size int         Disk size (in GB) of the cluster. (default 50)
       --disk-type string      Type of disk to use on AWS. (default "gp2")
   -e, --extra NAME=VALUE      One or more arguments provided as the NAME=VALUE key-value pairs to configure additional cluster settings. You can use this flag multiple times or enter the key-value pairs as a comma-separated list.
-  -k, --kube-version string   Kubernetes version of the cluster. (default "1.19")
+  -k, --kube-version string   Kubernetes version of the cluster. (default "1.20")
   -n, --name string           Name of the cluster to provision. (required)
   -p, --project string        Name of the Gardener project where you provision the cluster. (required)
   -r, --region string         Region of the cluster. (default "eu-west-3")

--- a/docs/gen-docs/kyma_provision_gardener_az.md
+++ b/docs/gen-docs/kyma_provision_gardener_az.md
@@ -22,7 +22,7 @@ kyma provision gardener az [flags]
       --disk-size int         Disk size (in GB) of the cluster. (default 50)
       --disk-type string      Type of disk to use on Azure. (default "Standard_LRS")
   -e, --extra NAME=VALUE      One or more arguments provided as the NAME=VALUE key-value pairs to configure additional cluster settings. You can use this flag multiple times or enter the key-value pairs as a comma-separated list.
-  -k, --kube-version string   Kubernetes version of the cluster. (default "1.19")
+  -k, --kube-version string   Kubernetes version of the cluster. (default "1.20")
   -n, --name string           Name of the cluster to provision. (required)
   -p, --project string        Name of the Gardener project where you provision the cluster. (required)
   -r, --region string         Region of the cluster. (default "westeurope")

--- a/docs/gen-docs/kyma_provision_gardener_gcp.md
+++ b/docs/gen-docs/kyma_provision_gardener_gcp.md
@@ -23,7 +23,7 @@ kyma provision gardener gcp [flags]
       --disk-size int         Disk size (in GB) of the cluster. (default 50)
       --disk-type string      Type of disk to use on GCP. (default "pd-standard")
   -e, --extra NAME=VALUE      One or more arguments provided as the NAME=VALUE key-value pairs to configure additional cluster settings. You can use this flag multiple times or enter the key-value pairs as a comma-separated list.
-  -k, --kube-version string   Kubernetes version of the cluster. (default "1.19")
+  -k, --kube-version string   Kubernetes version of the cluster. (default "1.20")
   -n, --name string           Name of the cluster to provision. (required)
   -p, --project string        Name of the Gardener project where you provision the cluster. (required)
   -r, --region string         Region of the cluster. (default "europe-west3")

--- a/docs/gen-docs/kyma_provision_gke.md
+++ b/docs/gen-docs/kyma_provision_gke.md
@@ -19,7 +19,7 @@ kyma provision gke [flags]
       --attempts uint         Maximum number of attempts to provision the cluster. (default 3)
   -c, --credentials string    Path to the GCP service account key file. (required)
       --disk-size int         Disk size (in GB) of the cluster. (default 50)
-  -k, --kube-version string   Kubernetes version of the cluster. (default "1.18")
+  -k, --kube-version string   Kubernetes version of the cluster. (default "1.19")
   -l, --location string       Location of the cluster. (default "europe-west3-a")
   -n, --name string           Name of the GKE cluster to provision. (required)
       --nodes int             Number of cluster nodes. (default 3)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The recommended kubernetes version for the next kyma release will be k8s 1.20, so the default versions used by the provisioning commands needs to be adjusted.

Changes proposed in this pull request:

- update k8s version for gardener and azure to k8s 1.20
- update k8s version for google to 1.19 as 1.20 is not supported yet
- No update of k8s version for minikube as for never versions it will require a new dependency "conntrack". As we will switch-over to k3s we will avoid that additional dependency

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
