### PR TITLE
Review fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/kyma-incubator/hydroform/function v0.0.0-20211013085232-f50b80b24d73
 	github.com/kyma-incubator/hydroform/install v0.0.0-20200922142757-cae045912c90
 	github.com/kyma-incubator/hydroform/provision v0.0.0-20210514061348-c71b69cb362e
-	github.com/kyma-incubator/reconciler v0.0.0-20220124224059-93ada2af830d
+	github.com/kyma-incubator/reconciler v0.0.0-20220126114301-0c29fec244d9
 	github.com/kyma-project/kyma/components/kyma-operator v0.0.0-20201125092745-687c943ac940
 	github.com/opencontainers/image-spec v1.0.1
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8

--- a/go.sum
+++ b/go.sum
@@ -1235,6 +1235,8 @@ github.com/kyma-incubator/hydroform/provision v0.0.0-20210514061348-c71b69cb362e
 github.com/kyma-incubator/hydroform/provision v0.0.0-20210514061348-c71b69cb362e/go.mod h1:x4YfWgupo4fc7vgGFb0aJfSWCh9W72ipmNekfY1oYeo=
 github.com/kyma-incubator/reconciler v0.0.0-20220124224059-93ada2af830d h1:RSt+mV/pwcPRQpwOP2WzOM+REmbdQO311sTk3OWGmyY=
 github.com/kyma-incubator/reconciler v0.0.0-20220124224059-93ada2af830d/go.mod h1:WTE1Tn9465gBcalCCSMR4JIjFOfUu8OaXQiUlJb0ewU=
+github.com/kyma-incubator/reconciler v0.0.0-20220126114301-0c29fec244d9 h1:CDdpWECprXJNZlt3PM2avlY5oJs5ZfT4m40tHADVEdU=
+github.com/kyma-incubator/reconciler v0.0.0-20220126114301-0c29fec244d9/go.mod h1:WTE1Tn9465gBcalCCSMR4JIjFOfUu8OaXQiUlJb0ewU=
 github.com/kyma-project/kyma/components/kyma-operator v0.0.0-20200817094157-8392259f5be1/go.mod h1:Svisep1qUjML69qtRee5OcDOpWVjxID2Nb6E/xyhQ5k=
 github.com/kyma-project/kyma/components/kyma-operator v0.0.0-20201125092745-687c943ac940 h1:TEquDCgUClhTnSIOc3oZn1YZ53/aK4mu3AwXu6kih+4=
 github.com/kyma-project/kyma/components/kyma-operator v0.0.0-20201125092745-687c943ac940/go.mod h1:jDvGQt3ccmrDW/9dZufC8e4xwr+PUTR74IJ0yQ81Jhk=


### PR DESCRIPTION
**Description**

Bump reconciler version
Changes in reconciler introduced with this pull request:

- Don't reconcile jobs (#718)
- Remove orphaned NATS pods when upgrading Kyma from 1.X to 2.X (#711)
- Drop CR finalizers (#712)
- Fix cleaner component order to run before CRDs (#717)
- Fix Flaky Parallel Tests (#673)
- Add config for delete strategy (#709)
- Upgrade to latest Golang image (#688)

**Related issue(s)**
Look into [reconciler repository](https://github.com/kyma-incubator/reconciler) for PR's listed above for details.