### PR TITLE
Set default kyma versions in config pkg

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,8 +11,7 @@ before:
 builds:
 - env:
   - CGO_ENABLED=0
-  - KYMA_VERSION=main
-  ldflags: -s -w -X github.com/kyma-project/cli/cmd/kyma/version.Version={{.Version}} -X github.com/kyma-project/cli/cmd/kyma/alpha/deploy.defaultKymaVersion={{.Env.KYMA_VERSION}}
+  ldflags: -s -w -X github.com/kyma-project/cli/cmd/kyma/version.Version={{.Version}}
   main: ./cmd/
   goos:
     - darwin

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,5 @@
 .DEFAULT_GOAL := local
 
-ifndef KYMA_VERSION
-	KYMA_VERSION = main
-endif
-
 ifndef VERSION
 	VERSION = ${shell git describe --tags --always}
 endif
@@ -12,7 +8,7 @@ ifeq ($(VERSION),stable)
 	VERSION = stable-${shell git rev-parse --short HEAD}
 endif
 
-FLAGS = -ldflags '-s -w -X github.com/kyma-project/cli/cmd/kyma/version.Version=$(VERSION) -X github.com/kyma-project/cli/cmd/kyma/alpha/deploy.defaultKymaVersion=$(KYMA_VERSION)'
+FLAGS = -ldflags '-s -w -X github.com/kyma-project/cli/cmd/kyma/version.Version=$(VERSION)'
 
 .PHONY: resolve
 resolve:

--- a/cmd/kyma/alpha/deploy/cmd.go
+++ b/cmd/kyma/alpha/deploy/cmd.go
@@ -3,6 +3,11 @@ package deploy
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"time"
+
 	"github.com/kyma-incubator/reconciler/pkg/keb"
 	"github.com/kyma-incubator/reconciler/pkg/reconciler"
 	"github.com/kyma-incubator/reconciler/pkg/reconciler/service"
