### PR TITLE
Fix linter

### DIFF
--- a/cmd/kyma/alpha/create/create.go
+++ b/cmd/kyma/alpha/create/create.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//NewCmd creates a new Kyma CLI command
+// NewCmd creates a new Kyma CLI command
 func NewCmd(o *cli.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",

--- a/cmd/kyma/alpha/init/init.go
+++ b/cmd/kyma/alpha/init/init.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//NewCmd creates a new Kyma CLI command
+// NewCmd creates a new Kyma CLI command
 func NewCmd(o *cli.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",

--- a/cmd/kyma/alpha/init/module/opts.go
+++ b/cmd/kyma/alpha/init/module/opts.go
@@ -4,14 +4,14 @@ import (
 	"github.com/kyma-project/cli/internal/cli"
 )
 
-//Options defines available options for the init module command
+// Options defines available options for the init module command
 type Options struct {
 	*cli.Options
 	ModuleName string
 	ParentDir  string
 }
 
-//NewOptions creates options with default values
+// NewOptions creates options with default values
 func NewOptions(o *cli.Options) *Options {
 	return &Options{Options: o}
 }

--- a/cmd/kyma/alpha/unpack/module/module.go
+++ b/cmd/kyma/alpha/unpack/module/module.go
@@ -10,7 +10,7 @@ type command struct {
 	cli.Command
 }
 
-//NewCmd creates a new Kyma CLI command
+// NewCmd creates a new Kyma CLI command
 func NewCmd(o *Options) *cobra.Command {
 
 	c := command{

--- a/cmd/kyma/alpha/unpack/module/opts.go
+++ b/cmd/kyma/alpha/unpack/module/opts.go
@@ -4,12 +4,12 @@ import (
 	"github.com/kyma-project/cli/internal/cli"
 )
 
-//Options defines available options for the version command
+// Options defines available options for the version command
 type Options struct {
 	*cli.Options
 }
 
-//NewOptions creates options with default values
+// NewOptions creates options with default values
 func NewOptions(o *cli.Options) *Options {
 	return &Options{Options: o}
 }

--- a/cmd/kyma/alpha/unpack/unpack.go
+++ b/cmd/kyma/alpha/unpack/unpack.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//NewCmd creates a new Kyma CLI command
+// NewCmd creates a new Kyma CLI command
 func NewCmd(o *cli.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "unpack",

--- a/cmd/kyma/alpha/verify/module/module.go
+++ b/cmd/kyma/alpha/verify/module/module.go
@@ -10,7 +10,7 @@ type command struct {
 	cli.Command
 }
 
-//NewCmd creates a new Kyma CLI command
+// NewCmd creates a new Kyma CLI command
 func NewCmd(o *Options) *cobra.Command {
 
 	c := command{

--- a/cmd/kyma/alpha/verify/module/opts.go
+++ b/cmd/kyma/alpha/verify/module/opts.go
@@ -4,12 +4,12 @@ import (
 	"github.com/kyma-project/cli/internal/cli"
 )
 
-//Options defines available options for the version command
+// Options defines available options for the version command
 type Options struct {
 	*cli.Options
 }
 
-//NewOptions creates options with default values
+// NewOptions creates options with default values
 func NewOptions(o *cli.Options) *Options {
 	return &Options{Options: o}
 }

--- a/cmd/kyma/alpha/verify/verify.go
+++ b/cmd/kyma/alpha/verify/verify.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//NewCmd verifys a new kyma CLI command
+// NewCmd verifys a new kyma CLI command
 func NewCmd(o *cli.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "verify",

--- a/cmd/kyma/apply/apply.go
+++ b/cmd/kyma/apply/apply.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//NewCmd creates a new function command
+// NewCmd creates a new function command
 func NewCmd(o *cli.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "apply",

--- a/cmd/kyma/apply/function/function.go
+++ b/cmd/kyma/apply/function/function.go
@@ -27,7 +27,7 @@ type command struct {
 	cli.Command
 }
 
-//NewCmd creates a new apply command
+// NewCmd creates a new apply command
 func NewCmd(o *Options) *cobra.Command {
 	c := command{
 		opts:    o,

--- a/cmd/kyma/apply/function/opts.go
+++ b/cmd/kyma/apply/function/opts.go
@@ -10,7 +10,7 @@ import (
 	"github.com/kyma-project/hydroform/function/pkg/workspace"
 )
 
-//Options defines available options for the command
+// Options defines available options for the command
 type Options struct {
 	*cli.Options
 
@@ -22,7 +22,7 @@ type Options struct {
 	Timeout  time.Duration
 }
 
-//NewOptions creates options with default values
+// NewOptions creates options with default values
 func NewOptions(o *cli.Options) *Options {
 	return &Options{
 		Options: o,

--- a/cmd/kyma/create/create.go
+++ b/cmd/kyma/create/create.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//NewCmd creates a new Kyma CLI command
+// NewCmd creates a new Kyma CLI command
 func NewCmd(o *cli.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",

--- a/cmd/kyma/create/system/opts.go
+++ b/cmd/kyma/create/system/opts.go
@@ -6,7 +6,7 @@ import (
 	"github.com/kyma-project/cli/internal/cli"
 )
 
-//Options defines available options for the version command
+// Options defines available options for the version command
 type Options struct {
 	*cli.Options
 	Namespace    string
@@ -15,7 +15,7 @@ type Options struct {
 	Timeout      time.Duration
 }
 
-//NewOptions creates options with default values
+// NewOptions creates options with default values
 func NewOptions(o *cli.Options) *Options {
 	return &Options{Options: o}
 }

--- a/cmd/kyma/create/system/system.go
+++ b/cmd/kyma/create/system/system.go
@@ -24,7 +24,7 @@ type command struct {
 	cli.Command
 }
 
-//NewCmd creates a new Kyma CLI command
+// NewCmd creates a new Kyma CLI command
 func NewCmd(o *Options) *cobra.Command {
 
 	c := command{

--- a/cmd/kyma/dashboard/cmd.go
+++ b/cmd/kyma/dashboard/cmd.go
@@ -20,7 +20,7 @@ type command struct {
 	cli.Command
 }
 
-//NewCmd creates a new dashboard command
+// NewCmd creates a new dashboard command
 func NewCmd(o *Options) *cobra.Command {
 	c := command{
 		Command: cli.Command{Options: o.Options},
@@ -40,7 +40,7 @@ func NewCmd(o *Options) *cobra.Command {
 	return cmd
 }
 
-//Run runs the command
+// Run runs the command
 func (cmd *command) Run() error {
 	var err error
 

--- a/cmd/kyma/dashboard/opts.go
+++ b/cmd/kyma/dashboard/opts.go
@@ -6,14 +6,14 @@ import (
 	"github.com/kyma-project/cli/internal/cli"
 )
 
-//Options defines available options for the dashboard command
+// Options defines available options for the dashboard command
 type Options struct {
 	*cli.Options
 	ContainerName string
 	Port          string
 }
 
-//NewOptions creates options with default values
+// NewOptions creates options with default values
 func NewOptions(o *cli.Options) *Options {
 	return &Options{Options: o}
 }

--- a/cmd/kyma/deploy/opts.go
+++ b/cmd/kyma/deploy/opts.go
@@ -17,7 +17,7 @@ const (
 	profileProduction = "production"
 )
 
-//Options defines available options for the command
+// Options defines available options for the command
 type Options struct {
 	*cli.Options
 	values.Sources
@@ -32,7 +32,7 @@ type Options struct {
 	DryRun         bool
 }
 
-//NewOptions creates options with default values
+// NewOptions creates options with default values
 func NewOptions(o *cli.Options) *Options {
 	return &Options{Options: o}
 }

--- a/cmd/kyma/get/get.go
+++ b/cmd/kyma/get/get.go
@@ -15,7 +15,7 @@ var (
 	}
 )
 
-//NewCmd creates a new function command
+// NewCmd creates a new function command
 func NewCmd(o *cli.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get",

--- a/cmd/kyma/get/schema/schema.go
+++ b/cmd/kyma/get/schema/schema.go
@@ -13,7 +13,7 @@ type command struct {
 	cli.Command
 }
 
-//NewCmd creates a new Kyma CLI command
+// NewCmd creates a new Kyma CLI command
 func NewCmd(o *Options) *cobra.Command {
 	c := command{
 		Command: cli.Command{Options: o.Options},

--- a/cmd/kyma/import/cmd.go
+++ b/cmd/kyma/import/cmd.go
@@ -4,7 +4,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//NewCmd creates a new import command
+// NewCmd creates a new import command
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "import",

--- a/cmd/kyma/import/hosts/cmd.go
+++ b/cmd/kyma/import/hosts/cmd.go
@@ -15,10 +15,10 @@ type command struct {
 	cli.Command
 }
 
-//Version contains the cli binary version injected by the build system
+// Version contains the cli binary version injected by the build system
 var Version string
 
-//NewCmd creates a new kyma command
+// NewCmd creates a new kyma command
 func NewCmd(o *cli.Options) *cobra.Command {
 
 	cmd := command{
@@ -36,7 +36,7 @@ func NewCmd(o *cli.Options) *cobra.Command {
 	return cobraCmd
 }
 
-//Run runs the command
+// Run runs the command
 func (cmd *command) Run() error {
 	var err error
 	f := step.Factory{

--- a/cmd/kyma/init/function/function.go
+++ b/cmd/kyma/init/function/function.go
@@ -31,7 +31,7 @@ type command struct {
 	cli.Command
 }
 
-//NewCmd creates a new init command
+// NewCmd creates a new init command
 func NewCmd(o *Options) *cobra.Command {
 	c := command{
 		opts:    o,

--- a/cmd/kyma/init/function/opts.go
+++ b/cmd/kyma/init/function/opts.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kyma-project/hydroform/function/pkg/workspace"
 )
 
-//Options defines available options for the command
+// Options defines available options for the command
 type Options struct {
 	*cli.Options
 
@@ -25,7 +25,7 @@ type Options struct {
 	VsCode               bool
 }
 
-//NewOptions creates options with default values
+// NewOptions creates options with default values
 func NewOptions(o *cli.Options) *Options {
 	options := &Options{Options: o}
 	return options

--- a/cmd/kyma/init/init.go
+++ b/cmd/kyma/init/init.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//NewCmd creates a new function command
+// NewCmd creates a new function command
 func NewCmd(o *cli.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",

--- a/cmd/kyma/kyma.go
+++ b/cmd/kyma/kyma.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//NewCmd creates a new Kyma CLI command
+// NewCmd creates a new Kyma CLI command
 func NewCmd(o *cli.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "kyma",

--- a/cmd/kyma/provision/cmd.go
+++ b/cmd/kyma/provision/cmd.go
@@ -4,7 +4,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//NewCmd creates a new provision command
+// NewCmd creates a new provision command
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "provision",

--- a/cmd/kyma/provision/gardener/aws/opts.go
+++ b/cmd/kyma/provision/gardener/aws/opts.go
@@ -24,7 +24,7 @@ type Options struct {
 	HibernationLocation string
 }
 
-//NewOptions creates options with default values
+// NewOptions creates options with default values
 func NewOptions(o *cli.Options) *Options {
 	return &Options{Options: o}
 }

--- a/cmd/kyma/provision/gardener/az/cmd.go
+++ b/cmd/kyma/provision/gardener/az/cmd.go
@@ -4,7 +4,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//NewCmd creates a new az command
+// NewCmd creates a new az command
 func NewCmd(o *Options) *cobra.Command {
 	c := newAzCmd(o)
 

--- a/cmd/kyma/provision/gardener/az/opts.go
+++ b/cmd/kyma/provision/gardener/az/opts.go
@@ -24,7 +24,7 @@ type Options struct {
 	HibernationLocation string
 }
 
-//NewOptions creates options with default values
+// NewOptions creates options with default values
 func NewOptions(o *cli.Options) *Options {
 	return &Options{Options: o}
 }

--- a/cmd/kyma/provision/gardener/cmd.go
+++ b/cmd/kyma/provision/gardener/cmd.go
@@ -4,7 +4,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//NewCmd creates a new gardener command
+// NewCmd creates a new gardener command
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "gardener",

--- a/cmd/kyma/provision/gardener/gcp/cmd.go
+++ b/cmd/kyma/provision/gardener/gcp/cmd.go
@@ -4,7 +4,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//NewCmd creates a new az command
+// NewCmd creates a new az command
 func NewCmd(o *Options) *cobra.Command {
 	c := newGcpCmd(o)
 

--- a/cmd/kyma/provision/gardener/gcp/opts.go
+++ b/cmd/kyma/provision/gardener/gcp/opts.go
@@ -24,7 +24,7 @@ type Options struct {
 	HibernationLocation string
 }
 
-//NewOptions creates options with default values
+// NewOptions creates options with default values
 func NewOptions(o *cli.Options) *Options {
 	return &Options{Options: o}
 }

--- a/cmd/kyma/provision/k3d/cmd.go
+++ b/cmd/kyma/provision/k3d/cmd.go
@@ -20,7 +20,7 @@ type command struct {
 	cli.Command
 }
 
-//NewCmd creates a new k3d command
+// NewCmd creates a new k3d command
 func NewCmd(o *Options) *cobra.Command {
 	c := command{
 		Command: cli.Command{Options: o.Options},
@@ -47,7 +47,7 @@ func NewCmd(o *Options) *cobra.Command {
 	return cmd
 }
 
-//Run runs the command
+// Run runs the command
 func (c *command) Run() error {
 	if c.opts.CI {
 		c.Factory.NonInteractive = true
@@ -73,7 +73,7 @@ func (c *command) Run() error {
 	return nil
 }
 
-//Verifies if k3d is properly installed and pre-conditions are fulfilled
+// Verifies if k3d is properly installed and pre-conditions are fulfilled
 func (c *command) verifyK3dStatus(k3dClient k3d.Client) error {
 	s := c.NewStep("Verifying k3d status")
 	if err := k3dClient.VerifyStatus(); err != nil {
@@ -163,7 +163,7 @@ func (c *command) createK3dRegistry(k3dClient k3d.Client) (string, error) {
 	return registryURL, nil
 }
 
-//Create a k3d cluster
+// Create a k3d cluster
 func (c *command) createK3dCluster(k3dClient k3d.Client, registryURL string) error {
 	s := c.NewStep(fmt.Sprintf("Create K3d cluster '%s'", c.opts.Name))
 
@@ -201,7 +201,7 @@ func extractPortsFromFlag(portFlag []string) ([]int, error) {
 	return ports, nil
 }
 
-//Check if a port is allocated
+// Check if a port is allocated
 func allocatePorts(ports ...int) error {
 	for _, port := range ports {
 		con, err := net.Listen("tcp", fmt.Sprintf(":%d", port))

--- a/cmd/kyma/provision/k3d/opts.go
+++ b/cmd/kyma/provision/k3d/opts.go
@@ -6,7 +6,7 @@ import (
 	"github.com/kyma-project/cli/internal/cli"
 )
 
-//Options defines available options for the k3d provisioning command
+// Options defines available options for the k3d provisioning command
 type Options struct {
 	*cli.Options
 
@@ -21,7 +21,7 @@ type Options struct {
 	PortMapping       []string
 }
 
-//NewOptions creates options with default values
+// NewOptions creates options with default values
 func NewOptions(o *cli.Options) *Options {
 	return &Options{Options: o}
 }

--- a/cmd/kyma/run/function/function.go
+++ b/cmd/kyma/run/function/function.go
@@ -20,7 +20,7 @@ type command struct {
 	cli.Command
 }
 
-//NewCmd creates a new init command
+// NewCmd creates a new init command
 func NewCmd(o *Options) *cobra.Command {
 	c := command{
 		opts:    o,

--- a/cmd/kyma/run/function/opts.go
+++ b/cmd/kyma/run/function/opts.go
@@ -9,7 +9,7 @@ import (
 	"github.com/kyma-project/hydroform/function/pkg/workspace"
 )
 
-//Options defines available options for the command
+// Options defines available options for the command
 type Options struct {
 	*cli.Options
 
@@ -22,7 +22,7 @@ type Options struct {
 	HotDeploy     bool
 }
 
-//NewOptions creates options with default values
+// NewOptions creates options with default values
 func NewOptions(o *cli.Options) *Options {
 	options := &Options{Options: o}
 	return options

--- a/cmd/kyma/run/run.go
+++ b/cmd/kyma/run/run.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//NewCmd creates a new run command
+// NewCmd creates a new run command
 func NewCmd(o *cli.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run",

--- a/cmd/kyma/sync/function/function.go
+++ b/cmd/kyma/sync/function/function.go
@@ -18,7 +18,7 @@ type command struct {
 	cli.Command
 }
 
-//NewCmd creates a new init command
+// NewCmd creates a new init command
 func NewCmd(o *Options) *cobra.Command {
 	c := command{
 		opts:    o,

--- a/cmd/kyma/sync/function/opts.go
+++ b/cmd/kyma/sync/function/opts.go
@@ -7,7 +7,7 @@ import (
 	"github.com/kyma-project/cli/internal/cli"
 )
 
-//Options defines available options for the command
+// Options defines available options for the command
 type Options struct {
 	*cli.Options
 
@@ -16,7 +16,7 @@ type Options struct {
 	Timeout   time.Duration
 }
 
-//NewOptions creates options with default values
+// NewOptions creates options with default values
 func NewOptions(o *cli.Options) *Options {
 	options := &Options{Options: o}
 	return options

--- a/cmd/kyma/sync/sync.go
+++ b/cmd/kyma/sync/sync.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//NewCmd creates a new function command
+// NewCmd creates a new function command
 func NewCmd(o *cli.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sync",

--- a/cmd/kyma/undeploy/opts.go
+++ b/cmd/kyma/undeploy/opts.go
@@ -11,13 +11,13 @@ const (
 	profileProduction = "production"
 )
 
-//Options defines available options for the command
+// Options defines available options for the command
 type Options struct {
 	*deploy.Options
 	DeleteStrategy string
 }
 
-//NewOptions creates options with default values
+// NewOptions creates options with default values
 func NewOptions(o *cli.Options) *Options {
 	return &Options{Options: deploy.NewOptions(o)}
 }

--- a/cmd/kyma/version/cmd.go
+++ b/cmd/kyma/version/cmd.go
@@ -19,10 +19,10 @@ type command struct {
 	cli.Command
 }
 
-//Version contains the cli binary version injected by the build system
+// Version contains the cli binary version injected by the build system
 var Version string
 
-//NewCmd creates a new kyma command
+// NewCmd creates a new kyma command
 func NewCmd(o *Options) *cobra.Command {
 
 	cmd := command{
@@ -43,7 +43,7 @@ func NewCmd(o *Options) *cobra.Command {
 	return cobraCmd
 }
 
-//Run runs the command
+// Run runs the command
 func (cmd *command) Run() error {
 	var w io.Writer = os.Stdout
 

--- a/cmd/kyma/version/opts.go
+++ b/cmd/kyma/version/opts.go
@@ -4,13 +4,13 @@ import (
 	"github.com/kyma-project/cli/internal/cli"
 )
 
-//Options defines available options for the command
+// Options defines available options for the command
 type Options struct {
 	*cli.Options
 	ClientOnly bool
 }
 
-//NewOptions creates options with default values
+// NewOptions creates options with default values
 func NewOptions(o *cli.Options) *Options {
 	return &Options{Options: o}
 }

--- a/hack/verify-lint.sh
+++ b/hack/verify-lint.sh
@@ -31,8 +31,8 @@ golangci::run_checks() {
   shout "Run golangci-lint checks"
   LINTS=(
     # default golangci-lint lints
-    deadcode errcheck gosimple govet ineffassign staticcheck \
-    typecheck unused varcheck \
+    errcheck gosimple govet ineffassign staticcheck \
+    typecheck unused \
     # additional lints
     revive gofmt misspell gochecknoinits unparam exportloopref gosec
   )

--- a/hack/verify-lint.sh
+++ b/hack/verify-lint.sh
@@ -22,7 +22,7 @@ golangci::install() {
   export PATH="${INSTALL_DIR}:${PATH}"
 
   shout "Install the golangci-lint in version ${GOLANGCI_LINT_VERSION}"
-  curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b "${INSTALL_DIR}" ${GOLANGCI_LINT_VERSION}
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b "${INSTALL_DIR}" ${GOLANGCI_LINT_VERSION}
   echo -e "${GREEN}√ install golangci-lint${NC}"
 
 }

--- a/hack/verify-lint.sh
+++ b/hack/verify-lint.sh
@@ -32,7 +32,7 @@ golangci::run_checks() {
   LINTS=(
     # default golangci-lint lints
     deadcode errcheck gosimple govet ineffassign staticcheck \
-    structcheck typecheck unused varcheck \
+    typecheck unused varcheck \
     # additional lints
     revive gofmt misspell gochecknoinits unparam exportloopref gosec
   )

--- a/hack/verify-lint.sh
+++ b/hack/verify-lint.sh
@@ -47,12 +47,12 @@ golangci::run_checks() {
 }
 
 main() {
-  # result=$(git status --porcelain)
-  # if [[ "${result}" != "" ]]; then
-  #   echo "ERROR: git is currently in a dirty state:" 
-  #   echo "${result}"
-  #   exit 1
-  # fi
+  result=$(git status --porcelain)
+  if [[ "${result}" != "" ]]; then
+    echo "ERROR: git is currently in a dirty state:" 
+    echo "${result}"
+    exit 1
+  fi
 
   if [[ "${SKIP_INSTALL:-x}" != "true" ]]; then
     export INSTALL_DIR=${TMP_DIR}

--- a/hack/verify-lint.sh
+++ b/hack/verify-lint.sh
@@ -47,12 +47,12 @@ golangci::run_checks() {
 }
 
 main() {
-  result=$(git status --porcelain)
-  if [[ "${result}" != "" ]]; then
-    echo "ERROR: git is currently in a dirty state:" 
-    echo "${result}"
-    exit 1
-  fi
+  # result=$(git status --porcelain)
+  # if [[ "${result}" != "" ]]; then
+  #   echo "ERROR: git is currently in a dirty state:" 
+  #   echo "${result}"
+  #   exit 1
+  # fi
 
   if [[ "${SKIP_INSTALL:-x}" != "true" ]]; then
     export INSTALL_DIR=${TMP_DIR}

--- a/hack/verify-lint.sh
+++ b/hack/verify-lint.sh
@@ -8,7 +8,7 @@ set -E         # needs to be set if we want the ERR trap
 readonly CURRENT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 readonly ROOT_PATH=$( cd "${CURRENT_DIR}/.." && pwd )
 readonly TMP_DIR=$(mktemp -d)
-readonly GOLANGCI_LINT_VERSION="v1.45.2"
+readonly GOLANGCI_LINT_VERSION="v1.49.0"
 
 source "${CURRENT_DIR}/utilities.sh" || { echo 'Cannot load CI utilities.'; exit 1; }
 

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -25,15 +25,15 @@ func createVerboseLogger() (*zap.Logger, error) {
 	return config.Build()
 }
 
-//NewHydroformLoggerAdapter adapts a ZAP logger to a Hydrofrom compatible logger
+// NewHydroformLoggerAdapter adapts a ZAP logger to a Hydrofrom compatible logger
 func NewHydroformLoggerAdapter(logger *zap.Logger) *HydroformLoggerAdapter {
 	return &HydroformLoggerAdapter{
 		logger: logger,
 	}
 }
 
-//HydroformLoggerAdapter is implementing the logger interface of Hydroform
-//to make it compatible with the ZAP logger API.
+// HydroformLoggerAdapter is implementing the logger interface of Hydroform
+// to make it compatible with the ZAP logger API.
 type HydroformLoggerAdapter struct {
 	logger *zap.Logger
 }

--- a/internal/cli/options.go
+++ b/internal/cli/options.go
@@ -4,7 +4,7 @@ import (
 	"github.com/kyma-project/cli/pkg/step"
 )
 
-//Options defines available options for the command
+// Options defines available options for the command
 type Options struct {
 	CI      bool
 	Verbose bool
@@ -13,7 +13,7 @@ type Options struct {
 	Finalizers     *Finalizers
 }
 
-//NewOptions creates options with default values
+// NewOptions creates options with default values
 func NewOptions() *Options {
 	return &Options{
 		Finalizers: NewFinalizer(),

--- a/internal/clusterinfo/clusterinfo.go
+++ b/internal/clusterinfo/clusterinfo.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-//Info is a discriminated union (can be either Gardener or K3d or Unrecognized)
+// Info is a discriminated union (can be either Gardener or K3d or Unrecognized)
 type Info interface {
 	//unexported method to make sure that Info members are only implemented by the clusterinfo package
 	sealed()

--- a/internal/k3d/cluster.go
+++ b/internal/k3d/cluster.go
@@ -2,30 +2,30 @@ package k3d
 
 import "encoding/json"
 
-//ClusterList containing cluster entities
+// ClusterList containing cluster entities
 type ClusterList struct {
 	Clusters []Cluster
 }
 
-//Cluster including list of nodes
+// Cluster including list of nodes
 type Cluster struct {
 	Name  string
 	Nodes []Node
 }
 
-//Node in the K3s setup (could be lb, main, agent etc.)
+// Node in the K3s setup (could be lb, main, agent etc.)
 type Node struct {
 	Name  string
 	State State
 }
 
-//State of a node
+// State of a node
 type State struct {
 	Running bool
 	Status  string
 }
 
-//Unmarshal converts a JSON to nested structs
+// Unmarshal converts a JSON to nested structs
 func (cl *ClusterList) Unmarshal(data []byte) error {
 	var clusters []Cluster
 	if err := json.Unmarshal(data, &clusters); err != nil {

--- a/internal/k3d/k3d.go
+++ b/internal/k3d/k3d.go
@@ -82,7 +82,7 @@ func (c *client) runCmd(args ...string) (string, error) {
 	return out, nil
 }
 
-//checkVersion checks whether k3d version is supported
+// checkVersion checks whether k3d version is supported
 func (c *client) checkVersion() error {
 	binaryVersionOutput, err := c.runCmd("version")
 	if err != nil {
@@ -114,7 +114,7 @@ func (c *client) checkVersion() error {
 	return nil
 }
 
-//getRegistryByName gets one k3d registry by name
+// getRegistryByName gets one k3d registry by name
 func (c *client) getRegistryByName(registryName string) (*Registry, error) {
 	registryJSON, err := c.runCmd("registry", "list", "-o", "json")
 	if err != nil {
@@ -141,7 +141,7 @@ func (c *client) getRegistryByName(registryName string) (*Registry, error) {
 	return nil, nil
 }
 
-//VerifyStatus verifies whether the k3d CLI tool is properly installed
+// VerifyStatus verifies whether the k3d CLI tool is properly installed
 func (c *client) VerifyStatus() error {
 	//ensure k3d is in PATH
 	if _, err := c.pathLooker.Look(binaryName); err != nil {
@@ -160,7 +160,7 @@ func (c *client) VerifyStatus() error {
 	return err
 }
 
-//ClusterExists checks whether a cluster exists
+// ClusterExists checks whether a cluster exists
 func (c *client) ClusterExists() (bool, error) {
 	clusterJSON, err := c.runCmd("cluster", "list", "-o", "json")
 	if err != nil {
@@ -187,7 +187,7 @@ func (c *client) ClusterExists() (bool, error) {
 	return false, nil
 }
 
-//RegistryExists checks whether a registry exists
+// RegistryExists checks whether a registry exists
 func (c *client) RegistryExists() (bool, error) {
 	registryName := fmt.Sprintf(defaultRegistryNamePattern, c.clusterName)
 
@@ -198,7 +198,7 @@ func (c *client) RegistryExists() (bool, error) {
 	return registry != nil, nil
 }
 
-//CreateCluster creates a cluster
+// CreateCluster creates a cluster
 func (c *client) CreateCluster(settings CreateClusterSettings) error {
 	k3sImage, err := getK3sImage(settings.KubernetesVersion)
 	if err != nil {

--- a/internal/k3d/registry.go
+++ b/internal/k3d/registry.go
@@ -2,18 +2,18 @@ package k3d
 
 import "encoding/json"
 
-//RegistryList containing Registry entities
+// RegistryList containing Registry entities
 type RegistryList struct {
 	Registries []Registry
 }
 
-//Registry including list of nodes
+// Registry including list of nodes
 type Registry struct {
 	Name  string
 	State State
 }
 
-//Unmarshal converts a JSON to nested structs
+// Unmarshal converts a JSON to nested structs
 func (cl *RegistryList) Unmarshal(data []byte) error {
 	var registries []Registry
 	if err := json.Unmarshal(data, &registries); err != nil {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -74,7 +74,7 @@ func (kv *KymaVersion) String() string {
 	return kv.stringVersion
 }
 
-//GetCurrentKymaVersion determines the semanticVersion of kyma installed in the cluster via the provided kubernetes client
+// GetCurrentKymaVersion determines the semanticVersion of kyma installed in the cluster via the provided kubernetes client
 func GetCurrentKymaVersion(k8s kube.KymaKube) (KymaVersion, error) {
 	isKyma2, err := checkKyma2(k8s)
 	if err != nil {

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -75,7 +75,7 @@ type ContainerRunOpts struct {
 	Ports         map[string]string
 }
 
-//NewClient creates docker client using docker environment of the OS
+// NewClient creates docker client using docker environment of the OS
 func NewClient() (Client, error) {
 	dClient, err := docker.NewClientWithOpts(docker.FromEnv)
 	if err != nil {

--- a/pkg/step/factory.go
+++ b/pkg/step/factory.go
@@ -4,7 +4,7 @@ import (
 	"runtime"
 )
 
-//FactoryInterface is an abstraction for step factory
+// FactoryInterface is an abstraction for step factory
 type FactoryInterface interface {
 	NewStep(msg string) Step
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Update golangci-lint to 1.49.0 to make it work with go 1.18.
- Remove deprecated linters (all have been replaced by the linter `unused`).
- Fix all new linting issues.

**Related issue(s)**
#1381 
