### PR TITLE
Feature/improved insecure detection

### DIFF
--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -214,11 +214,18 @@ func (cmd *command) validateInsecureRegistry() (*module.Remote, error) {
 
 	//Override insecure setting if https (because it's secure)
 	if strings.HasPrefix(cmd.opts.RegistryURL, "https:") {
+		if cmd.opts.Insecure == "true" {
+			return nil, errors.New("the provided value of the --insecure flag does not match the configured secure registry (https://)")
+		}
 		res.Insecure = false
 	}
 
 	if strings.HasPrefix(cmd.opts.RegistryURL, "http:") {
+		if cmd.opts.Insecure == "false" {
+			return nil, errors.New("the provided value of the --insecure flag does not match the configured insecure registry (http://)")
+		}
 		res.Insecure = true
+
 		//If user has not defined --insecure flag explicitly, display a warning
 		cmd.CurrentStep.LogWarn("CAUTION: You are about to push the module artifact to the insecure registry")
 		if cmd.opts.Insecure == "" && !cmd.opts.NonInteractive {

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -65,7 +65,7 @@ Build module modB in version 3.2.1 and push it to a local registry "unsigned" su
 	cmd.Flags().StringVar(&o.Channel, "channel", "stable", "Channel to use for the module template.")
 	cmd.Flags().StringVarP(&o.Token, "token", "t", "", "Authentication token for the given registry (alternative to basic authentication).")
 	cmd.Flags().BoolVarP(&o.Overwrite, "overwrite", "w", false, "overwrites the existing mod-path directory if it exists")
-	cmd.Flags().BoolVar(&o.Insecure, "insecure", false, "Allow to use an insecure connection to access the registry.")
+	cmd.Flags().BoolVar(&o.Insecure, "insecure", false, "Use an insecure connection to access the registry.")
 	cmd.Flags().BoolVar(&o.Clean, "clean", false, "Remove the mod-path folder and all its contents at the end.")
 
 	return cmd

--- a/cmd/kyma/alpha/create/module/opts.go
+++ b/cmd/kyma/alpha/create/module/opts.go
@@ -14,7 +14,7 @@ type Options struct {
 	TemplateOutput string
 	Channel        string
 	Token          string
-	Insecure       string
+	Insecure       bool
 	ResourcePaths  []string
 	Overwrite      bool
 	Clean          bool

--- a/cmd/kyma/alpha/create/module/opts.go
+++ b/cmd/kyma/alpha/create/module/opts.go
@@ -14,7 +14,7 @@ type Options struct {
 	TemplateOutput string
 	Channel        string
 	Token          string
-	Insecure       bool
+	Insecure       string
 	ResourcePaths  []string
 	Overwrite      bool
 	Clean          bool


### PR DESCRIPTION
**Description**

Improved handling of the `--insecure` flag, according the the https://github.com/kyma-project/cli/issues/1367
Changes proposed in this pull request:

- `--insecure` flag is now parsed manually so that we can detect it wasn't provided at all
- If the flag is not provided, and we detect insecure registry URL (http), the user is prompted unless in the NonInteractive mode
- It is an error now to provide insecure registry URL (http) and explicitly define `--insecure=false`. The same logic applies to https registries and `--insecure=true` combination.

**Related issue(s)**
https://github.com/kyma-project/cli/issues/1367