### PR TITLE
Change default exposed ports to 80 and 443

### DIFF
--- a/cmd/kyma/provision/k3d/cmd.go
+++ b/cmd/kyma/provision/k3d/cmd.go
@@ -2,17 +2,19 @@ package k3d
 
 import (
 	"fmt"
+
 	"github.com/kyma-project/cli/internal/cli"
 	"github.com/kyma-project/cli/internal/clusterinfo"
 	"github.com/kyma-project/cli/internal/k3d"
 	"github.com/kyma-project/cli/internal/kube"
 
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 	"net"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 )
 
 type command struct {
@@ -43,7 +45,7 @@ func NewCmd(o *Options) *cobra.Command {
 	cmd.Flags().DurationVar(&o.Timeout, "timeout", 5*time.Minute, `Maximum time for the provisioning. If you want no timeout, enter "0".`)
 	cmd.Flags().StringSliceVarP(&o.K3dArgs, "k3d-arg", "", []string{}, "One or more arguments passed to the k3d provisioning command (e.g. --k3d-arg='--no-rollback')")
 	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.20.7", "Kubernetes version of the cluster")
-	cmd.Flags().StringSliceVarP(&o.PortMapping, "port", "p", []string{"8000:80@loadbalancer", "8443:443@loadbalancer"}, "Map ports 80 and 443 of K3D loadbalancer (e.g. -p 8000:80@loadbalancer -p 8443:443@loadbalancer)")
+	cmd.Flags().StringSliceVarP(&o.PortMapping, "port", "p", []string{"80:80@loadbalancer", "443:443@loadbalancer"}, "Map ports 80 and 443 of K3D loadbalancer (e.g. -p 8000:80@loadbalancer -p 8443:443@loadbalancer)")
 	return cmd
 }
 

--- a/cmd/kyma/provision/k3d/cmd.go
+++ b/cmd/kyma/provision/k3d/cmd.go
@@ -45,7 +45,7 @@ func NewCmd(o *Options) *cobra.Command {
 	cmd.Flags().DurationVar(&o.Timeout, "timeout", 5*time.Minute, `Maximum time for the provisioning. If you want no timeout, enter "0".`)
 	cmd.Flags().StringSliceVarP(&o.K3dArgs, "k3d-arg", "", []string{}, "One or more arguments passed to the k3d provisioning command (e.g. --k3d-arg='--no-rollback')")
 	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.20.7", "Kubernetes version of the cluster")
-	cmd.Flags().StringSliceVarP(&o.PortMapping, "port", "p", []string{"80:80@loadbalancer", "443:443@loadbalancer"}, "Map ports 80 and 443 of K3D loadbalancer (e.g. -p 8000:80@loadbalancer -p 8443:443@loadbalancer)")
+	cmd.Flags().StringSliceVarP(&o.PortMapping, "port", "p", []string{"80:80@loadbalancer", "443:443@loadbalancer"}, "Map ports 80 and 443 of K3D loadbalancer (e.g. -p 80:80@loadbalancer -p 443:443@loadbalancer)")
 	return cmd
 }
 

--- a/docs/gen-docs/kyma_provision_k3d.md
+++ b/docs/gen-docs/kyma_provision_k3d.md
@@ -19,7 +19,7 @@ kyma provision k3d [flags]
       --k3d-arg strings       One or more arguments passed to the k3d provisioning command (e.g. --k3d-arg='--no-rollback')
   -k, --kube-version string   Kubernetes version of the cluster (default "1.20.7")
       --name string           Name of the Kyma cluster (default "kyma")
-  -p, --port strings          Map ports 80 and 443 of K3D loadbalancer (e.g. -p 8000:80@loadbalancer -p 8443:443@loadbalancer) (default [8000:80@loadbalancer,8443:443@loadbalancer])
+  -p, --port strings          Map ports 80 and 443 of K3D loadbalancer (e.g. -p 80:80@loadbalancer -p 443:443@loadbalancer) (default [80:80@loadbalancer,443:443@loadbalancer])
   -s, --server-arg strings    One or more arguments passed to the Kubernetes API server (e.g. --server-arg='--alsologtostderr')
       --timeout duration      Maximum time for the provisioning. If you want no timeout, enter "0". (default 5m0s)
       --workers int           Number of worker nodes (k3d agents) (default 1)


### PR DESCRIPTION
## Description
Changed back the k3d port mapping to the reserved but standard ports 80 and 443. As there is a way to customize the port that should be no problem.

## References
Relates to https://github.com/kyma-project/cli/pull/943