### PR TITLE
fix CLI version for non-release is always 'stable'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,3 +97,4 @@ ci-main: resolve validate build test integration-test upload-binaries
 
 .PHONY: ci-release
 ci-release: resolve validate build test integration-test archive release
+

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 .DEFAULT_GOAL := local
 
 ifndef VERSION
-	VERSION=${shell git rev-parse --abbrev-ref HEAD}-${shell git rev-parse --short HEAD} # branch-commit_hash
-endif
-
-ifeq (${shell git rev-list -n 1 tags/stable},${shell git rev-parse HEAD}) # if stable tag is the same as current commit
-	VERSION = stable-${shell git rev-parse --short HEAD}
+	ifeq (${shell git rev-list -n 1 tags/stable},${shell git rev-parse HEAD}) # if stable tag is the same as current commit
+		VERSION = stable-${shell git rev-parse --short HEAD}
+	else
+		VERSION = ${shell git rev-parse --abbrev-ref HEAD}-${shell git rev-parse --short HEAD} # branch-commit_hash
+	endif
 endif
 
 FLAGS = -ldflags '-s -w -X github.com/kyma-project/cli/cmd/kyma/version.Version=$(VERSION)'
@@ -97,4 +97,3 @@ ci-main: resolve validate build test integration-test upload-binaries
 
 .PHONY: ci-release
 ci-release: resolve validate build test integration-test archive release
-

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 .DEFAULT_GOAL := local
 
 ifndef VERSION
-	ifeq (${shell git rev-list -n 1 tags/stable},${shell git rev-parse HEAD}) # if stable tag is the same as current commit
-		VERSION = stable-${shell git rev-parse --short HEAD}
-	else
-		VERSION = ${shell git rev-parse --abbrev-ref HEAD}-${shell git rev-parse --short HEAD} # branch-commit_hash
+	VERSION = ${shell git rev-parse --abbrev-ref HEAD}-${shell git rev-parse --short HEAD}
+
+	ifneq (${shell git tag -l "stable"},) # if there is a stable tag
+		ifeq (${shell git rev-list -n 1 tags/stable},${shell git rev-parse HEAD}) # if stable tag is the same as current commit
+			VERSION = stable-${shell git rev-parse --short HEAD}
+		endif
 	endif
 endif
 
@@ -97,4 +99,3 @@ ci-main: resolve validate build test integration-test upload-binaries
 
 .PHONY: ci-release
 ci-release: resolve validate build test integration-test archive release
-

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .DEFAULT_GOAL := local
 
 ifndef VERSION
-	VERSION = ${shell git describe --tags --always}
+	VERSION=${shell git rev-parse --abbrev-ref HEAD}-${shell git rev-parse --short HEAD} # branch-commit_hash
 endif
 
-ifeq ($(VERSION),stable)
+ifeq (${shell git rev-list -n 1 tags/stable},${shell git rev-parse HEAD}) # if stable tag is the same as current commit
 	VERSION = stable-${shell git rev-parse --short HEAD}
 endif
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- change CLI version for non-releases to the pattern `<branch-name>-<commit-hash>`
- if the current commit has the stable tag, the CLI version should be the same as before: `stable-<commit-hash>`

**Related issue(s)**
Fixes #1147 
