### PR TITLE
fixed windows binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ build-windows:
 
 .PHONY: build-windows-arm
 build-windows-arm:
-	CGO_ENABLED=0 GOOS=windows GOARCH=arm go build -o ./bin/kyma.exe $(FLAGS) ./cmd
+	CGO_ENABLED=0 GOOS=windows GOARCH=arm go build -o ./bin/kyma-arm.exe $(FLAGS) ./cmd
 
 .PHONY: build-linux
 build-linux:

--- a/README.md
+++ b/README.md
@@ -80,6 +80,6 @@ Kyma CLI is used in CI jobs that install or test Kyma or provision clusters. To 
 To download the binaries, run:
 
 ```bash
-curl -Lo kyma https://storage.googleapis.com/kyma-cli-stable/kyma-darwin # kyma-linux, kyma-linux-arm, kyma.exe or kyma-arm.exe
+curl -Lo kyma https://storage.googleapis.com/kyma-cli-stable/kyma-darwin # kyma-linux, kyma-linux-arm, kyma.exe, or kyma-arm.exe
 chmod +x kyma
 ```

--- a/README.md
+++ b/README.md
@@ -80,6 +80,6 @@ Kyma CLI is used in CI jobs that install or test Kyma or provision clusters. To 
 To download the binaries, run:
 
 ```bash
-curl -Lo kyma https://storage.googleapis.com/kyma-cli-stable/kyma-darwin # kyma-linux or kyma.exe
+curl -Lo kyma https://storage.googleapis.com/kyma-cli-stable/kyma-darwin # kyma-linux, kyma-linux-arm, kyma.exe or kyma-arm.exe
 chmod +x kyma
 ```


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The common `make build` target to build all CLI binaries produced an ARM based windows binary only. Using the dedicated `make build windows` works fine. As the common target seem to be used for the stable binary, the windows binary works only on ARM.

Changes proposed in this pull request:

- ARM target should produce a binary named specific for ARM
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
