### PR TITLE
Ensure non-zero exit code on timeout

### DIFF
--- a/cmd/kyma/deploy/cmd.go
+++ b/cmd/kyma/deploy/cmd.go
@@ -94,9 +94,10 @@ func (cmd *command) RunWithTimeout() error {
 	for {
 		select {
 		case <-timeout:
-			timeoutStep := cmd.NewStep("Timeout reached while waiting for deployment to complete")
+			msg := "Timeout reached while waiting for deployment to complete"
+			timeoutStep := cmd.NewStep(msg)
 			timeoutStep.Failure()
-			return nil
+			return errors.New(msg)
 		case err := <-errChan:
 			return err
 		}


### PR DESCRIPTION
**Description**

Ensure a non-zero exit code is returned on `deploy` command timeout

Changes proposed in this pull request:

- non-zero exit code is returned on `deploy` command timeout

**Related issue(s)**
See: https://github.com/kyma-project/cli/issues/1166