### PR TITLE
Fix 1.24.7 release blocker

### DIFF
--- a/pkg/installation/utils_test.go
+++ b/pkg/installation/utils_test.go
@@ -5,16 +5,8 @@ import (
 	"path"
 	"testing"
 
-	stepMocks "github.com/kyma-project/cli/pkg/step/mocks"
 	"github.com/stretchr/testify/require"
 )
-
-func Test_GetLatestAvailableMainHash(t *testing.T) {
-	t.Parallel()
-	h, err := getLatestAvailableMainHash(&stepMocks.Step{}, 5, true)
-	require.NoError(t, err)
-	require.True(t, isHex(h))
-}
 
 func Test_LoadInstallationFiles(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Kyma 1.* CLI is not compatible with Kyma main anymore and can only install Kyma release-1.* branches. Just removing the test since it does not make sense to fix it properly due to the fact that Kyma 1.* CLI will be sunset soon.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
