### PR TITLE
Update default K8s version in the "kyma provision" command

### DIFF
--- a/cmd/kyma/provision/cmd.go
+++ b/cmd/kyma/provision/cmd.go
@@ -4,6 +4,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const DefaultK8sShortVersion = "1.24"                       //default K8s version for provisioning clusters on hyperscalers
+const DefaultK8sFullVersion = DefaultK8sShortVersion + ".6" //default K8s version with the "patch" component (mainly for K3d/K3s)
+
 // NewCmd creates a new provision command
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{

--- a/cmd/kyma/provision/cmd.go
+++ b/cmd/kyma/provision/cmd.go
@@ -4,8 +4,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const DefaultK8sShortVersion = "1.24"                       //default K8s version for provisioning clusters on hyperscalers
-const DefaultK8sFullVersion = DefaultK8sShortVersion + ".6" //default K8s version with the "patch" component (mainly for K3d/K3s)
+const DefaultK8sShortVersion = "1.24"                       //default Kubernetes version for provisioning clusters on hyperscalers
+const DefaultK8sFullVersion = DefaultK8sShortVersion + ".6" //default Kubernetes version with the "patch" component (mainly for K3d/K3s)
 
 // NewCmd creates a new provision command
 func NewCmd() *cobra.Command {

--- a/cmd/kyma/provision/gardener/aws/cmd.go
+++ b/cmd/kyma/provision/gardener/aws/cmd.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"github.com/kyma-project/cli/cmd/kyma/provision"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +23,7 @@ Use service account details to create a Secret and import it in Gardener.`,
 	cmd.Flags().StringVarP(&o.Project, "project", "p", "", "Name of the Gardener project where you provision the cluster. (required)")
 	cmd.Flags().StringVarP(&o.CredentialsFile, "credentials", "c", "", "Path to the kubeconfig file of the Gardener service account for AWS. (required)")
 	cmd.Flags().StringVarP(&o.Secret, "secret", "s", "", "Name of the Gardener secret used to access AWS. (required)")
-	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.23", "Kubernetes version of the cluster.")
+	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", provision.DefaultK8sShortVersion, "Kubernetes version of the cluster.")
 	cmd.Flags().StringVarP(&o.Region, "region", "r", "eu-west-3", "Region of the cluster.")
 	cmd.Flags().StringSliceVarP(&o.Zones, "zones", "z", []string{"eu-west-3a"}, "Zones specify availability zones that are used to evenly distribute the worker pool. eg. --zones=\"europe-west3-a,europe-west3-b\"")
 	cmd.Flags().StringVarP(&o.MachineType, "type", "t", "m5.xlarge", "Machine type used for the cluster.")

--- a/cmd/kyma/provision/gardener/aws/cmd_test.go
+++ b/cmd/kyma/provision/gardener/aws/cmd_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"testing"
 
+	"github.com/kyma-project/cli/cmd/kyma/provision"
 	"github.com/kyma-project/cli/internal/cli"
 	"github.com/kyma-project/hydroform/provision/types"
 	"github.com/stretchr/testify/require"
@@ -19,7 +20,7 @@ func TestProvisionGardenerAWSFlags(t *testing.T) {
 	require.Equal(t, "", o.Project, "Default value for the project flag not as expected.")
 	require.Equal(t, "", o.CredentialsFile, "Default value for the credentials flag not as expected.")
 	require.Equal(t, "", o.Secret, "The parsed value for the secret flag not as expected.")
-	require.Equal(t, "1.23", o.KubernetesVersion, "Default value for the kube-version flag not as expected.")
+	require.Equal(t, provision.DefaultK8sShortVersion, o.KubernetesVersion, "Default value for the kube-version flag not as expected.")
 	require.Equal(t, "eu-west-3", o.Region, "Default value for the region flag not as expected.")
 	require.Equal(t, []string{"eu-west-3a"}, o.Zones, "Default value for the zone flag not as expected.")
 	require.Equal(t, "m5.xlarge", o.MachineType, "Default value for the type flag not as expected.")

--- a/cmd/kyma/provision/gardener/az/cmd.go
+++ b/cmd/kyma/provision/gardener/az/cmd.go
@@ -1,6 +1,7 @@
 package az
 
 import (
+	"github.com/kyma-project/cli/cmd/kyma/provision"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +23,7 @@ Create a service account with the ` + "`contributor`" + ` role. Use service acco
 	cmd.Flags().StringVarP(&o.Project, "project", "p", "", "Name of the Gardener project where you provision the cluster. (required)")
 	cmd.Flags().StringVarP(&o.CredentialsFile, "credentials", "c", "", "Path to the kubeconfig file of the Gardener service account for Azure. (required)")
 	cmd.Flags().StringVarP(&o.Secret, "secret", "s", "", "Name of the Gardener secret used to access Azure. (required)")
-	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.23", "Kubernetes version of the cluster.")
+	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", provision.DefaultK8sShortVersion, "Kubernetes version of the cluster.")
 	cmd.Flags().StringVarP(&o.Region, "region", "r", "westeurope", "Region of the cluster.")
 	cmd.Flags().StringSliceVarP(&o.Zones, "zones", "z", []string{"1"}, "Zones specify availability zones that are used to evenly distribute the worker pool. eg. --zones=\"europe-west3-a,europe-west3-b\"")
 	cmd.Flags().StringVarP(&o.MachineType, "type", "t", "Standard_D4_v3", "Machine type used for the cluster.")

--- a/cmd/kyma/provision/gardener/az/cmd_test.go
+++ b/cmd/kyma/provision/gardener/az/cmd_test.go
@@ -3,6 +3,7 @@ package az
 import (
 	"testing"
 
+	"github.com/kyma-project/cli/cmd/kyma/provision"
 	"github.com/kyma-project/cli/internal/cli"
 	"github.com/kyma-project/hydroform/provision/types"
 	"github.com/stretchr/testify/require"
@@ -19,7 +20,7 @@ func TestProvisionGardenerAzureFlags(t *testing.T) {
 	require.Equal(t, "", o.Project, "Default value for the project flag not as expected.")
 	require.Equal(t, "", o.CredentialsFile, "Default value for the credentials flag not as expected.")
 	require.Equal(t, "", o.Secret, "The parsed value for the secret flag not as expected.")
-	require.Equal(t, "1.23", o.KubernetesVersion, "Default value for the kube-version flag not as expected.")
+	require.Equal(t, provision.DefaultK8sShortVersion, o.KubernetesVersion, "Default value for the kube-version flag not as expected.")
 	require.Equal(t, "westeurope", o.Region, "Default value for the region flag not as expected.")
 	require.Equal(t, []string{"1"}, o.Zones, "Default value for the zone flag not as expected.")
 	require.Equal(t, "Standard_D4_v3", o.MachineType, "Default value for the type flag not as expected.")

--- a/cmd/kyma/provision/gardener/gcp/cmd.go
+++ b/cmd/kyma/provision/gardener/gcp/cmd.go
@@ -1,6 +1,7 @@
 package gcp
 
 import (
+	"github.com/kyma-project/cli/cmd/kyma/provision"
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +24,7 @@ Use service account details to create a Secret and import it in Gardener.`,
 	cmd.Flags().StringVarP(&o.Project, "project", "p", "", "Name of the Gardener project where you provision the cluster. (required)")
 	cmd.Flags().StringVarP(&o.CredentialsFile, "credentials", "c", "", "Path to the kubeconfig file of the Gardener service account for GCP. (required)")
 	cmd.Flags().StringVarP(&o.Secret, "secret", "s", "", "Name of the Gardener secret used to access GCP. (required)")
-	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.23", "Kubernetes version of the cluster.")
+	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", provision.DefaultK8sShortVersion, "Kubernetes version of the cluster.")
 	cmd.Flags().StringVarP(&o.Region, "region", "r", "europe-west3", "Region of the cluster.")
 	cmd.Flags().StringSliceVarP(&o.Zones, "zones", "z", []string{"europe-west3-a"}, "Zones specify availability zones that are used to evenly distribute the worker pool. eg. --zones=\"europe-west3-a,europe-west3-b\"")
 	cmd.Flags().StringVarP(&o.MachineType, "type", "t", "n1-standard-4", "Machine type used for the cluster.")

--- a/cmd/kyma/provision/gardener/gcp/cmd_test.go
+++ b/cmd/kyma/provision/gardener/gcp/cmd_test.go
@@ -3,6 +3,7 @@ package gcp
 import (
 	"testing"
 
+	"github.com/kyma-project/cli/cmd/kyma/provision"
 	"github.com/kyma-project/cli/internal/cli"
 	"github.com/kyma-project/hydroform/provision/types"
 	"github.com/stretchr/testify/require"
@@ -19,7 +20,7 @@ func TestProvisionGardenerGCPFlags(t *testing.T) {
 	require.Equal(t, "", o.Project, "Default value for the project flag not as expected.")
 	require.Equal(t, "", o.CredentialsFile, "Default value for the credentials flag not as expected.")
 	require.Equal(t, "", o.Secret, "The parsed value for the secret flag not as expected.")
-	require.Equal(t, "1.23", o.KubernetesVersion, "Default value for the kube-version flag not as expected.")
+	require.Equal(t, provision.DefaultK8sShortVersion, o.KubernetesVersion, "Default value for the kube-version flag not as expected.")
 	require.Equal(t, "europe-west3", o.Region, "Default value for the region flag not as expected.")
 	require.Equal(t, []string{"europe-west3-a"}, o.Zones, "Default value for the zone flag not as expected.")
 	require.Equal(t, "n1-standard-4", o.MachineType, "Default value for the type flag not as expected.")

--- a/cmd/kyma/provision/k3d/cmd.go
+++ b/cmd/kyma/provision/k3d/cmd.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kyma-project/cli/cmd/kyma/provision"
 	"github.com/kyma-project/cli/internal/cli"
 	"github.com/kyma-project/cli/internal/k3d"
 
@@ -40,7 +41,7 @@ func NewCmd(o *Options) *cobra.Command {
 	cmd.Flags().StringSliceVarP(&o.K3sArgs, "k3s-arg", "s", []string{}, "One or more arguments passed from k3d to the k3s command (format: ARG@NODEFILTER[;@NODEFILTER])")
 	cmd.Flags().DurationVar(&o.Timeout, "timeout", 5*time.Minute, `Maximum time for the provisioning. If you want no timeout, enter "0".`)
 	cmd.Flags().StringSliceVarP(&o.K3dArgs, "k3d-arg", "", []string{}, "One or more arguments passed to the k3d provisioning command (e.g. --k3d-arg='--no-rollback')")
-	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", "1.23.8", "Kubernetes version of the cluster")
+	cmd.Flags().StringVarP(&o.KubernetesVersion, "kube-version", "k", provision.DefaultK8sFullVersion, "Kubernetes version of the cluster")
 	cmd.Flags().StringSliceVar(&o.UseRegistry, "registry-use", []string{}, "Connect to one or more k3d-managed registries. Kyma automatically creates a registry for Serverless images.")
 	cmd.Flags().StringVar(&o.RegistryPort, "registry-port", "5001", "Specify the port on which the k3d registry will be exposed")
 	cmd.Flags().StringSliceVarP(&o.PortMapping, "port", "p", []string{"80:80@loadbalancer", "443:443@loadbalancer"}, "Map ports 80 and 443 of K3D loadbalancer (e.g. -p 80:80@loadbalancer -p 443:443@loadbalancer)")

--- a/docs/gen-docs/kyma_provision_gardener_aws.md
+++ b/docs/gen-docs/kyma_provision_gardener_aws.md
@@ -26,7 +26,7 @@ kyma provision gardener aws [flags]
       --hibernation-end string        Cron expression to configure when the cluster should stop hibernating
       --hibernation-location string   Timezone in which the hibernation schedule should be applied. (default "Europe/Berlin")
       --hibernation-start string      Cron expression to configure when the cluster should start hibernating (default "00 18 * * 1,2,3,4,5")
-  -k, --kube-version string           Kubernetes version of the cluster. (default "1.23")
+  -k, --kube-version string           Kubernetes version of the cluster. (default "1.24")
   -n, --name string                   Name of the cluster to provision. (required)
   -p, --project string                Name of the Gardener project where you provision the cluster. (required)
   -r, --region string                 Region of the cluster. (default "eu-west-3")

--- a/docs/gen-docs/kyma_provision_gardener_az.md
+++ b/docs/gen-docs/kyma_provision_gardener_az.md
@@ -25,7 +25,7 @@ kyma provision gardener az [flags]
       --hibernation-end string        Cron expression to configure when the cluster should stop hibernating
       --hibernation-location string   Timezone in which the hibernation schedule should be applied. (default "Europe/Berlin")
       --hibernation-start string      Cron expression to configure when the cluster should start hibernating (default "00 18 * * 1,2,3,4,5")
-  -k, --kube-version string           Kubernetes version of the cluster. (default "1.23")
+  -k, --kube-version string           Kubernetes version of the cluster. (default "1.24")
   -n, --name string                   Name of the cluster to provision. (required)
   -p, --project string                Name of the Gardener project where you provision the cluster. (required)
   -r, --region string                 Region of the cluster. (default "westeurope")

--- a/docs/gen-docs/kyma_provision_gardener_gcp.md
+++ b/docs/gen-docs/kyma_provision_gardener_gcp.md
@@ -26,7 +26,7 @@ kyma provision gardener gcp [flags]
       --hibernation-end string        Cron expression to configure when the cluster should stop hibernating
       --hibernation-location string   Timezone in which the hibernation schedule should be applied. (default "Europe/Berlin")
       --hibernation-start string      Cron expression to configure when the cluster should start hibernating (default "00 18 * * 1,2,3,4,5")
-  -k, --kube-version string           Kubernetes version of the cluster. (default "1.23")
+  -k, --kube-version string           Kubernetes version of the cluster. (default "1.24")
   -n, --name string                   Name of the cluster to provision. (required)
   -p, --project string                Name of the Gardener project where you provision the cluster. (required)
   -r, --region string                 Region of the cluster. (default "europe-west3")

--- a/docs/gen-docs/kyma_provision_k3d.md
+++ b/docs/gen-docs/kyma_provision_k3d.md
@@ -17,7 +17,7 @@ kyma provision k3d [flags]
 ```bash
       --k3d-arg strings        One or more arguments passed to the k3d provisioning command (e.g. --k3d-arg='--no-rollback')
   -s, --k3s-arg strings        One or more arguments passed from k3d to the k3s command (format: ARG@NODEFILTER[;@NODEFILTER])
-  -k, --kube-version string    Kubernetes version of the cluster (default "1.23.8")
+  -k, --kube-version string    Kubernetes version of the cluster (default "1.24.6")
       --name string            Name of the Kyma cluster (default "kyma")
   -p, --port strings           Map ports 80 and 443 of K3D loadbalancer (e.g. -p 80:80@loadbalancer -p 443:443@loadbalancer) (default [80:80@loadbalancer,443:443@loadbalancer])
       --registry-port string   Specify the port on which the k3d registry will be exposed (default "5001")

--- a/internal/clusterinfo/clusterinfo_test.go
+++ b/internal/clusterinfo/clusterinfo_test.go
@@ -2,11 +2,13 @@ package clusterinfo
 
 import (
 	"context"
+	"testing"
+
+	"github.com/kyma-project/cli/cmd/kyma/provision"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
-	"testing"
 )
 
 func TestDiscover(t *testing.T) {
@@ -57,7 +59,7 @@ func TestDiscover(t *testing.T) {
 				{
 					Status: corev1.NodeStatus{
 						NodeInfo: corev1.NodeSystemInfo{
-							KubeProxyVersion: "v1.23.10-gke.1000",
+							KubeProxyVersion: "v" + provision.DefaultK8sFullVersion + "-gke.1000",
 						},
 					},
 				},


### PR DESCRIPTION
**Description**

Update default K8s version used in the `kyma provision` command to 1.24(.6)

Changes proposed in this pull request:

- default K8s version used in `kyma provision` command updated to 1.24(.6)
- introduce global constants that control the default version, so that future upgrades will be simpler

**Related issue(s)**

#1409 