### PR TITLE
Use only the latest Go YAML pkg

### DIFF
--- a/cmd/kyma/apply/function/function.go
+++ b/cmd/kyma/apply/function/function.go
@@ -17,7 +17,7 @@ import (
 	"github.com/kyma-project/cli/internal/kube"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )

--- a/cmd/kyma/create/system/system.go
+++ b/cmd/kyma/create/system/system.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 

--- a/cmd/kyma/run/function/function.go
+++ b/cmd/kyma/run/function/function.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type command struct {

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.21.0
 	gopkg.in/src-d/go-git.v4 v4.13.1
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	gotest.tools v2.2.0+incompatible
 	helm.sh/helm/v3 v3.7.2
@@ -311,6 +310,7 @@ require (
 	gopkg.in/src-d/go-billy.v4 v4.3.2 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	istio.io/gogo-genproto v0.0.0-20210113155706-4daf5697332f // indirect
 	k8s.io/apiextensions-apiserver v0.22.4 // indirect
 	k8s.io/apiserver v0.22.4 // indirect

--- a/internal/deploy/istioctl/istio.go
+++ b/internal/deploy/istioctl/istio.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/kyma-project/cli/internal/files"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const defaultIstioChartPath = "/resources/istio-configuration/Chart.yaml"

--- a/pkg/installation/utils.go
+++ b/pkg/installation/utils.go
@@ -24,7 +24,7 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/storage/memory"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func getLatestAvailableMainHash(currentStep step.Step, fallbackLevel int, nonInteractive bool) (string, error) {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Unified YAML dependencies to only have one version of the pkg in the whole CLI.
