### PR TITLE
Use Kyma 2.6 sources as default

### DIFF
--- a/docs/gen-docs/kyma_deploy.md
+++ b/docs/gen-docs/kyma_deploy.md
@@ -28,7 +28,7 @@ kyma deploy [flags]
                                  	- Deploy a specific branch of the Kyma repository on kyma-project.org: "kyma deploy --source=<my-branch-name>"
                                  	- Deploy a commit (8 characters or more), for example: "kyma deploy --source=34edf09a"
                                  	- Deploy a pull request, for example "kyma deploy --source=PR-9486"
-                                 	- Deploy the local sources: "kyma deploy --source=local" (default "main")
+                                 	- Deploy the local sources: "kyma deploy --source=local" (default "2.6.0")
   -t, --timeout duration         Maximum time for the deployment. (default 20m0s)
       --tls-crt string           TLS certificate file for the domain used for installation.
       --tls-key string           TLS key file for the domain used for installation.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,5 +6,5 @@
 package config
 
 const (
-	DefaultKyma2Version = "main"
+	DefaultKyma2Version = "2.6.0"
 )


### PR DESCRIPTION
**Description**

Part of Kyma CLI release process: set KYma 2.6 sources as default 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
