### PR TITLE
Add flag for custom port mapping in K3D

### DIFF
--- a/cmd/kyma/alpha/provision/k3s/cmd.go
+++ b/cmd/kyma/alpha/provision/k3s/cmd.go
@@ -40,7 +40,7 @@ func NewCmd(o *Options) *cobra.Command {
 	cmd.Flags().StringSliceVarP(&o.AgentArgs, "agent-arg", "a", []string{}, "One or more arguments passed to the k3s agent command on agent nodes (e.g. --agent-arg='--alsologtostderr')")
 	cmd.Flags().DurationVar(&o.Timeout, "timeout", 5*time.Minute, `Maximum time for the provisioning. If you want no timeout, enter "0".`)
 	cmd.Flags().StringSliceVarP(&o.K3dArgs, "k3d-arg", "", []string{}, "One or more arguments passed to the k3d provisioning command (e.g. --k3d-arg='--no-rollback')")
-	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.20.7", "Kubernetes version of the cluster.")
+	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.20.7", "Kubernetes version of the cluster")
 	cmd.Flags().StringToIntVar(&o.PortMapLb, "map-lb-ports", map[string]int{"80": 8080, "443": 8443}, "Map ports 80 and 443 of K3D loadbalancer (e.g. --map-lb-ports=80=8080,443=8443)")
 	return cmd
 }

