### PR TITLE
Muting unnecessary logs when using output flag in CLI

### DIFF
--- a/cmd/kyma/apply/function/function.go
+++ b/cmd/kyma/apply/function/function.go
@@ -147,6 +147,7 @@ func (c *command) Run() error {
 		ctx, cancel = context.WithTimeout(ctx, c.opts.Timeout)
 	}
 	defer cancel()
+
 	step.Successf("Configuration loaded")
 
 	return mgr.Do(ctx, options)

--- a/cmd/kyma/apply/function/function.go
+++ b/cmd/kyma/apply/function/function.go
@@ -64,14 +64,16 @@ func (c *command) Run() error {
 		c.opts.Filename = defaultFilename()
 	}
 
+	if c.opts.Output.value == "yaml" {
+		c.MuteLogger = true
+	}
 	file, err := os.Open(c.opts.Filename)
 	if err != nil {
 		return err
 	}
 
 	// Load project configuration
-	// TODO : Tu jest ten msg
-	step := c.NewStep("Cokolwiek")
+	step := c.NewStep("Loading configuration...")
 	var configuration workspace.Cfg
 	if err := yaml.NewDecoder(file).Decode(&configuration); err != nil {
 		step.Failure()
@@ -145,8 +147,7 @@ func (c *command) Run() error {
 		ctx, cancel = context.WithTimeout(ctx, c.opts.Timeout)
 	}
 	defer cancel()
-	// TODO : Tu jest ten msg
-	step.Successf("Cokolwiek")
+	step.Successf("Configuration loaded")
 
 	return mgr.Do(ctx, options)
 }

--- a/cmd/kyma/apply/function/function.go
+++ b/cmd/kyma/apply/function/function.go
@@ -70,7 +70,8 @@ func (c *command) Run() error {
 	}
 
 	// Load project configuration
-	step := c.NewStep("Loading configuration...")
+	// TODO : Tu jest ten msg
+	step := c.NewStep("Cokolwiek")
 	var configuration workspace.Cfg
 	if err := yaml.NewDecoder(file).Decode(&configuration); err != nil {
 		step.Failure()
@@ -144,8 +145,8 @@ func (c *command) Run() error {
 		ctx, cancel = context.WithTimeout(ctx, c.opts.Timeout)
 	}
 	defer cancel()
-
-	step.Successf("Configuration loaded")
+	// TODO : Tu jest ten msg
+	step.Successf("Cokolwiek")
 
 	return mgr.Do(ctx, options)
 }

--- a/pkg/step/factory.go
+++ b/pkg/step/factory.go
@@ -13,6 +13,7 @@ type FactoryInterface interface {
 type Factory struct {
 	NonInteractive bool
 	UseLogger      bool
+	MuteLogger     bool
 }
 
 // NewStep creates a new Step to print out the current status with or without a spinner.
@@ -23,5 +24,9 @@ func (f *Factory) NewStep(msg string) Step {
 	if f.NonInteractive || runtime.GOOS != "darwin" {
 		return newSimpleStep(msg)
 	}
+	if f.MuteLogger {
+		return NewMutedStep()
+	}
+	//TODO: create NoOpStep() compatible with step interface and return it.
 	return newStepWithSpinner(msg)
 }

--- a/pkg/step/factory.go
+++ b/pkg/step/factory.go
@@ -27,6 +27,5 @@ func (f *Factory) NewStep(msg string) Step {
 	if f.MuteLogger {
 		return NewMutedStep()
 	}
-	//TODO: create NoOpStep() compatible with step interface and return it.
 	return newStepWithSpinner(msg)
 }

--- a/pkg/step/muted.go
+++ b/pkg/step/muted.go
@@ -1,0 +1,60 @@
+package step
+
+var _ Step = mutedStep{}
+
+func NewMutedStep() Step {
+	return &mutedStep{}
+}
+
+type mutedStep struct {
+}
+
+func (m mutedStep) Start() {
+}
+
+func (m mutedStep) Status(msg string) {
+}
+
+func (m mutedStep) Success() {
+}
+
+func (m mutedStep) Successf(format string, args ...interface{}) {
+}
+
+func (m mutedStep) Failure() {
+}
+
+func (m mutedStep) Failuref(format string, args ...interface{}) {
+}
+
+func (m mutedStep) Stop(success bool) {
+}
+
+func (m mutedStep) Stopf(success bool, format string, args ...interface{}) {
+}
+
+func (m mutedStep) LogInfo(msg string) {
+}
+
+func (m mutedStep) LogInfof(format string, args ...interface{}) {
+}
+
+func (m mutedStep) LogError(msg string) {
+}
+
+func (m mutedStep) LogErrorf(format string, args ...interface{}) {
+}
+
+func (m mutedStep) LogWarn(msg string) {
+}
+
+func (m mutedStep) LogWarnf(format string, args ...interface{}) {
+}
+
+func (m mutedStep) Prompt(msg string) (string, error) {
+	return "", nil
+}
+
+func (m mutedStep) PromptYesNo(msg string) bool {
+	return false
+}


### PR DESCRIPTION
**Description**
Muted logs when user uses `kyma apply function --filename {FULL_PATH_TO_LOCAL_WORKSPACE_FOLDER}/config.yaml --output yaml --dry-run` 

**Related issue(s)**
Resolves: https://github.com/kyma-project/cli/issues/1210