### PR TITLE
provision k3d: use k3d v4 instead of v5

### DIFF
--- a/cmd/kyma/provision/k3d/opts.go
+++ b/cmd/kyma/provision/k3d/opts.go
@@ -13,8 +13,8 @@ type Options struct {
 	Name              string
 	Workers           int
 	Timeout           time.Duration
-	K3sArgs           []string
-	UseRegistry       []string
+	ServerArgs        []string
+	AgentArgs         []string
 	K3dArgs           []string
 	KubernetesVersion string
 	PortMapping       []string

--- a/docs/gen-docs/kyma_provision.md
+++ b/docs/gen-docs/kyma_provision.md
@@ -24,6 +24,6 @@ Provisions a cluster for Kyma installation.
 * [kyma provision aks](#kyma-provision-aks-kyma-provision-aks)	 - Provisions an Azure Kubernetes Service (AKS) cluster on Azure.
 * [kyma provision gardener](#kyma-provision-gardener-kyma-provision-gardener)	 - Provisions a cluster using Gardener on GCP, Azure, or AWS.
 * [kyma provision gke](#kyma-provision-gke-kyma-provision-gke)	 - Provisions a Google Kubernetes Engine (GKE) cluster on Google Cloud Platform (GCP).
-* [kyma provision k3d](#kyma-provision-k3d-kyma-provision-k3d)	 - Provisions a Kubernetes cluster based on k3d v5.
+* [kyma provision k3d](#kyma-provision-k3d-kyma-provision-k3d)	 - Provisions a Kubernetes cluster based on k3d v4.
 * [kyma provision minikube](#kyma-provision-minikube-kyma-provision-minikube)	 - [DEPRECATED] Provisions Minikube.
 

--- a/docs/gen-docs/kyma_provision_k3d.md
+++ b/docs/gen-docs/kyma_provision_k3d.md
@@ -2,7 +2,7 @@
 title: kyma provision k3d
 ---
 
-Provisions a Kubernetes cluster based on k3d v5.
+Provisions a Kubernetes cluster based on k3d v4.
 
 ## Synopsis
 
@@ -15,14 +15,14 @@ kyma provision k3d [flags]
 ## Flags
 
 ```bash
-      --k3d-arg strings        One or more arguments passed to the k3d provisioning command (e.g. --k3d-arg='--no-rollback')
-  -s, --k3s-arg strings        One or more arguments passed from k3d to the k3s command (format: ARG@NODEFILTER[;@NODEFILTER])
-  -k, --kube-version string    Kubernetes version of the cluster (default "1.20.11")
-      --name string            Name of the Kyma cluster (default "kyma")
-  -p, --port strings           Map ports 80 and 443 of K3D loadbalancer (e.g. -p 80:80@loadbalancer -p 443:443@loadbalancer) (default [80:80@loadbalancer,443:443@loadbalancer])
-      --registry-use strings   Connect to one or more k3d-managed registries. Kyma automatically creates a registry for serverless images.
-      --timeout duration       Maximum time for the provisioning. If you want no timeout, enter "0". (default 5m0s)
-      --workers int            Number of worker nodes (k3d agents) (default 1)
+  -a, --agent-arg strings     One or more arguments passed to the k3d agent command on agent nodes (e.g. --agent-arg='--alsologtostderr')
+      --k3d-arg strings       One or more arguments passed to the k3d provisioning command (e.g. --k3d-arg='--no-rollback')
+  -k, --kube-version string   Kubernetes version of the cluster (default "1.20.11")
+      --name string           Name of the Kyma cluster (default "kyma")
+  -p, --port strings          Map ports 80 and 443 of K3D loadbalancer (e.g. -p 80:80@loadbalancer -p 443:443@loadbalancer) (default [80:80@loadbalancer,443:443@loadbalancer])
+  -s, --server-arg strings    One or more arguments passed to the Kubernetes API server (e.g. --server-arg='--alsologtostderr')
+      --timeout duration      Maximum time for the provisioning. If you want no timeout, enter "0". (default 5m0s)
+      --workers int           Number of worker nodes (k3d agents) (default 1)
 ```
 
 ## Flags inherited from parent commands


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Revert previous upgrade to k3d v5 of `kyma provision k3d` command back to k3d v4

**Related issue(s)**
See #1052 