@@ -10,6 +15,7 @@ import (
 	"github.com/kyma-incubator/reconciler/pkg/scheduler"
 	"github.com/kyma-project/cli/internal/cli"
 	"github.com/kyma-project/cli/internal/component"
+	"github.com/kyma-project/cli/internal/config"
 	"github.com/kyma-project/cli/internal/coredns"
 	"github.com/kyma-project/cli/internal/files"
 	"github.com/kyma-project/cli/internal/istio"
@@ -21,10 +27,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
-	"io/ioutil"
-	"os"
-	"path"
-	"time"
 
 	//Register all reconcilers
 	_ "github.com/kyma-incubator/reconciler/pkg/reconciler/instances"
@@ -57,7 +59,7 @@ func NewCmd(o *Options) *cobra.Command {
 	cobraCmd.Flags().StringSliceVarP(&o.Components, "component", "", []string{}, "Provide one or more components to deploy (e.g. --component componentName@namespace)")
 	cobraCmd.Flags().StringVarP(&o.ComponentsFile, "components-file", "c", "", `Path to the components file (default "$HOME/.kyma/sources/installation/resources/components.yaml" or ".kyma-sources/installation/resources/components.yaml")`)
 	cobraCmd.Flags().StringVarP(&o.WorkspacePath, "workspace", "w", "", `Path to download Kyma sources (default "$HOME/.kyma/sources" or ".kyma-sources")`)
-	cobraCmd.Flags().StringVarP(&o.Source, "source", "s", defaultKymaVersion, `Installation source:
+	cobraCmd.Flags().StringVarP(&o.Source, "source", "s", config.DefaultKyma2Version, `Installation source:
 	- Deploy a specific release, for example: "kyma deploy --source=2.0.0"
 	- Deploy a specific branch of the Kyma repository on kyma-project.org: "kyma deploy --source=<my-branch-name>"
 	- Deploy a commit (8 characters or more), for example: "kyma deploy --source=34edf09a"

--- a/cmd/kyma/alpha/deploy/opts.go
+++ b/cmd/kyma/alpha/deploy/opts.go
@@ -12,8 +12,6 @@ import (
 
 var (
 	defaultWorkspacePath = getDefaultWorkspacePath()
-	// the value of defaultKymaVersion is injected when building the binaries
-	defaultKymaVersion string
 )
 
 const (

--- a/cmd/kyma/install/cmd.go
+++ b/cmd/kyma/install/cmd.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/kyma-project/cli/internal/config"
 	"github.com/kyma-project/cli/internal/hosts"
 	"github.com/kyma-project/cli/internal/kube"
 	"github.com/kyma-project/cli/internal/nice"
@@ -78,7 +79,7 @@ Both installation types continue with the following steps:
 	cobraCmd.Flags().StringVarP(&o.Domain, "domain", "d", defaultDomain, "Domain used for installation.")
 	cobraCmd.Flags().StringVarP(&o.TLSCert, "tls-cert", "", "", "TLS certificate for the domain used for installation. The certificate must be a base64-encoded value.")
 	cobraCmd.Flags().StringVarP(&o.TLSKey, "tls-key", "", "", "TLS key for the domain used for installation. The key must be a base64-encoded value.")
-	cobraCmd.Flags().StringVarP(&o.Source, "source", "s", installation.DefaultKymaVersion, `Installation source.
+	cobraCmd.Flags().StringVarP(&o.Source, "source", "s", config.DefaultKyma1Version, `Installation source.
 	- To use a specific release, write "kyma install --source=1.15.1".
 	- To use the main branch, write "kyma install --source=main".
 	- To use a commit, write "kyma install --source=34edf09a".

--- a/cmd/kyma/install/cmd.go
+++ b/cmd/kyma/install/cmd.go
@@ -72,7 +72,7 @@ Both installation types continue with the following steps:
    `,
 		RunE:       func(_ *cobra.Command, _ []string) error { return cmd.Run() },
 		Aliases:    []string{"i"},
-		Deprecated: "install is deprecated! Use `kyma deploy instead`",
+		Deprecated: `use "kyma deploy" instead`,
 	}
 
 	cobraCmd.Flags().BoolVarP(&o.NoWait, "no-wait", "n", false, "Determines if the command should wait for Kyma installation to complete.")

--- a/cmd/kyma/upgrade/cmd.go
+++ b/cmd/kyma/upgrade/cmd.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/kyma-project/cli/internal/cli"
+	"github.com/kyma-project/cli/internal/config"
 	"github.com/kyma-project/cli/internal/hosts"
 	"github.com/kyma-project/cli/internal/kube"
 	"github.com/kyma-project/cli/internal/nice"
@@ -43,7 +44,7 @@ func NewCmd(o *Options) *cobra.Command {
 	cobraCmd.Flags().StringVarP(&o.Domain, "domain", "d", defaultDomain, "Domain used for the upgrade.")
 	cobraCmd.Flags().StringVarP(&o.TLSCert, "tls-cert", "", "", "TLS certificate for the domain used for the upgrade. The certificate must be a base64-encoded value.")
 	cobraCmd.Flags().StringVarP(&o.TLSKey, "tls-key", "", "", "TLS key for the domain used for the upgrade. The key must be a base64-encoded value.")
-	cobraCmd.Flags().StringVarP(&o.Source, "source", "s", installation.DefaultKymaVersion, `Upgrade source.
+	cobraCmd.Flags().StringVarP(&o.Source, "source", "s", config.DefaultKyma1Version, `Upgrade source.
 	- To use a specific release, write "kyma upgrade --source=1.3.0".
 	- To use the main branch, write "kyma install --source=main".
 	- To use a commit, write "kyma upgrade --source=34edf09a".

--- a/cmd/kyma/upgrade/cmd.go
+++ b/cmd/kyma/upgrade/cmd.go
@@ -37,7 +37,7 @@ func NewCmd(o *Options) *cobra.Command {
 		Short:      "Upgrades Kyma",
 		Long:       `Use this command to upgrade the Kyma version on a cluster.`,
 		RunE:       func(_ *cobra.Command, _ []string) error { return cmd.Run() },
-		Deprecated: "Upgrade is deprecated! Use `kyma deploy instead`",
+		Deprecated: `use "kyma deploy" instead`,
 	}
 
 	cobraCmd.Flags().BoolVarP(&o.NoWait, "no-wait", "n", false, "Determines if the command should wait for the Kyma upgrade to complete.")

--- a/cmd/kyma/upgrade/cmd_test.go
+++ b/cmd/kyma/upgrade/cmd_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/kyma-project/cli/internal/cli"
-	"github.com/kyma-project/cli/pkg/installation"
+	"github.com/kyma-project/cli/internal/config"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,7 +20,7 @@ func TestUpgradeFlags(t *testing.T) {
 	require.Equal(t, defaultDomain, o.Domain, "Default value for the domain flag not as expected.")
 	require.Equal(t, "", o.TLSCert, "Default value for the tlsCert flag not as expected.")
 	require.Equal(t, "", o.TLSKey, "Default value for the tlsKey flag not as expected.")
-	require.Equal(t, installation.DefaultKymaVersion, o.Source, "Default value for the source flag not as expected.")
+	require.Equal(t, config.DefaultKyma1Version, o.Source, "Default value for the source flag not as expected.")
 	require.Equal(t, "", o.LocalSrcPath, "Default value for the src-path flag not as expected.")
 	require.Equal(t, 1*time.Hour, o.Timeout, "Default value for the timeout flag not as expected.")
 	require.Equal(t, "", o.Password, "Default value for the password flag not as expected.")

--- a/docs/gen-docs/kyma_alpha_deploy.md
+++ b/docs/gen-docs/kyma_alpha_deploy.md
@@ -24,7 +24,7 @@ kyma alpha deploy [flags]
                                  	- Deploy a specific branch of the Kyma repository on kyma-project.org: "kyma deploy --source=<my-branch-name>"
                                  	- Deploy a commit (8 characters or more), for example: "kyma deploy --source=34edf09a"
                                  	- Deploy a pull request, for example "kyma deploy --source=PR-9486"
-                                 	- Deploy the local sources: "kyma deploy --source=local"
+                                 	- Deploy the local sources: "kyma deploy --source=local" (default "main")
       --tls-crt string           TLS certificate file for the domain used for installation.
       --tls-key string           TLS key file for the domain used for installation.
       --value strings            Set configuration values. Can specify one or more values, also as a comma-separated list (e.g. --value component.a='1' --value component.b='2' or --value component.a='1',component.b='2').

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,11 @@
+// package config provides configuration values
+
+// NOTE: the values in this file are modified when a release branch is created,
+// so changes in this file should be reflected in the CLI release guidlines:
+// https://github.com/kyma-project/community/blob/main/guidelines/releases-guidelines/03-kyma-cli-release-process.md
+package config
+
+const (
+	DefaultKyma1Version = "1.24.6"
+	DefaultKyma2Version = "main"
+)

--- a/pkg/installation/opts.go
+++ b/pkg/installation/opts.go
@@ -2,8 +2,6 @@ package installation
 
 import "time"
 
-const DefaultKymaVersion = "1.24.6"
-
 // Options holds the configuration options for the installation.
 type Options struct {
 	// Source specifies the installation source. To use the specific release, pass the release version (e.g. 1.6.0).


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Added a config pkg in which default kyma 1 and kyma 2 versions are defined. These values will be modified whenever a release branch is created instead of injecting these values at build time. The reason for this approach is that [Homebrew formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/kyma-cli.rb) injects the CLI version as the default Kyma version at build time and this didn't allow us to to release CLI patches without having a corresponding Kyma patch.
- Improve deprecation message for `install` and `upgrade` commands.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#973
#836 