### PR TITLE
Rremove tobiscr as codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # These are the default owners for the whole content of the repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @clebs @jeremyharisch @tobiscr @khlifi411 @ruanxin @Tomasz-Smelcerz-SAP @jakobmoellersap @adityabhatia @a-thaler @lilitgh @rakesh-garimella @skhalash @chrkl @lindnerby @adityabhatia @dennis-ge
+* @clebs @jeremyharisch @khlifi411 @ruanxin @Tomasz-Smelcerz-SAP @jakobmoellersap @adityabhatia @a-thaler @lilitgh @rakesh-garimella @skhalash @chrkl @lindnerby @adityabhatia @dennis-ge
 
 # Owners of the .kyma-project-io folder
 /.kyma-project-io/ @m00g3n @pPrecel @dbadura @kwiatekus @moelsayed @cortey @anoipm


### PR DESCRIPTION
**Description**

Caused by internal team rearrangements, dropping myself as code owner from the CLI.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
