### PR TITLE
undeploy: setup istioctl before undeploy

### DIFF
--- a/cmd/kyma/deploy/cmd.go
+++ b/cmd/kyma/deploy/cmd.go
@@ -149,7 +149,7 @@ func (cmd *command) run() error {
 		return err
 	}
 
-	err = cmd.installPrerequisites(ws.WorkspaceDir)
+	err = cmd.initialSetup(ws.WorkspaceDir)
 	if err != nil {
 		return err
 	}
@@ -293,8 +293,8 @@ func (cmd *command) decideVersionUpgrade() error {
 	return nil
 }
 
-func (cmd *command) installPrerequisites(wsp string) error {
-	preReqStep := cmd.NewStep("Installing Prerequisites")
+func (cmd *command) initialSetup(wsp string) error {
+	preReqStep := cmd.NewStep("Initial setup")
 
 	istio, err := istioctl.New(wsp)
 	if err != nil {
@@ -305,7 +305,7 @@ func (cmd *command) installPrerequisites(wsp string) error {
 		return err
 	}
 
-	preReqStep.Successf("Installed Prerequisites")
+	preReqStep.Success()
 	return nil
 }
 

--- a/internal/deploy/istioctl/istio.go
+++ b/internal/deploy/istioctl/istio.go
@@ -6,9 +6,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
-	"github.com/kyma-project/cli/internal/files"
-	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -17,11 +14,15 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/kyma-project/cli/internal/files"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
 )
 
 const defaultIstioChartPath = "/resources/istio-configuration/Chart.yaml"
 const archSupport = "1.6"
-const environmentVariable = "ISTIOCTL_PATH"
+const envVar = "ISTIOCTL_PATH"
 const dirName = "istio"
 const binName = "istioctl"
 const winBinName = "istioctl.exe"
@@ -62,7 +63,6 @@ type Installation struct {
 	IstioChartPath string
 	Client         HTTPClient
 	kymaHome       string
-	environmentVar string
 	istioVersion   string
 	osExt          string
 	istioArch      string
@@ -87,7 +87,6 @@ func New(workspacePath string) (Installation, error) {
 		IstioChartPath: defaultIstioChartPath,
 		Client:         &http.Client{},
 		kymaHome:       kymaHome,
-		environmentVar: environmentVariable,
 		archSupport:    archSupport,
 		dirName:        dirName,
 		binName:        binName,
@@ -243,10 +242,10 @@ func (i *Installation) extractIstio() error {
 }
 
 func (i *Installation) exportEnvVar() error {
-	if i.environmentVar == "" || i.binPath == "" {
-		return errors.New("envVar or binPath empty")
+	if i.binPath == "" {
+		return errors.New("failed exporting istioctl envvar: binPath empty")
 	}
-	if err := os.Setenv(i.environmentVar, i.binPath); err != nil {
+	if err := os.Setenv(envVar, i.binPath); err != nil {
 		return err
 	}
 	return nil

--- a/internal/deploy/workspace_test.go
+++ b/internal/deploy/workspace_test.go
@@ -13,12 +13,14 @@ func TestResolveWorkspace(t *testing.T) {
 		ws := path.Join("dummyWS")
 		err := os.Mkdir(ws, 0700)
 		require.NoError(t, err)
+		defer func() {
+			err := os.Remove(ws)
+			require.NoError(t, err)
+		}()
 		wsp, err := ResolveLocalWorkspacePath(ws, true)
 		require.NoError(t, err)
 		require.Equal(t, ws, wsp)
 		err = pathExists(ws, "dummy ws path")
-		require.NoError(t, err)
-		err = os.Remove(ws)
 		require.NoError(t, err)
 	})
 


### PR DESCRIPTION
**Description**

- Istioctl is now configured properly on undeploy
- Simplified env var resolution
- Changed "Installing prerequisites" step to "Initial setup" so it does not get confused with prerequisites installation on the reconciler.


**Related issue(s)**
#1130
