### PR TITLE
Add error filtering fr provision

### DIFF
--- a/cmd/kyma/provision/gardener/aws/template.go
+++ b/cmd/kyma/provision/gardener/aws/template.go
@@ -118,3 +118,11 @@ func (c *awsCmd) ValidateFlags() error {
 }
 
 func (c *awsCmd) IsVerbose() bool { return c.opts.Verbose }
+
+func (c *awsCmd) FilterErr(e error) error {
+	if strings.Contains(e.Error(), "already exists") {
+		return nil
+	}
+
+	return e
+}

--- a/cmd/kyma/provision/gardener/az/template.go
+++ b/cmd/kyma/provision/gardener/az/template.go
@@ -112,3 +112,11 @@ func (c *azCmd) ValidateFlags() error {
 }
 
 func (c *azCmd) IsVerbose() bool { return c.opts.Verbose }
+
+func (c *azCmd) FilterErr(e error) error {
+	if strings.Contains(e.Error(), "already exists") {
+		return nil
+	}
+
+	return e
+}

--- a/cmd/kyma/provision/gardener/gcp/template.go
+++ b/cmd/kyma/provision/gardener/gcp/template.go
@@ -119,3 +119,11 @@ func (c *gcpCmd) ValidateFlags() error {
 }
 
 func (c *gcpCmd) IsVerbose() bool { return c.opts.Verbose }
+
+func (c *gcpCmd) FilterErr(e error) error {
+	if strings.Contains(e.Error(), "already exists") {
+		return nil
+	}
+
+	return e
+}

--- a/cmd/kyma/provision/run_template.go
+++ b/cmd/kyma/provision/run_template.go
@@ -19,12 +19,12 @@ type Command interface {
 	KubeconfigPath() string
 	Attempts() uint
 	ProviderName() string
-
+	// FilterErr checks if e can be filtered out. If so, nil is returned, otherwise e is returned unchanged.
+	FilterErr(e error) error
 	ValidateFlags() error
 	NewStep(msg string) step.Step
 	NewCluster() *types.Cluster
 	NewProvider() (*types.Provider, error)
-
 	Run() error
 }
 
@@ -55,7 +55,7 @@ func RunTemplate(c Command) error {
 	err = retry.Do(
 		func() error {
 			cluster, err = hf.Provision(cluster, provider, types.WithDataDir(home), types.Persistent(), types.Verbose(c.IsVerbose()))
-			return err
+			return c.FilterErr(err)
 		},
 		retry.Attempts(c.Attempts()), retry.LastErrorOnly(!c.IsVerbose()))
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Added interface function to filter errors for provision commands
- Now gardener provision filters out "already exists" errors

**Related issue(s)**
https://github.com/kyma-project/cli/issues/1267
