### PR TITLE
Fix inconsistent hashes on tar blobs

### DIFF
--- a/cmd/kyma/apply/apply_test.go
+++ b/cmd/kyma/apply/apply_test.go
@@ -1,7 +1,7 @@
 package apply
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/kyma-project/cli/internal/cli"
@@ -11,7 +11,7 @@ import (
 func TestSubcommands(t *testing.T) {
 	t.Parallel()
 	c := NewCmd(&cli.Options{})
-	c.SetOutput(ioutil.Discard) // not interested in the command's output
+	c.SetOutput(io.Discard) // not interested in the command's output
 
 	// test default flag values
 	require.NoError(t, c.Execute(), "Command execution must not fail")

--- a/cmd/kyma/create/create_test.go
+++ b/cmd/kyma/create/create_test.go
@@ -1,7 +1,7 @@
 package create
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/kyma-project/cli/internal/cli"
@@ -11,7 +11,7 @@ import (
 func TestSubcommands(t *testing.T) {
 	t.Parallel()
 	c := NewCmd(&cli.Options{})
-	c.SetOutput(ioutil.Discard) // not interested in the command's output
+	c.SetOutput(io.Discard) // not interested in the command's output
 
 	// test default flag values
 	require.NoError(t, c.Execute(), "Command execution must not fail")

--- a/cmd/kyma/deploy/cmd.go
+++ b/cmd/kyma/deploy/cmd.go
@@ -3,7 +3,6 @@ package deploy
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -36,7 +35,7 @@ type command struct {
 	opts *Options
 }
 
-//NewCmd creates a new deploy command
+// NewCmd creates a new deploy command
 func NewCmd(o *Options) *cobra.Command {
 
 	cmd := command{
@@ -220,7 +219,7 @@ func (cmd *command) dryRun() error {
 
 func (cmd *command) deployKyma(l *zap.SugaredLogger, components component.List, vals values.Values, summary *nice.Summary) error {
 	kubeconfigPath := kube.KubeconfigPath(cmd.KubeconfigPath)
-	kubeconfig, err := ioutil.ReadFile(kubeconfigPath)
+	kubeconfig, err := os.ReadFile(kubeconfigPath)
 	if err != nil {
 		return errors.Wrap(err, "failed to read kubeconfig")
 	}

--- a/cmd/kyma/deploy/cmd_test.go
+++ b/cmd/kyma/deploy/cmd_test.go
@@ -1,7 +1,7 @@
 package deploy
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -50,7 +50,7 @@ func Test_upgkyma2tokyma2_noninteractive(t *testing.T) {
 	err := cmd.decideVersionUpgrade()
 
 	w.Close()
-	out, _ := ioutil.ReadAll(r)
+	out, _ := io.ReadAll(r)
 	os.Stdout = captureStdout
 	expectedOutput := "A Kyma installation was found, but compatibility between version '2.0.0' and 'main' is not guaranteed. This might cause errors!"
 	require.Contains(t, string(out), expectedOutput)
@@ -93,7 +93,7 @@ func Test_upgkyma2tokyma2_interactive(t *testing.T) {
 	err := cmd.decideVersionUpgrade()
 
 	w.Close()
-	out, _ := ioutil.ReadAll(r)
+	out, _ := io.ReadAll(r)
 	os.Stdout = captureStdout
 	expectedOutput := "Do you want to proceed with the upgrade to 'main'? Type [y/N]:"
 	require.Contains(t, string(out), expectedOutput)
@@ -139,7 +139,7 @@ func Test_upgkyma1tokyma2_interactive(t *testing.T) {
 	err := cmd.decideVersionUpgrade()
 
 	w.Close()
-	out, _ := ioutil.ReadAll(r)
+	out, _ := io.ReadAll(r)
 	os.Stdout = captureStdout
 	expectedOutput := "Do you want to proceed with the upgrade to '2.0.0'? Type [y/N]:"
 	require.Contains(t, string(out), expectedOutput)
@@ -183,7 +183,7 @@ func Test_upgkymaFootokyma2_noninteractive(t *testing.T) {
 	err := cmd.decideVersionUpgrade()
 
 	w.Close()
-	out, _ := ioutil.ReadAll(r)
+	out, _ := io.ReadAll(r)
 	os.Stdout = captureStdout
 	expectedOutput := "A Kyma installation was found, but compatibility between version '12e41ab5' and '2.0.0' is not guaranteed. This might cause errors!"
 	require.Contains(t, string(out), expectedOutput)

--- a/cmd/kyma/import/certs/cmd.go
+++ b/cmd/kyma/import/certs/cmd.go
@@ -1,7 +1,6 @@
 package certs
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/kyma-project/cli/internal/cli"
@@ -18,7 +17,7 @@ type command struct {
 	cli.Command
 }
 
-//NewCmd creates a new dashboard command
+// NewCmd creates a new dashboard command
 func NewCmd(o *cli.Options) *cobra.Command {
 	c := command{
 		Command: cli.Command{Options: o},
@@ -34,7 +33,7 @@ func NewCmd(o *cli.Options) *cobra.Command {
 	return cmd
 }
 
-//Run runs the command
+// Run runs the command
 func (cmd *command) Run() error {
 	var err error
 
@@ -69,7 +68,7 @@ func (cmd *command) importCertificate() error {
 		return err
 	}
 
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "kyma-*.crt")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "kyma-*.crt")
 	if err != nil {
 		return errors.Wrap(err, "cannot create temporary file for Kyma certificate")
 	}

--- a/cmd/kyma/init/init_test.go
+++ b/cmd/kyma/init/init_test.go
@@ -1,7 +1,7 @@
 package init
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/kyma-project/cli/internal/cli"
@@ -11,7 +11,7 @@ import (
 func TestSubcommands(t *testing.T) {
 	t.Parallel()
 	c := NewCmd(&cli.Options{})
-	c.SetOutput(ioutil.Discard) // not interested in the command's output
+	c.SetOutput(io.Discard) // not interested in the command's output
 
 	// test default flag values
 	require.NoError(t, c.Execute(), "Command execution must not fail")

--- a/cmd/kyma/kyma_test.go
+++ b/cmd/kyma/kyma_test.go
@@ -1,7 +1,7 @@
 package kyma
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/kyma-project/cli/internal/cli"
@@ -13,7 +13,7 @@ func TestKymaFlags(t *testing.T) {
 	t.Parallel()
 	o := &cli.Options{}
 	c := NewCmd(o)
-	c.SetOutput(ioutil.Discard) // not interested in the command's output
+	c.SetOutput(io.Discard) // not interested in the command's output
 
 	// test default flag values
 	require.Equal(t, "", o.KubeconfigPath, "kubeconfig path must be empty when default")
@@ -31,7 +31,7 @@ func TestKymaFlags(t *testing.T) {
 func TestKymaSubcommands(t *testing.T) {
 	t.Parallel()
 	c := NewCmd(&cli.Options{})
-	c.SetOutput(ioutil.Discard) // not interested in the command's output
+	c.SetOutput(io.Discard) // not interested in the command's output
 
 	// test default flag values
 	require.NoError(t, c.Execute(), "Command execution must not fail")

--- a/cmd/kyma/provision/run_template.go
+++ b/cmd/kyma/provision/run_template.go
@@ -2,7 +2,7 @@ package provision
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 
 	"github.com/avast/retry-go"
@@ -43,7 +43,7 @@ func RunTemplate(c Command) error {
 	}
 	if !c.IsVerbose() {
 		// discard all the noise from terraform logs if not verbose
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 	}
 	s = c.NewStep(fmt.Sprintf("Provisioning %s cluster", c.ProviderName()))
 	home, err := files.KymaHome()

--- a/cmd/kyma/run/run_test.go
+++ b/cmd/kyma/run/run_test.go
@@ -1,7 +1,7 @@
 package run
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/kyma-project/cli/internal/cli"
@@ -13,7 +13,7 @@ func TestSubcommands(t *testing.T) {
 	c := NewCmd(&cli.Options{
 		KubeconfigPath: "/fakepath",
 	})
-	c.SetOutput(ioutil.Discard) // not interested in the command's output
+	c.SetOutput(io.Discard) // not interested in the command's output
 
 	// test default flag values
 	require.NoError(t, c.Execute(), "Command execution must not fail")

--- a/cmd/kyma/sync/sync_test.go
+++ b/cmd/kyma/sync/sync_test.go
@@ -1,7 +1,7 @@
 package sync
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/kyma-project/cli/internal/cli"
@@ -13,7 +13,7 @@ func TestSubcommands(t *testing.T) {
 	c := NewCmd(&cli.Options{
 		KubeconfigPath: "/fakepath",
 	})
-	c.SetOutput(ioutil.Discard) // not interested in the command's output
+	c.SetOutput(io.Discard) // not interested in the command's output
 
 	// test default flag values
 	require.NoError(t, c.Execute(), "Command execution must not fail")

--- a/cmd/kyma/undeploy/cmd.go
+++ b/cmd/kyma/undeploy/cmd.go
@@ -3,7 +3,7 @@ package undeploy
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"go.uber.org/zap"
@@ -29,7 +29,7 @@ type command struct {
 	cli.Command
 }
 
-//NewCmd creates a new kyma command
+// NewCmd creates a new kyma command
 func NewCmd(o *Options) *cobra.Command {
 
 	cmd := command{
@@ -67,7 +67,7 @@ func NewCmd(o *Options) *cobra.Command {
 	return cobraCmd
 }
 
-//Run runs the command
+// Run runs the command
 func (cmd *command) Run() error {
 	var err error
 
@@ -84,7 +84,7 @@ func (cmd *command) Run() error {
 	}
 
 	kubeconfigPath := kube.KubeconfigPath(cmd.KubeconfigPath)
-	kubeconfig, err := ioutil.ReadFile(kubeconfigPath)
+	kubeconfig, err := os.ReadFile(kubeconfigPath)
 	if err != nil {
 		return errors.Wrap(err, "failed to read kubeconfig")
 	}

--- a/internal/deploy/component/list.go
+++ b/internal/deploy/component/list.go
@@ -2,7 +2,7 @@ package component
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -15,14 +15,14 @@ import (
 
 const defaultNamespace = "kyma-system"
 
-//List collects component definitions
+// List collects component definitions
 type List struct {
 	DefaultNamespace string       `yaml:"defaultNamespace" json:"defaultNamespace"`
 	Prerequisites    []Definition `yaml:"prerequisites" json:"prerequisites"`
 	Components       []Definition `yaml:"components" json:"components"`
 }
 
-//Definition defines a component in component list
+// Definition defines a component in component list
 type Definition struct {
 	Name      string `yaml:"name" json:"name"`
 	Namespace string `yaml:"namespace" json:"namespace"`
@@ -65,7 +65,7 @@ func FromFile(filePath string) (List, error) {
 		return List{}, errors.New("Path to a components file is required")
 	}
 
-	data, err := ioutil.ReadFile(filePath)
+	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return List{}, err
 	}

--- a/internal/deploy/istioctl/istio.go
+++ b/internal/deploy/istioctl/istio.go
@@ -6,15 +6,15 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
-	"go.uber.org/zap"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"go.uber.org/zap"
 
 	"github.com/kyma-project/cli/internal/files"
 	"github.com/pkg/errors"
@@ -133,7 +133,7 @@ func (i *Installation) Install() error {
 
 func (i *Installation) getIstioVersion() error {
 	var chart Config
-	istioConfig, err := ioutil.ReadFile(filepath.Join(i.WorkspacePath, i.IstioChartPath))
+	istioConfig, err := os.ReadFile(filepath.Join(i.WorkspacePath, i.IstioChartPath))
 	if err != nil {
 		return err
 	}

--- a/internal/deploy/istioctl/istio_test.go
+++ b/internal/deploy/istioctl/istio_test.go
@@ -2,12 +2,13 @@ package istioctl
 
 import (
 	"bytes"
-	"go.uber.org/zap"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path"
 	"testing"
+
+	"go.uber.org/zap"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -218,7 +219,7 @@ func TestInstallation_downloadFile(t *testing.T) {
 		{name: "Download Istioctl", fields: fields{Client: &mockClient{}}, args: args{filepath: "tmp", filename: "mock_download.txt", url: "someUrl"},
 			getFunc: func(url string) (*http.Response, error) {
 				jsonBody := `{"name":"Istioctl","full_name":"Istioctl binary mock download","bin":{"data": "some binary"}}`
-				r := ioutil.NopCloser(bytes.NewReader([]byte(jsonBody)))
+				r := io.NopCloser(bytes.NewReader([]byte(jsonBody)))
 				return &http.Response{
 					StatusCode: 200,
 					Body:       r,

--- a/internal/deploy/values/builder.go
+++ b/internal/deploy/values/builder.go
@@ -3,7 +3,7 @@ package values
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -129,7 +129,7 @@ func (b *builder) mergeSources() (map[string]interface{}, error) {
 func loadValuesFile(filePath string) (map[string]interface{}, error) {
 	var vals map[string]interface{}
 
-	data, err := ioutil.ReadFile(filePath)
+	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/deploy/values/builder_test.go
+++ b/internal/deploy/values/builder_test.go
@@ -1,10 +1,11 @@
 package values
 
 import (
+	"os"
+	"testing"
+
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
-	"io/ioutil"
-	"testing"
 )
 
 func TestBuild(t *testing.T) {
@@ -29,7 +30,7 @@ func TestBuild(t *testing.T) {
 			addValues(override2)
 
 		// read expected result
-		data, err := ioutil.ReadFile("testdata/deployment-values-result.yaml")
+		data, err := os.ReadFile("testdata/deployment-values-result.yaml")
 		require.NoError(t, err)
 		var expected map[string]interface{}
 		err = yaml.Unmarshal(data, &expected)

--- a/internal/deploy/values/values.go
+++ b/internal/deploy/values/values.go
@@ -3,7 +3,7 @@ package values
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/kyma-project/cli/internal/clusterinfo"
@@ -119,7 +119,7 @@ func addDomainValues(builder *builder, opts Sources) error {
 }
 
 func readFileAndEncode(filename string) (string, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/docker/docker_test.go
+++ b/pkg/docker/docker_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -65,7 +65,7 @@ func genConfigFile() *dockerConfigFile.ConfigFile {
 }
 
 func Test_Resolve_happy_path(t *testing.T) {
-	tmpHome, err := ioutil.TempDir("/tmp", "config-test")
+	tmpHome, err := os.MkdirTemp("/tmp", "config-test")
 	assert.NilError(t, err)
 	defer os.RemoveAll(tmpHome)
 
@@ -73,7 +73,7 @@ func Test_Resolve_happy_path(t *testing.T) {
 	b, err := json.Marshal(configFile)
 	assert.NilError(t, err)
 	tmpFile := fmt.Sprintf("%s/config.json", tmpHome)
-	err = ioutil.WriteFile(tmpFile, b, 0600)
+	err = os.WriteFile(tmpFile, b, 0600)
 	assert.NilError(t, err)
 
 	os.Setenv("DOCKER_CONFIG", tmpHome)
@@ -123,7 +123,7 @@ func Test_PullImageAndStartContainer(t *testing.T) {
 
 	t.Run("happy path", func(t *testing.T) {
 		mockDocker.On("ImagePull", ctx, testOpts.Image, mock.AnythingOfType("types.ImagePullOptions")).Return(
-			ioutil.NopCloser(bytes.NewReader(nil)), nil).Times(1)
+			io.NopCloser(bytes.NewReader(nil)), nil).Times(1)
 
 		mockDocker.On("ContainerCreate", ctx, mock.AnythingOfType("*container.Config"),
 			mock.AnythingOfType("*container.HostConfig"), mock.Anything, mock.Anything, testOpts.ContainerName).Return(
@@ -139,7 +139,7 @@ func Test_PullImageAndStartContainer(t *testing.T) {
 
 	t.Run("image pull error", func(t *testing.T) {
 		mockDocker.On("ImagePull", ctx, testOpts.Image, mock.AnythingOfType("types.ImagePullOptions")).Return(
-			ioutil.NopCloser(bytes.NewReader(nil)), testErr).Times(1)
+			io.NopCloser(bytes.NewReader(nil)), testErr).Times(1)
 
 		id, err := mockWrapper.PullImageAndStartContainer(ctx, testOpts)
 
@@ -150,7 +150,7 @@ func Test_PullImageAndStartContainer(t *testing.T) {
 
 	t.Run("container create error", func(t *testing.T) {
 		mockDocker.On("ImagePull", ctx, testOpts.Image, mock.AnythingOfType("types.ImagePullOptions")).Return(
-			ioutil.NopCloser(bytes.NewReader(nil)), nil).Times(1)
+			io.NopCloser(bytes.NewReader(nil)), nil).Times(1)
 
 		mockDocker.On("ContainerCreate", ctx, mock.AnythingOfType("*container.Config"),
 			mock.AnythingOfType("*container.HostConfig"), mock.Anything, mock.Anything, testOpts.ContainerName).Return(
@@ -165,7 +165,7 @@ func Test_PullImageAndStartContainer(t *testing.T) {
 
 	t.Run("container start error", func(t *testing.T) {
 		mockDocker.On("ImagePull", ctx, testOpts.Image, mock.AnythingOfType("types.ImagePullOptions")).Return(
-			ioutil.NopCloser(bytes.NewReader(nil)), nil).Times(1)
+			io.NopCloser(bytes.NewReader(nil)), nil).Times(1)
 
 		mockDocker.On("ContainerCreate", ctx, mock.AnythingOfType("*container.Config"),
 			mock.AnythingOfType("*container.HostConfig"), mock.Anything, mock.Anything, testOpts.ContainerName).Return(

--- a/pkg/module/oci/cache.go
+++ b/pkg/module/oci/cache.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	ocispecv1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -47,7 +46,7 @@ func (fs *inmemoryCache) Get(desc ocispecv1.Descriptor) (io.ReadCloser, error) {
 	if !ok {
 		return nil, ErrNotFound
 	}
-	return ioutil.NopCloser(bytes.NewBuffer(data)), nil
+	return io.NopCloser(bytes.NewBuffer(data)), nil
 }
 
 func (fs *inmemoryCache) Add(desc ocispecv1.Descriptor, reader io.ReadCloser) error {

--- a/pkg/module/oci/client.go
+++ b/pkg/module/oci/client.go
@@ -6,11 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"go.uber.org/zap"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
+
+	"go.uber.org/zap"
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
@@ -239,7 +239,7 @@ func (c *client) PushManifest(ctx context.Context, ref string, manifest *ocispec
 				Digest:    digest.FromBytes(dummyConfig),
 				Size:      int64(len(dummyConfig)),
 			}
-			if err := c.cache.Add(manifest.Config, ioutil.NopCloser(bytes.NewBuffer(dummyConfig))); err != nil {
+			if err := c.cache.Add(manifest.Config, io.NopCloser(bytes.NewBuffer(dummyConfig))); err != nil {
 				return fmt.Errorf("unable to add dummy config to cache: %w", err)
 			}
 		}
@@ -256,7 +256,7 @@ func (c *client) PushManifest(ctx context.Context, ref string, manifest *ocispec
 		}
 	}
 
-	if err := c.cache.Add(desc, ioutil.NopCloser(bytes.NewBuffer(manifestBytes))); err != nil {
+	if err := c.cache.Add(desc, io.NopCloser(bytes.NewBuffer(manifestBytes))); err != nil {
 		return fmt.Errorf("unable to add manifest to cache: %w", err)
 	}
 

--- a/pkg/module/oci/manifest_v1_conversion.go
+++ b/pkg/module/oci/manifest_v1_conversion.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"time"
 
@@ -146,7 +145,7 @@ func ParseV1Manifest(ctx context.Context, client Client, ref string, v1Manifest 
 				return nil, nil, nil, fmt.Errorf("unable to decompress layer blob: %w", err)
 			}
 
-			decompressedData, err := ioutil.ReadAll(decompressedReader)
+			decompressedData, err := io.ReadAll(decompressedReader)
 			if err != nil {
 				return nil, nil, nil, fmt.Errorf("unable to read decompressed layer blob: %w", err)
 			}

--- a/pkg/module/signatures/digester.go
+++ b/pkg/module/signatures/digester.go
@@ -7,10 +7,11 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"github.com/kyma-project/cli/pkg/module/oci"
 	"io"
-	"io/ioutil"
+	"os"
 	"reflect"
+
+	"github.com/kyma-project/cli/pkg/module/oci"
 
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
 	"github.com/gardener/component-spec/bindings-go/apis/v2/signatures"
@@ -55,7 +56,7 @@ func (d *Digester) digestForLocalOciBlob(ctx context.Context, componentDescripto
 		return nil, fmt.Errorf("unable to decode repository context: %w", err)
 	}
 
-	tmpfile, err := ioutil.TempFile("", "")
+	tmpfile, err := os.CreateTemp("", "")
 	if err != nil {
 		return nil, fmt.Errorf("unable to create tempfile: %w", err)
 	}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Tar archives now have always the same hash if the content is identical regardless of when they were created/modified.
- Removed `io/ioutil` usage from codebase (deprecated).

**Related issue(s)**
#1339 
