### PR TITLE
alpha provision k3d: use k3d v5.1.0

### DIFF
--- a/cmd/kyma/alpha/provision/k3d/cmd.go
+++ b/cmd/kyma/alpha/provision/k3d/cmd.go
@@ -40,7 +40,7 @@ func NewCmd(o *Options) *cobra.Command {
 	cmd.Flags().StringSliceVarP(&o.K3sArgs, "k3s-arg", "s", []string{}, "One or more arguments passed from k3d to the k3s command (format: ARG@NODEFILTER[;@NODEFILTER])")
 	cmd.Flags().DurationVar(&o.Timeout, "timeout", 5*time.Minute, `Maximum time for the provisioning. If you want no timeout, enter "0".`)
 	cmd.Flags().StringSliceVarP(&o.K3dArgs, "k3d-arg", "", []string{}, "One or more arguments passed to the k3d provisioning command (e.g. --k3d-arg='--no-rollback')")
-	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.20.11", "Kubernetes version of the cluster")
+	cmd.Flags().StringVarP(&o.MinorKubernetesVersion, "kube-version", "k", "1.20", "Minor Kubernetes version of the cluster")
 	cmd.Flags().StringSliceVar(&o.UseRegistry, "registry-use", []string{}, "Connect to one or more k3d-managed registries. Kyma automatically creates a registry for serverless images.")
 	cmd.Flags().StringVar(&o.RegistryPort, "registry-port", "5001", "Specify the port on which the k3d registry will be exposed")
 	cmd.Flags().StringSliceVarP(&o.PortMapping, "port", "p", []string{"80:80@loadbalancer", "443:443@loadbalancer"}, "Map ports 80 and 443 of K3D loadbalancer (e.g. -p 80:80@loadbalancer -p 443:443@loadbalancer)")
@@ -168,7 +168,7 @@ func (c *command) createK3dCluster(k3dClient k3d.Client, registryURL string) err
 
 	settings := k3d.CreateClusterSettings{
 		Args:              parseK3dArgs(c.opts.K3dArgs),
-		KubernetesVersion: c.opts.KubernetesVersion,
+		KubernetesVersion: c.opts.MinorKubernetesVersion,
 		PortMapping:       c.opts.PortMapping,
 		Workers:           c.opts.Workers,
 		V5Settings: k3d.V5CreateClusterSettings{

--- a/cmd/kyma/alpha/provision/k3d/opts.go
+++ b/cmd/kyma/alpha/provision/k3d/opts.go
@@ -10,15 +10,15 @@ import (
 type Options struct {
 	*cli.Options
 
-	Name              string
-	Workers           int
-	Timeout           time.Duration
-	K3sArgs           []string
-	UseRegistry       []string
-	RegistryPort      string
-	K3dArgs           []string
-	KubernetesVersion string
-	PortMapping       []string
+	Name                   string
+	Workers                int
+	Timeout                time.Duration
+	K3sArgs                []string
+	UseRegistry            []string
+	RegistryPort           string
+	K3dArgs                []string
+	MinorKubernetesVersion string
+	PortMapping            []string
 }
 
 //NewOptions creates options with default values

--- a/docs/gen-docs/kyma_alpha_provision_k3d.md
+++ b/docs/gen-docs/kyma_alpha_provision_k3d.md
@@ -17,7 +17,7 @@ kyma alpha provision k3d [flags]
 ```bash
       --k3d-arg strings        One or more arguments passed to the k3d provisioning command (e.g. --k3d-arg='--no-rollback')
   -s, --k3s-arg strings        One or more arguments passed from k3d to the k3s command (format: ARG@NODEFILTER[;@NODEFILTER])
-  -k, --kube-version string    Kubernetes version of the cluster (default "1.20.11")
+  -k, --kube-version string    Minor Kubernetes version of the cluster (default "1.20")
       --name string            Name of the Kyma cluster (default "kyma")
   -p, --port strings           Map ports 80 and 443 of K3D loadbalancer (e.g. -p 80:80@loadbalancer -p 443:443@loadbalancer) (default [80:80@loadbalancer,443:443@loadbalancer])
       --registry-port string   Specify the port on which the k3d registry will be exposed (default "5001")

--- a/internal/k3d/k3d.go
+++ b/internal/k3d/k3d.go
@@ -308,16 +308,15 @@ func getK3sImageForV4(kubernetesVersion string) (string, error) {
 	return fmt.Sprintf("rancher/k3s:v%s-k3s1", kubernetesVersion), nil
 }
 
-// getK3sImageForV5 only takes the major version of kubernetes and transform it to a k3s image tag from the channelserver (See https://update.k3s.io/v1-release/channels).
+// getK3sImageForV5 parses the given Kubernetes version into a corresponding k3s image tag.
 func getK3sImageForV5(kubernetesVersion string) (string, error) {
-	// we need to use the `ParseTolerant` function as the `Parse` function failes when there is no patch version specified.
+	// using the `ParseTolerant` function as the `Parse` function fails when there is no patch version specified
 	semVer, err := semver.ParseTolerant(kubernetesVersion)
 	if err != nil {
 		return "", fmt.Errorf("Invalid Kubernetes version %v: %v", kubernetesVersion, err)
 	}
 
-	// if there was a patch version specified in the Kubernetes version, warn the user that this patch version is not considered by k3d.
-	// if no patch version was specified, the `ParseTolerant` function will add a 0
+	// printing a warning to the user if there was a patch version specified in the Kubernetes version
 	if semVer.Patch != 0 {
 		fmt.Printf("WARNING: The specified Kubernetes patch version (%d) will not be considered. k3d will use the latest available patch version of the specified Kubernetes minor version.", semVer.Patch)
 	}

--- a/internal/k3d/k3d.go
+++ b/internal/k3d/k3d.go
@@ -123,7 +123,7 @@ func (c *client) checkVersion(minRequiredVersion string) error {
 		return fmt.Errorf(incompatibleMajorVersionMsg, binarySemVersion.Major, minRequiredSemVersion.Major)
 	} else if binarySemVersion.LT(minRequiredSemVersion) {
 		incompatibleVersionMsg := "You are using an unsupported k3d version '%s'. The supported k3d version for this command is >= '%s'."
-		return fmt.Errorf(incompatibleVersionMsg, binaryVersion, minRequiredSemVersion)
+		return fmt.Errorf(incompatibleVersionMsg, binarySemVersion, minRequiredSemVersion)
 	}
 
 	return nil

--- a/internal/k3d/k3d_test.go
+++ b/internal/k3d/k3d_test.go
@@ -32,7 +32,7 @@ func (suite *V5TestSuite) SetupTest() {
 func (suite *V5TestSuite) TestVerifyStatus() {
 	suite.mockPathLooker.On("Look", "k3d").Return("", nil)
 
-	suite.mockCmdRunner.On("Run", mock.Anything, "k3d", "version").Return("k3d version v5.0.0\nk3s version v1.21.5-k3s2 (default)", nil)
+	suite.mockCmdRunner.On("Run", mock.Anything, "k3d", "version").Return("k3d version v5.1.0\nk3s version v1.21.5-k3s2 (default)", nil)
 
 	suite.mockCmdRunner.On("Run", mock.Anything, "k3d", "cluster", "list").Return("", nil)
 

--- a/internal/k3d/k3d_test.go
+++ b/internal/k3d/k3d_test.go
@@ -131,7 +131,7 @@ func (suite *V5TestSuite) TestRegistryExistsFalse() {
 func (suite *V5TestSuite) TestCreateCluster() {
 	settings := CreateClusterSettings{
 		Args:              []string{"--verbose"},
-		KubernetesVersion: "1.20.11",
+		KubernetesVersion: "1.20",
 		PortMapping:       []string{"80:80@loadbalancer", "443:443@loadbalancer"},
 		Workers:           0,
 		V5Settings: V5CreateClusterSettings{
@@ -144,7 +144,7 @@ func (suite *V5TestSuite) TestCreateCluster() {
 		"--kubeconfig-update-default",
 		"--timeout", "5s",
 		"--agents", "0",
-		"--image", "rancher/k3s:v1.20.11-k3s1",
+		"--image", "+v1.20",
 		"--kubeconfig-switch-context",
 		"--k3s-arg", "--disable=traefik@server:0",
 		"--registry-use", "k3d-own-registry:5001",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- k3d v5.1.0 has a nice feature where it is only necessary to specify the kubernetes minor version and k3d automatically will use the latest patch version of this minor version. E.g. if you specify `1.19`, k3d uses the version `1.19.16`. 


**Related issue(s)**
