### PR TITLE
If CI mode enabled, disable DetectManagedEnvironmentCheck

### DIFF
--- a/cmd/kyma/deploy/cmd.go
+++ b/cmd/kyma/deploy/cmd.go
@@ -122,8 +122,10 @@ func (cmd *command) run() error {
 		return errors.Wrap(err, "failed to initialize the Kubernetes client from given kubeconfig")
 	}
 
-	if err := cli.DetectManagedEnvironment(cmd.K8s, cmd.Factory.NewStep("")); err != nil {
-		return err
+	if !cmd.opts.NonInteractive {
+		if err := cli.DetectManagedEnvironment(cmd.K8s, cmd.Factory.NewStep("")); err != nil {
+			return err
+		}
 	}
 
 	if err := cmd.decideVersionUpgrade(); err != nil {

--- a/cmd/kyma/undeploy/cmd.go
+++ b/cmd/kyma/undeploy/cmd.go
@@ -83,8 +83,10 @@ func (cmd *command) Run() error {
 		return errors.Wrap(err, "Cannot initialize the Kubernetes client. Make sure your kubeconfig is valid")
 	}
 
-	if err := cli.DetectManagedEnvironment(cmd.K8s, cmd.Factory.NewStep("")); err != nil {
-		return err
+	if !cmd.opts.NonInteractive {
+		if err := cli.DetectManagedEnvironment(cmd.K8s, cmd.Factory.NewStep("")); err != nil {
+			return err
+		}
 	}
 
 	kubeconfigPath := kube.KubeconfigPath(cmd.KubeconfigPath)

--- a/internal/root/root.go
+++ b/internal/root/root.go
@@ -10,7 +10,7 @@ func PromptUser() bool {
 			return false
 		}
 		switch res {
-		case "yes", "y":
+		case "Yes", "Y", "yes", "y":
 			return true
 		case "No", "N", "no", "n":
 			return false


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
When the CLI is used in Pipelines to change SKR-CLusters, it fails due to the `DetectManagedEnvironment` check. This should be skipped if the `--ci` flag is set.

Changes proposed in this pull request:

- When `DetectManagedEnvironment` is called check beforehand if CI-mode is activated
- Skip check if then

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
