### PR TITLE
dashboard cmd: support local clusters on linux

### DIFF
--- a/cmd/kyma/dashboard/cmd.go
+++ b/cmd/kyma/dashboard/cmd.go
@@ -131,7 +131,7 @@ func (cmd *command) initContainerRunOpts(envs []string) (docker.ContainerRunOpts
 
 	if runtime.GOOS == "linux" {
 		if cmd.Verbose {
-			fmt.Printf("Operating System seems to be linux. Changing the Docker network mode to 'host'")
+			fmt.Printf("Operating system seems to be Linux. Changing the Docker network mode to 'host'")
 		}
 		containerRunOpts.NetworkMode = "host"
 	}

--- a/cmd/kyma/dashboard/cmd.go
+++ b/cmd/kyma/dashboard/cmd.go
@@ -3,6 +3,7 @@ package dashboard
 import (
 	"context"
 	"fmt"
+	"runtime"
 
 	"github.com/docker/docker/api/types/mount"
 	"github.com/kyma-project/cli/internal/cli"
@@ -126,6 +127,13 @@ func (cmd *command) initContainerRunOpts(envs []string) (docker.ContainerRunOpts
 			},
 		}
 		dashboardURL = fmt.Sprintf("%s?kubeconfigID=%s", dashboardURL, containerKubeconfigFilename)
+	}
+
+	if runtime.GOOS == "linux" {
+		if cmd.Verbose {
+			fmt.Printf("Operating System seems to be linux. Changing the Docker network mode to 'host'")
+		}
+		containerRunOpts.NetworkMode = "host"
 	}
 
 	return containerRunOpts, dashboardURL

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -83,6 +83,7 @@ type ContainerRunOpts struct {
 	Envs          []string
 	Image         string
 	Mounts        []mount.Mount
+	NetworkMode   string
 	Ports         map[string]string
 }
 
@@ -223,6 +224,7 @@ func (w *dockerWrapper) PullImageAndStartContainer(ctx context.Context, opts Con
 		PortBindings: portMap(opts.Ports),
 		AutoRemove:   true,
 		Mounts:       opts.Mounts,
+		NetworkMode:  container.NetworkMode(opts.NetworkMode),
 	}
 
 	var r io.ReadCloser


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- start busola with the docker network flag in order to use the dashboard cmd with local clusters running on linux


**Related issue(s)**
Fixes #1127 
