### PR TITLE
Remove import certs from deploy time

### DIFF
--- a/cmd/kyma/deploy/cmd.go
+++ b/cmd/kyma/deploy/cmd.go
@@ -135,11 +135,13 @@ func (cmd *command) Run(o *Options) error {
 		return err
 	}
 
+	deployTime := time.Since(start)
+
 	if err := cmd.importCertificate(); err != nil {
 		return err
 	}
 
-	return cmd.printSummary(vs, time.Since(start))
+	return cmd.printSummary(vs, deployTime)
 }
 
 func (cmd *command) deployKyma(l *zap.SugaredLogger, components component.List) error {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The time for Kyma how long the deployment took gets printed in the summary, this also includes the question if the user wants to import the certificates. With this PR importing certificates will not be considered to this time any more.
Reasons for that are if a user does not pay attention to the install and answers the question after i.e. 10 min, the summary tells the user that the deployment took "deployment time" + 10min because it needed to wait for user input.

This can be changed using this PR.
