### PR TITLE
Increase undeploy default timeout and provide flag

### DIFF
--- a/cmd/kyma/undeploy/cmd.go
+++ b/cmd/kyma/undeploy/cmd.go
@@ -57,6 +57,7 @@ func NewCmd(o *Options) *cobra.Command {
 	}
 
 	cobraCmd.Flags().BoolVarP(&o.KeepCRDs, "keep-crds", "", false, "Set --keep-crds=true to keep CRDs on clean-up")
+	cobraCmd.Flags().DurationVarP(&o.Timeout, "timeout", "", 6*time.Minute, "Maximum time for the deletion")
 	return cobraCmd
 }
 
@@ -288,8 +289,8 @@ func (cmd *command) waitForNamespaces() error {
 
 	cmd.NewStep("Waiting for Namespace deletion")
 
-	timeout := time.After(4 * time.Minute)
-	poll := time.Tick(5 * time.Second)
+	timeout := time.After(cmd.opts.Timeout)
+	poll := time.Tick(6 * time.Second)
 	for {
 		select {
 		case <-timeout:

--- a/cmd/kyma/undeploy/opts.go
+++ b/cmd/kyma/undeploy/opts.go
@@ -2,12 +2,14 @@ package undeploy
 
 import (
 	"github.com/kyma-project/cli/internal/cli"
+	"time"
 )
 
 //Options defines available options for the command
 type Options struct {
 	*cli.Options
 	KeepCRDs bool
+	Timeout time.Duration
 }
 
 //NewOptions creates options with default values


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Increase the default timeout for `undeploy` to 6 minutes
- Provide a flag to set a timeout value

**Related issue(s)**
* https://github.com/kyma-project/cli/issues/1006
