### PR TITLE
WIP Update CLI

### DIFF
--- a/cmd/kyma/apply/function/function.go
+++ b/cmd/kyma/apply/function/function.go
@@ -115,15 +115,6 @@ func (c *command) Run() error {
 		return err
 	}
 
-	if configuration.Source.Type == workspace.SourceTypeGit {
-		gitRepository, err := resources.NewPublicGitRepository(configuration)
-		if err != nil {
-			step.Failure()
-			return errors.Wrap(err, "Unable to read the Git repository from the provided configuration")
-		}
-		mgr.AddParent(operator.NewGenericOperator(client.Resource(operator.GVRGitRepository).Namespace(configuration.Namespace), gitRepository), nil)
-	}
-
 	mgr.AddParent(
 		operator.NewGenericOperator(client.Resource(operator.GVRFunction).Namespace(configuration.Namespace), function),
 		[]operator.Operator{


### PR DESCRIPTION
**Description**
`gitRepository` fields such as `gitRepository.Spec.URL` [are now being moved to](https://github.com/kyma-project/hydroform/pull/386) `function.Spec.Source.GitRepository` so any code calling the base `gitRepository` structure is being removed as it will no longer exist.

**Related issue(s)**
https://github.com/kyma-project/cli/issues/1314
Depends on: https://github.com/kyma-project/hydroform/pull/386
