### PR TITLE
Make user/password credentials work for gcloud registry

### DIFF
--- a/pkg/module/oci/client.go
+++ b/pkg/module/oci/client.go
@@ -322,8 +322,16 @@ func (c *client) resolver() remotes.Resolver {
 				Capabilities: docker.HostCapabilityPull | docker.HostCapabilityResolve | docker.HostCapabilityPush,
 			}
 
-			config.Authorizer = docker.NewDockerAuthorizer(docker.WithAuthClient(config.Client))
+			//The secret alone may be enough for token-based auth scenarios
+			if c.secret != "" {
+				f := func(host string) (string, string, error) {
+					//We do nothing with the host value
+					return c.user, c.secret, nil
+				}
 
+				config.Authorizer = docker.NewDockerAuthorizer(docker.WithAuthCreds(f))
+
+			}
 			return []docker.RegistryHost{config}, nil
 		},
 	}


### PR DESCRIPTION
**Description**

Fixes: https://github.com/kyma-project/cli/issues/1342
Changes proposed in this pull request:

- Used a different authorizer that uses username/password combination to authorize push operations to the registry
- Usage: Just provide the flag: `--credentials user:password` without any additional encoding. The username in gcloud case is always `oauth2accesstoken` and the password is the short-lived gcloud token (1 hour)


**Related issue(s)**
https://github.com/kyma-project/cli/issues/1342