### PR TITLE
Remove kazydek & superojla from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 * @suleymanakbas91 @clebs @a-thaler @lilitgh @hisarbalik @rakesh-garimella @shorim @tobiscr @skhalash @jeremyharisch @elchead @chrkl
 
 # All .md files
-*.md @kazydek @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @superojla @NHingerl
+*.md @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @NHingerl
 
 # Owners of the .kyma-project-io folder
 /.kyma-project-io/ @m00g3n @pPrecel @dbadura @tgorgol @rJankowski93


### PR DESCRIPTION
**Description**

As Karolina is no longer an active contributor to the project, she must be removed from the CODEOWNERS. 
As Nina's been actively contributing to Kyma for some time now, she, in turn, must be added.

Changes proposed in this pull request:

- Remove @kazydek from CODEOWNERS
- Add @NHingerl to CODEOWNERS