### PR TITLE
version: add retry to get the cluster kyma version

### DIFF
--- a/cmd/kyma/version/opts.go
+++ b/cmd/kyma/version/opts.go
@@ -7,8 +7,7 @@ import (
 //Options defines available options for the command
 type Options struct {
 	*cli.Options
-	ClientOnly     bool
-	VersionDetails bool
+	ClientOnly bool
 }
 
 //NewOptions creates options with default values

--- a/docs/gen-docs/kyma_version.md
+++ b/docs/gen-docs/kyma_version.md
@@ -16,8 +16,7 @@ kyma version [flags]
 ## Flags
 
 ```bash
-  -c, --client    Client version only (no server required)
-  -d, --details   Detailed information for each Kyma version
+  -c, --client   Client version only (no server required)
 ```
 
 ## Flags inherited from parent commands


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Now the version command retries 3 times to get the kyma version from the cluster.
- Added an incremental backoff delay after each try.
- Version now uses the CLI `verbose` flag to show errors from all tries or the last error only.
- Removed unused flag `VersionDetails`

**Related issue(s)**
#1256 
