### PR TITLE
Add waiting for kyma-system namespace deletion

### DIFF
--- a/cmd/kyma/deploy/cmd.go
+++ b/cmd/kyma/deploy/cmd.go
@@ -297,7 +297,7 @@ func (cmd *command) importCertificate() error {
 	defer os.Remove(tmpFile.Name())
 
 	if _, err = tmpFile.Write(cert); err != nil {
-		return errors.Wrap(err, "Failed to write the kyma certificate")
+		return errors.Wrap(err, "Failed to write the Kyma certificate")
 	}
 	if err := tmpFile.Close(); err != nil {
 		return err
@@ -355,7 +355,7 @@ func (cmd *command) decideVersionUpgrade() error {
 
 	currentVersion, err := version.GetCurrentKymaVersion(cmd.K8s)
 	if err != nil {
-		return errors.Wrap(err, "Cannot fetch kyma version")
+		return errors.Wrap(err, "Cannot fetch Kyma version")
 	}
 
 	if currentVersion.None() {
@@ -369,7 +369,7 @@ func (cmd *command) decideVersionUpgrade() error {
 	}
 
 	if cmd.avoidUserInteraction() {
-		verifyStep.Successf("A kyma installation with version '%s' was found. Proceeding with upgrade to '%s' in non-interactive mode. ", currentVersion.String(), upgradeVersion.String())
+		verifyStep.Successf("A Kyma installation with version '%s' was found. Proceeding with upgrade to '%s' in non-interactive mode. ", currentVersion.String(), upgradeVersion.String())
 		return nil
 	}
 
@@ -377,16 +377,16 @@ func (cmd *command) decideVersionUpgrade() error {
 	switch upgradeScenario {
 	case version.UpgradeEqualVersion:
 		{
-			verifyStep.Failuref("A kyma installation was found. Current and target version are equal: %s ", currentVersion.String())
+			verifyStep.Failuref("A Kyma installation was found. Current and target version are equal: %s ", currentVersion.String())
 		}
 	case version.UpgradeUndetermined:
 		{
-			verifyStep.Failuref("A kyma installation was found, but compatibility between version '%s' and '%s' is not guaranteed. This might cause errors! ",
+			verifyStep.Failuref("A Kyma installation was found, but compatibility between version '%s' and '%s' is not guaranteed. This might cause errors! ",
 				currentVersion.String(), upgradeVersion.String())
 		}
 	case version.UpgradePossible:
 		{
-			verifyStep.Successf("A kyma installation with version '%s' was found. ", currentVersion.String())
+			verifyStep.Successf("A Kyma installation with version '%s' was found. ", currentVersion.String())
 		}
 	}
 

--- a/cmd/kyma/deploy/cmd_test.go
+++ b/cmd/kyma/deploy/cmd_test.go
@@ -51,7 +51,7 @@ func Test_upgkyma2tokyma2_noninteractive(t *testing.T) {
 	w.Close()
 	out, _ := ioutil.ReadAll(r)
 	os.Stdout = captureStdout
-	expectedOutput := "A kyma installation with version '2.0.0' was found. Proceeding with upgrade to 'main' in non-interactive mode."
+	expectedOutput := "A Kyma installation with version '2.0.0' was found. Proceeding with upgrade to 'main' in non-interactive mode."
 	require.Contains(t, string(out), expectedOutput)
 	require.NoError(t, err)
 }
@@ -184,7 +184,7 @@ func Test_upgkymaFootokyma2_noninteractive(t *testing.T) {
 	w.Close()
 	out, _ := ioutil.ReadAll(r)
 	os.Stdout = captureStdout
-	expectedOutput := "A kyma installation with version '12e41ab5' was found. Proceeding with upgrade to '2.0.0' in non-interactive mode."
+	expectedOutput := "A Kyma installation with version '12e41ab5' was found. Proceeding with upgrade to '2.0.0' in non-interactive mode."
 	require.Contains(t, string(out), expectedOutput)
 	require.NoError(t, err)
 }

--- a/cmd/kyma/undeploy/cmd.go
+++ b/cmd/kyma/undeploy/cmd.go
@@ -304,8 +304,8 @@ func (cmd *command) waitForNamespaces() error {
 
 	cmd.NewStep("Waiting for namespace termination")
 
-	timeout := time.After(180 * time.Second)
-	poll := time.Tick(2 * time.Second)
+	timeout := time.After(3 * time.Minute)
+	poll := time.Tick(3 * time.Second)
 	for {
 		select {
 		case <-timeout:

--- a/cmd/kyma/undeploy/cmd.go
+++ b/cmd/kyma/undeploy/cmd.go
@@ -210,10 +210,10 @@ func (cmd *command) removeCustomResourceFinalizers(gvr schema.GroupVersionResour
 }
 
 func (cmd *command) deleteKymaNamespaces() error {
-	step := cmd.NewStep("Deleting Kyma namespaces")
+	step := cmd.NewStep("Deleting Kyma Namespaces")
 
 	if !cmd.NonInteractive && !cmd.CI {
-		if !step.PromptYesNo("This will delete all Kyma namespace resources. Do you want to continue? ") {
+		if !step.PromptYesNo("This will delete all Kyma Namespace resources. Do you want to continue? ") {
 			return errors.New("Undeploy cancelled by user")
 		}
 	}
@@ -228,7 +228,7 @@ func (cmd *command) deleteKymaNamespaces() error {
 			defer wg.Done()
 			err := retry.Do(func() error {
 				if cmd.Verbose {
-					cmd.CurrentStep.Status(fmt.Sprintf("Deleting namespace \"%s\"", ns))
+					cmd.CurrentStep.Status(fmt.Sprintf("Deleting Namespace \"%s\"", ns))
 				}
 
 				if err := cmd.K8s.Static().CoreV1().Namespaces().Delete(context.Background(), ns, metav1.DeleteOptions{}); err != nil && !apierr.IsNotFound(err) {
@@ -242,7 +242,7 @@ func (cmd *command) deleteKymaNamespaces() error {
 					return nil
 				}
 
-				return errors.Wrapf(err, "\"%s\" namespace still exists in \"%s\" Phase", nsT.Name, nsT.Status.Phase)
+				return errors.Wrapf(err, "\"%s\" Namespace still exists in \"%s\" Phase", nsT.Name, nsT.Status.Phase)
 			})
 			if err != nil {
 				errorCh <- err
@@ -250,7 +250,7 @@ func (cmd *command) deleteKymaNamespaces() error {
 			}
 
 			if cmd.Verbose {
-				cmd.CurrentStep.Status(fmt.Sprintf("\"%s\" namespace is removed", ns))
+				cmd.CurrentStep.Status(fmt.Sprintf("\"%s\" Namespace is removed", ns))
 			}
 		}(namespace)
 	}
@@ -269,7 +269,7 @@ func (cmd *command) deleteKymaNamespaces() error {
 			if errWrapped != nil {
 				step.Failure()
 			} else {
-				step.Successf("All Kyma namespaces marked for deletion")
+				step.Successf("All Kyma Namespaces marked for deletion")
 			}
 			return errWrapped
 		case err := <-errorCh:
@@ -286,14 +286,14 @@ func (cmd *command) deleteKymaNamespaces() error {
 
 func (cmd *command) waitForNamespaces() error {
 
-	cmd.NewStep("Waiting for namespace deletion")
+	cmd.NewStep("Waiting for Namespace deletion")
 
 	timeout := time.After(4 * time.Minute)
 	poll := time.Tick(5 * time.Second)
 	for {
 		select {
 		case <-timeout:
-			cmd.CurrentStep.Failuref("Timed out while waiting for deletion of kyma-system namespace")
+			cmd.CurrentStep.Failuref("Timed out while waiting for deletion of Namespace")
 			return errors.New("Timed out")
 		case <-poll:
 			if err := cmd.removeFinalizers(); err != nil {
@@ -328,7 +328,7 @@ func (cmd *command) checkKymaNamespaces() (bool, error) {
 	}
 
 	if namespaceList.Size() == 0 {
-		cmd.CurrentStep.Successf("No remaining Kyma namespaces found")
+		cmd.CurrentStep.Successf("No remaining Kyma Namespaces found")
 		return true, nil
 	}
 
@@ -339,7 +339,7 @@ func (cmd *command) checkKymaNamespaces() (bool, error) {
 		}
 	}
 
-	cmd.CurrentStep.Successf("No remaining Kyma namespaces found")
+	cmd.CurrentStep.Successf("No remaining Kyma Namespaces found")
 
 	return true, nil
 }

--- a/cmd/kyma/undeploy/cmd.go
+++ b/cmd/kyma/undeploy/cmd.go
@@ -293,7 +293,7 @@ func (cmd *command) waitForNamespaces() error {
 	for {
 		select {
 		case <-timeout:
-			cmd.CurrentStep.Failuref("Timed out while waiting for deletion of Namespace")
+			cmd.CurrentStep.Failuref("Timed out while waiting for Namespace deletion")
 			return errors.New("Timed out")
 		case <-poll:
 			if err := cmd.removeFinalizers(); err != nil {

--- a/cmd/kyma/undeploy/cmd.go
+++ b/cmd/kyma/undeploy/cmd.go
@@ -286,7 +286,7 @@ func (cmd *command) deleteKymaNamespaces() error {
 
 func (cmd *command) waitForNamespaces() error {
 
-	cmd.NewStep("Waiting for namespace termination")
+	cmd.NewStep("Waiting for namespace deletion")
 
 	timeout := time.After(4 * time.Minute)
 	poll := time.Tick(5 * time.Second)

--- a/cmd/kyma/undeploy/cmd.go
+++ b/cmd/kyma/undeploy/cmd.go
@@ -293,7 +293,7 @@ func (cmd *command) waitForNamespaces() error {
 	for {
 		select {
 		case <-timeout:
-			cmd.CurrentStep.Failuref("Timed out when waiting for deletion of kyma-system namespace")
+			cmd.CurrentStep.Failuref("Timed out while waiting for deletion of kyma-system namespace")
 			return errors.New("Timed out")
 		case <-poll:
 			if err := cmd.removeFinalizers(); err != nil {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Since kyma-system namespace stays in Terminating state for some time when deleted during `undeploy`, it should wait and run until the namespace is not found anymore

Changes proposed in this pull request:

- When waiting for kyma-system namespaces to be terminated, also remove finalizers
- Times out after 4 minutes
- Add prompt for user confirmation if not `ci` and not `non-interactive`

**Related issue(s)**
* https://github.com/kyma-project/cli/issues/1006
