### PR TITLE
Allow to share docker registry between local k3d clusters

### DIFF
--- a/cmd/kyma/provision/k3d/cmd.go
+++ b/cmd/kyma/provision/k3d/cmd.go
@@ -58,7 +58,6 @@ func (c *command) Run() error {
 	}
 
 	var err error
-	var registries []string
 
 	k3dClient := k3d.NewClient(k3d.NewCmdRunner(), k3d.NewPathLooker(), c.opts.Name, c.opts.Verbose, c.opts.Timeout)
 
@@ -71,10 +70,10 @@ func (c *command) Run() error {
 		if err != nil {
 			return err
 		}
-		registries = append(registries, defaultRegistry)
+		c.opts.UseRegistry = append(c.opts.UseRegistry, defaultRegistry)
 	}
 
-	if err = c.createK3dCluster(k3dClient, registries); err != nil {
+	if err = c.createK3dCluster(k3dClient); err != nil {
 		return err
 	}
 
@@ -172,7 +171,7 @@ func (c *command) createK3dRegistry(k3dClient k3d.Client) (string, error) {
 }
 
 // Create a k3d cluster
-func (c *command) createK3dCluster(k3dClient k3d.Client, registries []string) error {
+func (c *command) createK3dCluster(k3dClient k3d.Client) error {
 	s := c.NewStep(fmt.Sprintf("Create K3d cluster '%s'", c.opts.Name))
 
 	settings := k3d.CreateClusterSettings{
@@ -181,7 +180,7 @@ func (c *command) createK3dCluster(k3dClient k3d.Client, registries []string) er
 		PortMapping:       c.opts.PortMapping,
 		Workers:           c.opts.Workers,
 		K3sArgs:           c.opts.K3sArgs,
-		UseRegistry:       registries,
+		UseRegistry:       c.opts.UseRegistry,
 	}
 
 	err := k3dClient.CreateCluster(settings)

--- a/cmd/kyma/provision/k3d/cmd.go
+++ b/cmd/kyma/provision/k3d/cmd.go
@@ -65,9 +65,13 @@ func (c *command) Run() error {
 	if err = c.verifyK3dStatus(k3dClient); err != nil {
 		return err
 	}
-	if registryURL, err = c.createK3dRegistry(k3dClient); err != nil {
-		return err
+
+	if len(c.opts.UseRegistry) == 0 {
+		if registryURL, err = c.createK3dRegistry(k3dClient); err != nil {
+			return err
+		}
 	}
+
 	if err = c.createK3dCluster(k3dClient, registryURL); err != nil {
 		return err
 	}
@@ -96,7 +100,7 @@ func (c *command) verifyK3dStatus(k3dClient k3d.Client) error {
 	}
 
 	s.LogInfo("Checking if k3d cluster of previous kyma installation exists")
-	clusterExists, err := k3dClient.ClusterExists()
+	clusterExists, err := k3dClient.ClusterExists(c.opts.Name)
 	if err != nil {
 		s.Failure()
 		return err
@@ -168,7 +172,9 @@ func (c *command) createK3dRegistry(k3dClient k3d.Client) (string, error) {
 func (c *command) createK3dCluster(k3dClient k3d.Client, registryURL string) error {
 	s := c.NewStep(fmt.Sprintf("Create K3d cluster '%s'", c.opts.Name))
 
-	c.opts.UseRegistry = append(c.opts.UseRegistry, registryURL)
+	if len(registryURL) > 0 {
+		c.opts.UseRegistry = append(c.opts.UseRegistry, registryURL)
+	}
 
 	settings := k3d.CreateClusterSettings{
 		Args:              parseK3dArgs(c.opts.K3dArgs),

--- a/cmd/kyma/provision/k3d/cmd.go
+++ b/cmd/kyma/provision/k3d/cmd.go
@@ -100,7 +100,7 @@ func (c *command) verifyK3dStatus(k3dClient k3d.Client) error {
 	}
 
 	s.LogInfo("Checking if k3d cluster of previous kyma installation exists")
-	clusterExists, err := k3dClient.ClusterExists(c.opts.Name)
+	clusterExists, err := k3dClient.ClusterExists()
 	if err != nil {
 		s.Failure()
 		return err

--- a/cmd/kyma/provision/k3d/cmd.go
+++ b/cmd/kyma/provision/k3d/cmd.go
@@ -58,7 +58,7 @@ func (c *command) Run() error {
 	}
 
 	var err error
-	var registryURL string
+	var registries []string
 
 	k3dClient := k3d.NewClient(k3d.NewCmdRunner(), k3d.NewPathLooker(), c.opts.Name, c.opts.Verbose, c.opts.Timeout)
 
@@ -67,14 +67,17 @@ func (c *command) Run() error {
 	}
 
 	if len(c.opts.UseRegistry) == 0 {
-		if registryURL, err = c.createK3dRegistry(k3dClient); err != nil {
+		defaultRegistry, err := c.createK3dRegistry(k3dClient)
+		if err != nil {
 			return err
 		}
+		registries = append(registries, defaultRegistry)
 	}
 
-	if err = c.createK3dCluster(k3dClient, registryURL); err != nil {
+	if err = c.createK3dCluster(k3dClient, registries); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -169,12 +172,8 @@ func (c *command) createK3dRegistry(k3dClient k3d.Client) (string, error) {
 }
 
 // Create a k3d cluster
-func (c *command) createK3dCluster(k3dClient k3d.Client, registryURL string) error {
+func (c *command) createK3dCluster(k3dClient k3d.Client, registries []string) error {
 	s := c.NewStep(fmt.Sprintf("Create K3d cluster '%s'", c.opts.Name))
-
-	if len(registryURL) > 0 {
-		c.opts.UseRegistry = append(c.opts.UseRegistry, registryURL)
-	}
 
 	settings := k3d.CreateClusterSettings{
 		Args:              parseK3dArgs(c.opts.K3dArgs),
@@ -182,7 +181,7 @@ func (c *command) createK3dCluster(k3dClient k3d.Client, registryURL string) err
 		PortMapping:       c.opts.PortMapping,
 		Workers:           c.opts.Workers,
 		K3sArgs:           c.opts.K3sArgs,
-		UseRegistry:       c.opts.UseRegistry,
+		UseRegistry:       registries,
 	}
 
 	err := k3dClient.CreateCluster(settings)

--- a/cmd/kyma/provision/k3d/opts.go
+++ b/cmd/kyma/provision/k3d/opts.go
@@ -10,7 +10,7 @@ import (
 type Options struct {
 	*cli.Options
 
-	Name              string
+	Name              string //here
 	Workers           int
 	Timeout           time.Duration
 	K3sArgs           []string

--- a/cmd/kyma/provision/k3d/opts.go
+++ b/cmd/kyma/provision/k3d/opts.go
@@ -10,7 +10,7 @@ import (
 type Options struct {
 	*cli.Options
 
-	Name              string //here
+	Name              string
 	Workers           int
 	Timeout           time.Duration
 	K3sArgs           []string

--- a/internal/k3d/k3d.go
+++ b/internal/k3d/k3d.go
@@ -22,7 +22,7 @@ type Client interface {
 	runCmd(args ...string) (string, error)
 	checkVersion() error
 	VerifyStatus() error
-	ClusterExists(name string) (bool, error)
+	ClusterExists() (bool, error)
 	RegistryExists() (bool, error)
 	CreateCluster(settings CreateClusterSettings) error
 	CreateRegistry(registryPort string) (string, error)
@@ -161,7 +161,7 @@ func (c *client) VerifyStatus() error {
 }
 
 // ClusterExists checks whether the given cluster exists
-func (c *client) ClusterExists(name string) (bool, error) {
+func (c *client) ClusterExists() (bool, error) {
 	clusterJSON, err := c.runCmd("cluster", "list", "-o", "json")
 	if err != nil {
 		return false, err

--- a/internal/k3d/k3d.go
+++ b/internal/k3d/k3d.go
@@ -22,7 +22,7 @@ type Client interface {
 	runCmd(args ...string) (string, error)
 	checkVersion() error
 	VerifyStatus() error
-	ClusterExists() (bool, error)
+	ClusterExists(name string) (bool, error)
 	RegistryExists() (bool, error)
 	CreateCluster(settings CreateClusterSettings) error
 	CreateRegistry(registryPort string) (string, error)
@@ -160,8 +160,8 @@ func (c *client) VerifyStatus() error {
 	return err
 }
 
-// ClusterExists checks whether a cluster exists
-func (c *client) ClusterExists() (bool, error) {
+// ClusterExists checks whether the given cluster exists
+func (c *client) ClusterExists(name string) (bool, error) {
 	clusterJSON, err := c.runCmd("cluster", "list", "-o", "json")
 	if err != nil {
 		return false, err
@@ -216,6 +216,7 @@ func (c *client) CreateCluster(settings CreateClusterSettings) error {
 	cmdArgs = append(cmdArgs, getCreateClusterArgs(settings)...)
 
 	cmdArgs = append(cmdArgs, constructArgs("--port", settings.PortMapping)...)
+
 	//add further k3d args which are not offered by the Kyma CLI flags
 	cmdArgs = append(cmdArgs, settings.Args...)
 

--- a/internal/k3d/k3d.go
+++ b/internal/k3d/k3d.go
@@ -160,7 +160,7 @@ func (c *client) VerifyStatus() error {
 	return err
 }
 
-// ClusterExists checks whether the given cluster exists
+// ClusterExists checks whether a cluster exists
 func (c *client) ClusterExists() (bool, error) {
 	clusterJSON, err := c.runCmd("cluster", "list", "-o", "json")
 	if err != nil {
@@ -216,7 +216,6 @@ func (c *client) CreateCluster(settings CreateClusterSettings) error {
 	cmdArgs = append(cmdArgs, getCreateClusterArgs(settings)...)
 
 	cmdArgs = append(cmdArgs, constructArgs("--port", settings.PortMapping)...)
-
 	//add further k3d args which are not offered by the Kyma CLI flags
 	cmdArgs = append(cmdArgs, settings.Args...)
 


### PR DESCRIPTION
**Description**

Change the behavior of the `kyma provision k3d` command: Create a default registry named _k3d-<cluster-name>-registry_ only if `--registry-use` flag is not provided.

This change allows the CLI to provision two k3d clusters sharing the same local registry.

Changes proposed in this pull request:

- Change the behavior of the `kyma provision k3d` command: Create a default registry named _"k3d-\<cluster-name\>-registry"_ only if the `--registry-use` flag is not provided.

**Related issue(s)**
#1385