--- a/cmd/kyma/alpha/provision/k3s/cmd.go
+++ b/cmd/kyma/alpha/provision/k3s/cmd.go
@@ -3,6 +3,8 @@ package k3s
 import (
 	"fmt"
 	"net"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/kyma-project/cli/internal/cli"
@@ -41,8 +43,7 @@ func NewCmd(o *Options) *cobra.Command {
 	cmd.Flags().DurationVar(&o.Timeout, "timeout", 5*time.Minute, `Maximum time for the provisioning. If you want no timeout, enter "0".`)
 	cmd.Flags().StringSliceVarP(&o.K3dArgs, "k3d-arg", "", []string{}, "One or more arguments passed to the k3d provisioning command (e.g. --k3d-arg='--no-rollback')")
 	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.20.7", "Kubernetes version of the cluster")
-	cmd.Flags().StringToIntVar(&o.PortMapLb, "map-lbports", map[string]int{"80": 8080, "443": 8443}, "Map ports 80 and 443 of K3D loadbalancer (e.g. --map-lb-ports=80=8080,443=8443)")
-	cmd.Flags().StringSliceVarP(&o.PortMapping, "port", "p", []string{"8000:80@loadbalancer", "8443:443@loadbalancer"}, "Map ports 80 and 443 of K3D loadbalancer (e.g. -p 8000:80@loadbalancer --port 8443:443@loadbalancer)")
+	cmd.Flags().StringSliceVarP(&o.PortMapping, "port", "p", []string{"8000:80@loadbalancer", "8443:443@loadbalancer"}, "Map ports 80 and 443 of K3D loadbalancer (e.g. -p 8000:80@loadbalancer -p 8443:443@loadbalancer)")
 	return cmd
 }
 
@@ -67,6 +68,19 @@ func (c *command) Run() error {
 	return nil
 }
 
+func extractPortsFromFlag(portFlag []string) ([]int, error) {
+	ports := []int{}
+	for _, rawport := range portFlag {
+		portStr := rawport[:strings.IndexByte(rawport, ':')]
+		portInt, err := strconv.Atoi(portStr)
+		if err != nil {
+			return nil, err
+		}
+		ports = append(ports, portInt)
+	}
+	return ports, nil
+}
+
 //Ensure k3s is installed and pre-conditions are fulfilled
 func (c *command) verifyK3sStatus() error {
 	s := c.NewStep("Checking k3s status")
@@ -80,13 +94,17 @@ func (c *command) verifyK3sStatus() error {
 		s.Failure()
 		return err
 	}
+	ports, err := extractPortsFromFlag(c.opts.PortMapping)
+	if err != nil {
+		errors.Wrap(err, fmt.Sprintf("Could not extract host ports from %s", c.opts.PortMapping))
+	}
 
 	if exists {
 		if err := c.deleteExistingK3sCluster(); err != nil {
 			s.Failure()
 			return err
 		}
-	} else if err := c.allocatePorts(c.opts.PortMapLb["80"], c.opts.PortMapLb["443"]); err != nil {
+	} else if err := c.allocatePorts(ports...); err != nil {
 		s.Failure()
 		return errors.Wrap(err, "Port cannot be allocated")
 	}
@@ -137,7 +155,6 @@ func (c *command) createK3sCluster() error {
 		ClusterName: c.opts.Name,
 		Args:        c.opts.K3dArgs,
 		Version:     c.opts.KubernetesVersion,
-		PortMap:     c.opts.PortMapLb,
 		PortMapping: c.opts.PortMapping,
 	}
 	err := k3s.StartCluster(c.Verbose, c.opts.Timeout, c.opts.Workers, c.opts.ServerArgs, c.opts.AgentArgs, k3sSettings)

--- a/cmd/kyma/alpha/provision/k3s/cmd.go
+++ b/cmd/kyma/alpha/provision/k3s/cmd.go
@@ -40,7 +40,7 @@ func NewCmd(o *Options) *cobra.Command {
 	cmd.Flags().StringSliceVarP(&o.AgentArgs, "agent-arg", "a", []string{}, "One or more arguments passed to the k3s agent command on agent nodes (e.g. --agent-arg='--alsologtostderr')")
 	cmd.Flags().DurationVar(&o.Timeout, "timeout", 5*time.Minute, `Maximum time for the provisioning. If you want no timeout, enter "0".`)
 	cmd.Flags().StringSliceVarP(&o.K3dArgs, "k3d-arg", "", []string{}, "One or more arguments passed to the k3d provisioning command (e.g. --k3d-arg='--no-rollback')")
-	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.20.6", "Kubernetes version of the cluster.")
+	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.20.7", "Kubernetes version of the cluster.")
 	cmd.Flags().StringToIntVar(&o.PortMapLb, "map-lb-ports", map[string]int{"80": 8080, "443": 8443}, "Map ports 80 and 443 of K3D loadbalancer (e.g. --map-lb-ports=80=8080,443=8443)")
 	return cmd
 }

--- a/cmd/kyma/alpha/provision/k3s/cmd.go
+++ b/cmd/kyma/alpha/provision/k3s/cmd.go
@@ -41,7 +41,8 @@ func NewCmd(o *Options) *cobra.Command {
 	cmd.Flags().DurationVar(&o.Timeout, "timeout", 5*time.Minute, `Maximum time for the provisioning. If you want no timeout, enter "0".`)
 	cmd.Flags().StringSliceVarP(&o.K3dArgs, "k3d-arg", "", []string{}, "One or more arguments passed to the k3d provisioning command (e.g. --k3d-arg='--no-rollback')")
 	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.20.7", "Kubernetes version of the cluster")
-	cmd.Flags().StringToIntVar(&o.PortMapLb, "map-lb-ports", map[string]int{"80": 8080, "443": 8443}, "Map ports 80 and 443 of K3D loadbalancer (e.g. --map-lb-ports=80=8080,443=8443)")
+	cmd.Flags().StringToIntVar(&o.PortMapLb, "map-lbports", map[string]int{"80": 8080, "443": 8443}, "Map ports 80 and 443 of K3D loadbalancer (e.g. --map-lb-ports=80=8080,443=8443)")
+	cmd.Flags().StringSliceVarP(&o.PortMapping, "port", "p", []string{"8000:80@loadbalancer", "8443:443@loadbalancer"}, "Map ports 80 and 443 of K3D loadbalancer (e.g. -p 8000:80@loadbalancer --port 8443:443@loadbalancer)")
 	return cmd
 }
 
@@ -137,6 +138,7 @@ func (c *command) createK3sCluster() error {
 		Args:        c.opts.K3dArgs,
 		Version:     c.opts.KubernetesVersion,
 		PortMap:     c.opts.PortMapLb,
+		PortMapping: c.opts.PortMapping,
 	}
 	err := k3s.StartCluster(c.Verbose, c.opts.Timeout, c.opts.Workers, c.opts.ServerArgs, c.opts.AgentArgs, k3sSettings)
 	if err != nil {

--- a/cmd/kyma/alpha/provision/k3s/cmd.go
+++ b/cmd/kyma/alpha/provision/k3s/cmd.go
@@ -96,7 +96,7 @@ func (c *command) verifyK3sStatus() error {
 	}
 	ports, err := extractPortsFromFlag(c.opts.PortMapping)
 	if err != nil {
-		errors.Wrap(err, fmt.Sprintf("Could not extract host ports from %s", c.opts.PortMapping))
+		return errors.Wrap(err, fmt.Sprintf("Could not extract host ports from %s", c.opts.PortMapping))
 	}
 
 	if exists {

--- a/cmd/kyma/alpha/provision/k3s/cmd_test.go
+++ b/cmd/kyma/alpha/provision/k3s/cmd_test.go
@@ -1,0 +1,14 @@
+package k3s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractPortsFromFlag(t *testing.T) {
+	rawPorts := []string{"8000:80@loadbalancer", "8443:443@loadbalancer"}
+	res, err := extractPortsFromFlag(rawPorts)
+	require.NoError(t, err)
+	require.Equal(t, []int{8000, 8443}, res)
+}

--- a/cmd/kyma/alpha/provision/k3s/opts.go
+++ b/cmd/kyma/alpha/provision/k3s/opts.go
@@ -18,6 +18,7 @@ type Options struct {
 	K3dArgs           []string
 	KubernetesVersion string
 	PortMapLb         map[string]int
+	PortMapping       []string
 }
 
 //NewOptions creates options with default values

--- a/cmd/kyma/alpha/provision/k3s/opts.go
+++ b/cmd/kyma/alpha/provision/k3s/opts.go
@@ -17,6 +17,7 @@ type Options struct {
 	AgentArgs         []string
 	K3dArgs           []string
 	KubernetesVersion string
+	PortMapLb         map[string]int
 }
 
 //NewOptions creates options with default values

--- a/cmd/kyma/alpha/provision/k3s/opts.go
+++ b/cmd/kyma/alpha/provision/k3s/opts.go
@@ -17,7 +17,6 @@ type Options struct {
 	AgentArgs         []string
 	K3dArgs           []string
 	KubernetesVersion string
-	PortMapLb         map[string]int
 	PortMapping       []string
 }
 

--- a/docs/gen-docs/kyma_alpha_provision_k3s.md
+++ b/docs/gen-docs/kyma_alpha_provision_k3s.md
@@ -17,7 +17,7 @@ kyma alpha provision k3s [flags]
 ```bash
   -a, --agent-arg strings          One or more arguments passed to the k3s agent command on agent nodes (e.g. --agent-arg='--alsologtostderr')
       --k3d-arg strings            One or more arguments passed to the k3d provisioning command (e.g. --k3d-arg='--no-rollback')
-  -k, --kube-version string        Kubernetes version of the cluster. (default "1.20.7")
+  -k, --kube-version string        Kubernetes version of the cluster (default "1.20.7")
       --map-lb-ports stringToInt   Map ports 80 and 443 of K3D loadbalancer (e.g. --map-lb-ports=80=8080,443=8443) (default [80=8080,443=8443])
       --name string                Name of the Kyma cluster (default "kyma")
   -s, --server-arg strings         One or more arguments passed to the Kubernetes API server (e.g. --server-arg='--alsologtostderr')

--- a/docs/gen-docs/kyma_alpha_provision_k3s.md
+++ b/docs/gen-docs/kyma_alpha_provision_k3s.md
@@ -17,7 +17,7 @@ kyma alpha provision k3s [flags]
 ```bash
   -a, --agent-arg strings          One or more arguments passed to the k3s agent command on agent nodes (e.g. --agent-arg='--alsologtostderr')
       --k3d-arg strings            One or more arguments passed to the k3d provisioning command (e.g. --k3d-arg='--no-rollback')
-  -k, --kube-version string        Kubernetes version of the cluster. (default "1.20.6")
+  -k, --kube-version string        Kubernetes version of the cluster. (default "1.20.7")
       --map-lb-ports stringToInt   Map ports 80 and 443 of K3D loadbalancer (e.g. --map-lb-ports=80=8080,443=8443) (default [80=8080,443=8443])
       --name string                Name of the Kyma cluster (default "kyma")
   -s, --server-arg strings         One or more arguments passed to the Kubernetes API server (e.g. --server-arg='--alsologtostderr')

--- a/docs/gen-docs/kyma_alpha_provision_k3s.md
+++ b/docs/gen-docs/kyma_alpha_provision_k3s.md
@@ -15,14 +15,14 @@ kyma alpha provision k3s [flags]
 ## Flags
 
 ```bash
-  -a, --agent-arg strings          One or more arguments passed to the k3s agent command on agent nodes (e.g. --agent-arg='--alsologtostderr')
-      --k3d-arg strings            One or more arguments passed to the k3d provisioning command (e.g. --k3d-arg='--no-rollback')
-  -k, --kube-version string        Kubernetes version of the cluster (default "1.20.7")
-      --map-lb-ports stringToInt   Map ports 80 and 443 of K3D loadbalancer (e.g. --map-lb-ports=80=8080,443=8443) (default [80=8080,443=8443])
-      --name string                Name of the Kyma cluster (default "kyma")
-  -s, --server-arg strings         One or more arguments passed to the Kubernetes API server (e.g. --server-arg='--alsologtostderr')
-      --timeout duration           Maximum time for the provisioning. If you want no timeout, enter "0". (default 5m0s)
-      --workers int                Number of worker nodes (k3s agents) (default 1)
+  -a, --agent-arg strings     One or more arguments passed to the k3s agent command on agent nodes (e.g. --agent-arg='--alsologtostderr')
+      --k3d-arg strings       One or more arguments passed to the k3d provisioning command (e.g. --k3d-arg='--no-rollback')
+  -k, --kube-version string   Kubernetes version of the cluster (default "1.20.7")
+      --name string           Name of the Kyma cluster (default "kyma")
+  -p, --port strings          Map ports 80 and 443 of K3D loadbalancer (e.g. -p 8000:80@loadbalancer -p 8443:443@loadbalancer) (default [8000:80@loadbalancer,8443:443@loadbalancer])
+  -s, --server-arg strings    One or more arguments passed to the Kubernetes API server (e.g. --server-arg='--alsologtostderr')
+      --timeout duration      Maximum time for the provisioning. If you want no timeout, enter "0". (default 5m0s)
+      --workers int           Number of worker nodes (k3s agents) (default 1)
 ```
 
 ## Flags inherited from parent commands

--- a/docs/gen-docs/kyma_alpha_provision_k3s.md
+++ b/docs/gen-docs/kyma_alpha_provision_k3s.md
@@ -15,13 +15,14 @@ kyma alpha provision k3s [flags]
 ## Flags
 
 ```bash
-  -a, --agent-arg strings     One or more arguments passed to the k3s agent command on agent nodes (e.g. --agent-arg='--alsologtostderr')
-      --k3d-arg strings       One or more arguments passed to the k3d provisioning command (e.g. --k3d-arg='--no-rollback')
-  -k, --kube-version string   Kubernetes version of the cluster. (default "1.20.7")
-      --name string           Name of the Kyma cluster (default "kyma")
-  -s, --server-arg strings    One or more arguments passed to the Kubernetes API server (e.g. --server-arg='--alsologtostderr')
-      --timeout duration      Maximum time for the provisioning. If you want no timeout, enter "0". (default 5m0s)
-      --workers int           Number of worker nodes (k3s agents) (default 1)
+  -a, --agent-arg strings          One or more arguments passed to the k3s agent command on agent nodes (e.g. --agent-arg='--alsologtostderr')
+      --k3d-arg strings            One or more arguments passed to the k3d provisioning command (e.g. --k3d-arg='--no-rollback')
+  -k, --kube-version string        Kubernetes version of the cluster. (default "1.20.6")
+      --map-lb-ports stringToInt   Map ports 80 and 443 of K3D loadbalancer (e.g. --map-lb-ports=80=8080,443=8443) (default [80=8080,443=8443])
+      --name string                Name of the Kyma cluster (default "kyma")
+  -s, --server-arg strings         One or more arguments passed to the Kubernetes API server (e.g. --server-arg='--alsologtostderr')
+      --timeout duration           Maximum time for the provisioning. If you want no timeout, enter "0". (default 5m0s)
+      --workers int                Number of worker nodes (k3s agents) (default 1)
 ```
 
 ## Flags inherited from parent commands

--- a/docs/gen-docs/kyma_provision_minikube.md
+++ b/docs/gen-docs/kyma_provision_minikube.md
@@ -24,7 +24,7 @@ kyma provision minikube [flags]
       --profile string                 Specifies the Minikube profile.
       --timeout duration               Maximum time during which the provisioning takes place, where "0" means "infinite". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". (default 5m0s)
       --use-hyperkit-vpnkit-sock       Uses vpnkit sock provided by Docker. This is useful when DNS Port (53) is being used by some other program like dns-proxy (eg. provided by Cisco Umbrella. This flag works only on Mac OS).
-      --vm-driver string               Specifies the VM driver. Possible values: vmwarefusion,kvm,xhyve,hyperv,hyperkit,virtualbox,kvm2,docker,none (default "none")
+      --vm-driver string               Specifies the VM driver. Possible values: vmwarefusion,kvm,xhyve,hyperv,hyperkit,virtualbox,kvm2,docker,none (default "hyperkit")
 ```
 
 ## Flags inherited from parent commands

--- a/internal/k3s/k3s.go
+++ b/internal/k3s/k3s.go
@@ -143,10 +143,10 @@ type Settings struct {
 	PortMapping []string
 }
 
-func constructPortArguments(rawPorts []string) []string {
+func constructArgs(argname string, rawPorts []string) []string {
 	portMap := []string{}
 	for _, port := range rawPorts {
-		portMap = append(portMap, []string{"-p", port}...)
+		portMap = append(portMap, argname, port)
 	}
 	return portMap
 }
@@ -157,7 +157,6 @@ func StartCluster(verbose bool, timeout time.Duration, workers int, serverArgs [
 	if err != nil {
 		return err
 	}
-	portArgs := constructPortArguments(k3d.PortMapping)
 	cmdArgs := []string{
 		"cluster", "create", k3d.ClusterName,
 		"--kubeconfig-update-default",
@@ -168,17 +167,10 @@ func StartCluster(verbose bool, timeout time.Duration, workers int, serverArgs [
 		"--k3s-server-arg", "--disable",
 		"--k3s-server-arg", "traefik",
 	}
-	cmdArgs = append(cmdArgs, portArgs...)
 
-	//add further custom server args
-	for _, srvArg := range serverArgs {
-		cmdArgs = append(cmdArgs, "--k3s-server-arg", srvArg)
-	}
-
-	//add agent args
-	for _, agentArg := range agentArgs {
-		cmdArgs = append(cmdArgs, "--k3s-agent-arg", agentArg)
-	}
+	cmdArgs = append(cmdArgs, constructArgs("-p", k3d.PortMapping)...)
+	cmdArgs = append(cmdArgs, constructArgs("--k3s-server-arg", serverArgs)...)
+	cmdArgs = append(cmdArgs, constructArgs("--k3s-agent-arg", agentArgs)...)
 
 	//add further k3d args which are not offered by the Kyma CLI flags
 	cmdArgs = append(cmdArgs, k3d.Args...)

--- a/internal/k3s/k3s.go
+++ b/internal/k3s/k3s.go
@@ -168,9 +168,9 @@ func StartCluster(verbose bool, timeout time.Duration, workers int, serverArgs [
 		"--k3s-server-arg", "traefik",
 	}
 
-	cmdArgs = append(cmdArgs, constructArgs("-p", k3d.PortMapping)...)
 	cmdArgs = append(cmdArgs, constructArgs("--k3s-server-arg", serverArgs)...)
 	cmdArgs = append(cmdArgs, constructArgs("--k3s-agent-arg", agentArgs)...)
+	cmdArgs = append(cmdArgs, constructArgs("-p", k3d.PortMapping)...)
 
 	//add further k3d args which are not offered by the Kyma CLI flags
 	cmdArgs = append(cmdArgs, k3d.Args...)

--- a/internal/k3s/k3s.go
+++ b/internal/k3s/k3s.go
@@ -135,20 +135,20 @@ func ClusterExists(verbose bool, clusterName string) (bool, error) {
 	return false, nil
 }
 
-type Settings struct {
-	ClusterName string
-	Args        []string
-	Version     string
-	PortMap     map[string]int
-	PortMapping []string
-}
-
 func constructArgs(argname string, rawPorts []string) []string {
 	portMap := []string{}
 	for _, port := range rawPorts {
 		portMap = append(portMap, argname, port)
 	}
 	return portMap
+}
+
+type Settings struct {
+	ClusterName string
+	Args        []string
+	Version     string
+	PortMap     map[string]int
+	PortMapping []string
 }
 
 //StartCluster starts a cluster

--- a/internal/k3s/k3s.go
+++ b/internal/k3s/k3s.go
@@ -161,7 +161,6 @@ func StartCluster(verbose bool, timeout time.Duration, workers int, serverArgs [
 		"--k3s-server-arg", "--disable",
 		"--k3s-server-arg", "traefik",
 	}
-	fmt.Println(cmdArgs)
 
 	//add further custom server args
 	for _, srvArg := range serverArgs {

--- a/internal/k3s/k3s_test.go
+++ b/internal/k3s/k3s_test.go
@@ -103,7 +103,13 @@ func TestInitializeFailed(t *testing.T) {
 }
 
 func TestStartCluster(t *testing.T) {
-	err := StartCluster(false, 5*time.Second, "kyma", 1, []string{"--alsologtostderr"}, []string{"--alsologtostderr"}, []string{"--no-rollback"}, "1.20.7")
+	k3sSettings := Settings{
+		ClusterName: "kyma",
+		Args:        []string{"--alsologtostderr"},
+		Version:     "1.20.6",
+		PortMap:     map[string]int{"80": 8888, "443": 4444},
+	}
+	err := StartCluster(false, 5*time.Second, 1, []string{"--alsologtostderr"}, []string{"--no-rollback"}, k3sSettings)
 	require.NoError(t, err)
 }
 

--- a/internal/k3s/k3s_test.go
+++ b/internal/k3s/k3s_test.go
@@ -126,7 +126,7 @@ func TestClusterExists(t *testing.T) {
 	os.Setenv("K3D_MOCK_DUMPFILE", "")
 }
 
-func TestPortArgs(t *testing.T) {
+func TestArgConstruction(t *testing.T) {
 	rawPorts := []string{"8000:80@loadbalancer", "8443:443@loadbalancer"}
 	res := constructArgs("-p", rawPorts)
 	require.Equal(t, []string{"-p", "8000:80@loadbalancer", "-p", "8443:443@loadbalancer"}, res)

--- a/internal/k3s/k3s_test.go
+++ b/internal/k3s/k3s_test.go
@@ -107,7 +107,7 @@ func TestStartCluster(t *testing.T) {
 		ClusterName: "kyma",
 		Args:        []string{"--alsologtostderr"},
 		Version:     "1.20.7",
-		PortMap:     map[string]int{"80": 80, "443": 443},
+		PortMapping: []string{"80:80@loadbalancer", "443:443@loadbalancer"},
 	}
 	err := StartCluster(false, 5*time.Second, 1, []string{"--alsologtostderr"}, []string{"--no-rollback"}, k3sSettings)
 	require.NoError(t, err)

--- a/internal/k3s/k3s_test.go
+++ b/internal/k3s/k3s_test.go
@@ -106,8 +106,8 @@ func TestStartCluster(t *testing.T) {
 	k3sSettings := Settings{
 		ClusterName: "kyma",
 		Args:        []string{"--alsologtostderr"},
-		Version:     "1.20.6",
-		PortMap:     map[string]int{"80": 8888, "443": 4444},
+		Version:     "1.20.7",
+		PortMap:     map[string]int{"80": 80, "443": 443},
 	}
 	err := StartCluster(false, 5*time.Second, 1, []string{"--alsologtostderr"}, []string{"--no-rollback"}, k3sSettings)
 	require.NoError(t, err)

--- a/internal/k3s/k3s_test.go
+++ b/internal/k3s/k3s_test.go
@@ -125,3 +125,9 @@ func TestClusterExists(t *testing.T) {
 	require.True(t, exists)
 	os.Setenv("K3D_MOCK_DUMPFILE", "")
 }
+
+func TestPortArgs(t *testing.T) {
+	rawPorts := []string{"8000:80@loadbalancer", "8443:443@loadbalancer"}
+	res := constructPortArguments(rawPorts)
+	require.Equal(t, []string{"-p", "8000:80@loadbalancer", "-p", "8443:443@loadbalancer"}, res)
+}

--- a/internal/k3s/k3s_test.go
+++ b/internal/k3s/k3s_test.go
@@ -128,6 +128,6 @@ func TestClusterExists(t *testing.T) {
 
 func TestPortArgs(t *testing.T) {
 	rawPorts := []string{"8000:80@loadbalancer", "8443:443@loadbalancer"}
-	res := constructPortArguments(rawPorts)
+	res := constructArgs("-p", rawPorts)
 	require.Equal(t, []string{"-p", "8000:80@loadbalancer", "-p", "8443:443@loadbalancer"}, res)
 }

--- a/internal/k3s/mock/k3d
+++ b/internal/k3s/mock/k3d
@@ -40,9 +40,9 @@ function cluster_list_-o_json {
 }
 
 #
-# Mock for 'k3d cluster create kyma --kubeconfig-update-default --timeout 5s -p 80:80@loadbalancer -p 443:443@loadbalancer --agents 1 --registry-create --image rancher/k3s:v1.20.7-k3s1--k3s-server-arg --disable --k3s-server-arg traefik' command
+# Mock for 'k3d cluster create kyma' command
 #
-function cluster_create_kyma_--kubeconfig-update-default_--timeout_5s_-p_80:80@loadbalancer_-p_443:443@loadbalancer_--agents_1_--registry-create_--image_rancher/k3s:v1.20.7-k3s1_--k3s-server-arg_--disable_--k3s-server-arg_traefik_--k3s-server-arg_--alsologtostderr_--k3s-agent-arg_--no-rollback_--alsologtostderr {
+function cluster_create_kyma_--kubeconfig-update-default_--timeout_5s_--agents_1_--registry-create_--image_rancher/k3s:v1.20.7-k3s1_--k3s-server-arg_--disable_--k3s-server-arg_traefik_--k3s-server-arg_--alsologtostderr_--k3s-agent-arg_--no-rollback_-p_80:80@loadbalancer_-p_443:443@loadbalancer_--alsologtostderr {
     dump_file cluster_create.txt
 }
 

--- a/internal/k3s/mock/k3d
+++ b/internal/k3s/mock/k3d
@@ -42,7 +42,7 @@ function cluster_list_-o_json {
 #
 # Mock for 'k3d cluster create kyma --kubeconfig-update-default --timeout 5s -p 80:80@loadbalancer -p 443:443@loadbalancer --agents 1 --registry-create --image rancher/k3s:v1.20.7-k3s1--k3s-server-arg --disable --k3s-server-arg traefik' command
 #
-function cluster_create_kyma_--kubeconfig-update-default_--timeout_5s_-p_80:80@loadbalancer_-p_443:443@loadbalancer_--agents_1_--registry-create_--image_rancher/k3s:v1.20.7-k3s1_--k3s-server-arg_--disable_--k3s-server-arg_traefik_--k3s-server-arg_--alsologtostderr_--k3s-agent-arg_--alsologtostderr_--no-rollback {
+function cluster_create_kyma_--kubeconfig-update-default_--timeout_5s_-p_80:80@loadbalancer_-p_443:443@loadbalancer_--agents_1_--registry-create_--image_rancher/k3s:v1.20.7-k3s1_--k3s-server-arg_--disable_--k3s-server-arg_traefik_--k3s-server-arg_--alsologtostderr_--k3s-agent-arg_--no-rollback_--alsologtostderr {
     dump_file cluster_create.txt
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
On Linux, the ports exposed from the K3S loadbalancer are privileged. In order to avoid forcing the use of `sudo`, a new flag `--ports` is introduced to allocate custom ports.
E.g.:
kyma alpha provision k3s --ports="8000:80,8443:443"

Testing:
The cluster was successfully created on a Ubuntu cluster without sudo
![image](https://user-images.githubusercontent.com/29373967/125940828-2b156f83-b57f-4f4e-b74f-1307ff207945.png)


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves https://github.com/kyma-project/kyma/issues/11615