### PR TITLE
rephrase location flag for aks and gke

### DIFF
--- a/cmd/kyma/provision/aks/cmd.go
+++ b/cmd/kyma/provision/aks/cmd.go
@@ -20,7 +20,7 @@ func NewCmd(o *Options) *cobra.Command {
 	cmd.Flags().StringVarP(&o.Project, "project", "p", "", "Name of the Azure Resource Group where you provision the AKS cluster. (required)")
 	cmd.Flags().StringVarP(&o.CredentialsFile, "credentials", "c", "", "Path to the TOML file containing the Azure Subscription ID (SUBSCRIPTION_ID), Tenant ID (TENANT_ID), Client ID (CLIENT_ID) and Client Secret (CLIENT_SECRET). (required)")
 	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.19.7", "Kubernetes version of the cluster.")
-	cmd.Flags().StringVarP(&o.Location, "location", "l", "westeurope", "Location of the cluster.")
+	cmd.Flags().StringVarP(&o.Location, "location", "l", "westeurope", "Region (e.g. europe-west3) or zone (e.g. europe-west3-a) of the cluster.")
 	cmd.Flags().StringVarP(&o.MachineType, "type", "t", "Standard_D4_v3", "Machine type used for the cluster.")
 	cmd.Flags().IntVar(&o.DiskSizeGB, "disk-size", 50, "Disk size (in GB) of the cluster.")
 	cmd.Flags().IntVar(&o.NodeCount, "nodes", 3, "Number of cluster nodes.")

--- a/cmd/kyma/provision/aks/cmd.go
+++ b/cmd/kyma/provision/aks/cmd.go
@@ -20,7 +20,7 @@ func NewCmd(o *Options) *cobra.Command {
 	cmd.Flags().StringVarP(&o.Project, "project", "p", "", "Name of the Azure Resource Group where you provision the AKS cluster. (required)")
 	cmd.Flags().StringVarP(&o.CredentialsFile, "credentials", "c", "", "Path to the TOML file containing the Azure Subscription ID (SUBSCRIPTION_ID), Tenant ID (TENANT_ID), Client ID (CLIENT_ID) and Client Secret (CLIENT_SECRET). (required)")
 	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.19.7", "Kubernetes version of the cluster.")
-	cmd.Flags().StringVarP(&o.Location, "location", "l", "westeurope", "Region (e.g. europe-west3) or zone (e.g. europe-west3-a) of the cluster.")
+	cmd.Flags().StringVarP(&o.Location, "location", "l", "westeurope", "Region (e.g. westeurope) of the cluster.")
 	cmd.Flags().StringVarP(&o.MachineType, "type", "t", "Standard_D4_v3", "Machine type used for the cluster.")
 	cmd.Flags().IntVar(&o.DiskSizeGB, "disk-size", 50, "Disk size (in GB) of the cluster.")
 	cmd.Flags().IntVar(&o.NodeCount, "nodes", 3, "Number of cluster nodes.")

--- a/cmd/kyma/provision/gke/cmd.go
+++ b/cmd/kyma/provision/gke/cmd.go
@@ -21,7 +21,7 @@ NOTE: To access the provisioned cluster, make sure you get authenticated by Goog
 	cmd.Flags().StringVarP(&o.Project, "project", "p", "", "Name of the GCP Project where you provision the GKE cluster. (required)")
 	cmd.Flags().StringVarP(&o.CredentialsFile, "credentials", "c", "", "Path to the GCP service account key file. (required)")
 	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.19", "Kubernetes version of the cluster.")
-	cmd.Flags().StringVarP(&o.Location, "location", "l", "europe-west3-a", "Location of the cluster.")
+	cmd.Flags().StringVarP(&o.Location, "location", "l", "europe-west3-a", "Region (e.g. europe-west3) or zone (e.g. europe-west3-a) of the cluster.")
 	cmd.Flags().StringVarP(&o.MachineType, "type", "t", "n1-standard-4", "Machine type used for the cluster.")
 	cmd.Flags().IntVar(&o.DiskSizeGB, "disk-size", 50, "Disk size (in GB) of the cluster.")
 	cmd.Flags().IntVar(&o.NodeCount, "nodes", 3, "Number of cluster nodes.")

--- a/docs/gen-docs/kyma_provision_aks.md
+++ b/docs/gen-docs/kyma_provision_aks.md
@@ -20,7 +20,7 @@ kyma provision aks [flags]
   -c, --credentials string    Path to the TOML file containing the Azure Subscription ID (SUBSCRIPTION_ID), Tenant ID (TENANT_ID), Client ID (CLIENT_ID) and Client Secret (CLIENT_SECRET). (required)
       --disk-size int         Disk size (in GB) of the cluster. (default 50)
   -k, --kube-version string   Kubernetes version of the cluster. (default "1.19.7")
-  -l, --location string       Location of the cluster. (default "westeurope")
+  -l, --location string       Region (e.g. europe-west3) or zone (e.g. europe-west3-a) of the cluster. (default "westeurope")
   -n, --name string           Name of the AKS cluster to provision. (required)
       --nodes int             Number of cluster nodes. (default 3)
   -p, --project string        Name of the Azure Resource Group where you provision the AKS cluster. (required)

--- a/docs/gen-docs/kyma_provision_aks.md
+++ b/docs/gen-docs/kyma_provision_aks.md
@@ -20,7 +20,7 @@ kyma provision aks [flags]
   -c, --credentials string    Path to the TOML file containing the Azure Subscription ID (SUBSCRIPTION_ID), Tenant ID (TENANT_ID), Client ID (CLIENT_ID) and Client Secret (CLIENT_SECRET). (required)
       --disk-size int         Disk size (in GB) of the cluster. (default 50)
   -k, --kube-version string   Kubernetes version of the cluster. (default "1.19.7")
-  -l, --location string       Region (e.g. europe-west3) or zone (e.g. europe-west3-a) of the cluster. (default "westeurope")
+  -l, --location string       Region (e.g. westeurope) of the cluster. (default "westeurope")
   -n, --name string           Name of the AKS cluster to provision. (required)
       --nodes int             Number of cluster nodes. (default 3)
   -p, --project string        Name of the Azure Resource Group where you provision the AKS cluster. (required)

--- a/docs/gen-docs/kyma_provision_gke.md
+++ b/docs/gen-docs/kyma_provision_gke.md
@@ -20,7 +20,7 @@ kyma provision gke [flags]
   -c, --credentials string    Path to the GCP service account key file. (required)
       --disk-size int         Disk size (in GB) of the cluster. (default 50)
   -k, --kube-version string   Kubernetes version of the cluster. (default "1.19")
-  -l, --location string       Location of the cluster. (default "europe-west3-a")
+  -l, --location string       Region (e.g. europe-west3) or zone (e.g. europe-west3-a) of the cluster. (default "europe-west3-a")
   -n, --name string           Name of the GKE cluster to provision. (required)
       --nodes int             Number of cluster nodes. (default 3)
   -p, --project string        Name of the GCP Project where you provision the GKE cluster. (required)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- replace current description: "Location of the cluster." with new description: "Region (e.g. europe-west3) or zone (e.g. europe-west3-a) of the cluster." in the following cmd.go files:
  - provision aks
  - provision gke

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/cli/issues/410