### PR TITLE
dashboard cmd: open current cluster automatically

### DIFF
--- a/cmd/kyma/dashboard/cmd.go
+++ b/cmd/kyma/dashboard/cmd.go
@@ -120,7 +120,6 @@ func (cmd *command) runDashboardContainer(dashboardURL, kubeconfigPath, kubeconf
 		cmd.Finalizers.Add(dockerWrapper.Stop(followCtx, id, func(i ...interface{}) { fmt.Print(i...) }))
 		return dockerWrapper.ContainerFollowRun(followCtx, id)
 	}
-
 	return nil
 }
 

--- a/cmd/kyma/dashboard/cmd.go
+++ b/cmd/kyma/dashboard/cmd.go
@@ -120,6 +120,7 @@ func (cmd *command) runDashboardContainer(dashboardURL, kubeconfigPath, kubeconf
 		cmd.Finalizers.Add(dockerWrapper.Stop(followCtx, id, func(i ...interface{}) { fmt.Print(i...) }))
 		return dockerWrapper.ContainerFollowRun(followCtx, id)
 	}
+
 	return nil
 }
 

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/cli/cli/streams"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	docker "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/archive"
@@ -81,6 +82,7 @@ type ContainerRunOpts struct {
 	ContainerName string
 	Envs          []string
 	Image         string
+	Mounts        []mount.Mount
 	Ports         map[string]string
 }
 
@@ -220,6 +222,7 @@ func (w *dockerWrapper) PullImageAndStartContainer(ctx context.Context, opts Con
 	hostConfig := &container.HostConfig{
 		PortBindings: portMap(opts.Ports),
 		AutoRemove:   true,
+		Mounts:       opts.Mounts,
 	}
 
 	var r io.ReadCloser

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/cli/cli/config/types"
 	imageTypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/go-connections/nat"
 	"github.com/kyma-project/cli/pkg/docker/mocks"
@@ -188,7 +189,7 @@ func Test_mapMap(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
-func Test_PullImageAndStartContainergst(t *testing.T) {
+func Test_PullImageAndStartContainer(t *testing.T) {
 	mockDocker := &mocks.Client{}
 	mockWrapper := dockerWrapper{Docker: mockDocker}
 
@@ -196,7 +197,14 @@ func Test_PullImageAndStartContainergst(t *testing.T) {
 		ContainerName: "container-name",
 		Envs:          nil,
 		Image:         "valid-image",
-		Ports:         map[string]string{"3000": "3001"},
+		Mounts: []mount.Mount{
+			{
+				Type:   mount.TypeBind,
+				Source: "valid/source/path",
+				Target: "valid/target/path",
+			},
+		},
+		Ports: map[string]string{"3000": "3001"},
 	}
 	testContainerID := "container-id-123"
 	testErr := errors.New("container create and start error")


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- mount the kubeconfig into the busola docker container
- call busola with the kubeConfigID parameter to automatically open the current cluster

**Related issue(s)**
https://github.com/kyma-project/cli/issues/1066
