### PR TITLE
Fix deploying local source without explicit GOPATH

### DIFF
--- a/cmd/kyma/deploy/opts.go
+++ b/cmd/kyma/deploy/opts.go
@@ -50,11 +50,16 @@ func (o *Options) ResolveLocalWorkspacePath() (string, error) {
 	if o.Source == VersionLocal && o.WorkspacePath == defaultWorkspacePath {
 		//use Kyma sources stored in GOPATH (if they exist)
 		goPath := os.Getenv("GOPATH")
-		if goPath != "" {
-			kymaPath := filepath.Join(goPath, "src", "github.com", "kyma-project", "kyma")
-			if o.pathExists(kymaPath, "Local Kyma source directory") == nil {
-				return kymaPath, nil
+		if goPath == "" {
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				return "", err
 			}
+			goPath = filepath.Join(homeDir, "go")
+		}
+		kymaPath := filepath.Join(goPath, "src", "github.com", "kyma-project", "kyma")
+		if o.pathExists(kymaPath, "Local Kyma source directory") == nil {
+			return kymaPath, nil
 		}
 	}
 


### PR DESCRIPTION
Use $HOME/go to search kyma source if $GOPATH is unset when deploying
Kyma with -s local set.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

Fixes #1057