### PR TITLE
dashboard cmd: print only error logs in non-verbose mode

### DIFF
--- a/cmd/kyma/dashboard/opts.go
+++ b/cmd/kyma/dashboard/opts.go
@@ -10,7 +10,6 @@ import (
 type Options struct {
 	*cli.Options
 	ContainerName string
-	Detach        bool
 	Port          string
 }
 

--- a/docs/gen-docs/kyma_dashboard.md
+++ b/docs/gen-docs/kyma_dashboard.md
@@ -16,7 +16,6 @@ kyma dashboard [flags]
 
 ```bash
       --container-name string   Specify the name of the local container. (default "busola")
-  -d, --detach                  Change this flag to "true" if you don't want to follow the logs of the local container.
   -p, --port string             Specify the port on which the local dashboard will be exposed. (default "3001")
 ```
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- In non-verbose mode, set `NODE_ENV=development` which results in printing only error logs from the `busola` container.
- Remove `detach` flag, as `verbose` flag can already be used to decide whether to have extensive logs from the `busola` container or not.
- Ensure that the `busola` container will be removed after the command is terminated in all cases and not only when the `detach` flag was set to false.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
