### PR TITLE
provision k3d: print hint in 'permission denied to allocate ports' scenario

### DIFF
--- a/cmd/kyma/provision/k3d/cmd.go
+++ b/cmd/kyma/provision/k3d/cmd.go
@@ -124,6 +124,9 @@ func (c *command) verifyK3dStatus(k3dClient k3d.Client) error {
 	} else {
 		if err := allocatePorts(ports...); err != nil {
 			s.Failure()
+			if strings.Contains(err.Error(), "bind: permission denied") {
+				s.LogInfo("Hint: The following error can potentially be mitigated by either running the command with `sudo` privileges or specifying other ports with the `--port` flag:")
+			}
 			return errors.Wrap(err, "Port cannot be allocated")
 		}
 		if registryExists {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Prints a hint when the user encounters an error in k3d provisioning

**Related issue(s)**
See also #1123 
