### PR TITLE
chore: adopt state to be in progress for run in reconciler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/kyma-incubator/hydroform/function v0.0.0-20220201101045-fa7ac5fbce3f
 	github.com/kyma-incubator/hydroform/install v0.0.0-20200922142757-cae045912c90
 	github.com/kyma-incubator/hydroform/provision v0.0.0-20210514061348-c71b69cb362e
-	github.com/kyma-incubator/reconciler v0.0.0-20220304105103-0ce3c73fe5d4
+	github.com/kyma-incubator/reconciler v0.0.0-20220308141216-c3f1b187c963
 	github.com/kyma-project/kyma/components/kyma-operator v0.0.0-20201125092745-687c943ac940
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
@@ -77,12 +77,12 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
 	github.com/Masterminds/squirrel v1.5.2 // indirect
 	github.com/Microsoft/go-winio v0.5.0 // indirect
-	github.com/Microsoft/hcsshim v0.8.21 // indirect
+	github.com/Microsoft/hcsshim v0.8.23 // indirect
 	github.com/Peripli/service-manager v0.19.0 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
-	github.com/SAP/sap-btp-service-operator v0.1.21 // indirect
+	github.com/SAP/sap-btp-service-operator v0.1.22 // indirect
 	github.com/Unknwon/com v0.0.0-20151008135407-28b053d5a292 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/agext/levenshtein v1.2.2 // indirect
@@ -106,7 +106,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/containerd/cgroups v1.0.1 // indirect
-	github.com/containerd/containerd v1.5.7 // indirect
+	github.com/containerd/containerd v1.5.10 // indirect
 	github.com/coreos/etcd v3.3.13+incompatible // indirect
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.2 // indirect

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -166,9 +166,9 @@ func prepareKebComponents(components component.List, vals values.Values) ([]*keb
 }
 
 func prepareKebCluster(opts Options, kebComponents []*keb.Component, delete bool) *cluster.State {
-	status := model.ClusterStatusReconcilePending
+	status := model.ClusterStatusReconciling
 	if delete {
-		status = model.ClusterStatusDeletePending
+		status = model.ClusterStatusDeleting
 	}
 
 	return &cluster.State{

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -137,14 +137,14 @@ func TestPrepareKebCluster(t *testing.T) {
 			RuntimeID:      "local",
 			ClusterVersion: 1,
 			ConfigVersion:  1,
-			Status:         model.ClusterStatusReconcilePending,
+			Status:         model.ClusterStatusReconciling,
 		},
 	}
 
 	result := prepareKebCluster(options, expected, false)
 	require.Equal(t, expectedState, result)
 
-	expectedState.Status.Status = model.ClusterStatusDeletePending
+	expectedState.Status.Status = model.ClusterStatusDeleting
 	result = prepareKebCluster(options, expected, true)
 	require.Equal(t, expectedState, result)
 }


### PR DESCRIPTION


**Description**

Changes proposed in this pull request:

- makes sure we are compatible with the state change of the
reconciler that is now expecting an in progress scenario due to a
stricter check of the scheduled reconciliation state.


**Related issue(s)**
See https://github.com/kyma-incubator/reconciler/pull/877
