### PR TITLE
Fix coredns patching for modular kyma on k3d

### DIFF
--- a/cmd/kyma/alpha/deploy/cmd.go
+++ b/cmd/kyma/alpha/deploy/cmd.go
@@ -31,6 +31,13 @@ type command struct {
 	opts *Options
 }
 
+const (
+	hostsTemplate = `
+    {{ .K3dRegistryIP}} {{ .K3dRegistryHost}}
+    {{ .K3dRegistryIP}} {{ .K3dRegistryHost}}.localhost
+`
+)
+
 // NewCmd creates a new deploy command
 func NewCmd(o *Options) *cobra.Command {
 
@@ -168,7 +175,7 @@ func (cmd *command) deploy(start time.Time) error {
 		return err
 	}
 
-	if _, err := coredns.Patch(l.Desugar(), cmd.K8s.Static(), false, clusterInfo); err != nil {
+	if _, err := coredns.Patch(l.Desugar(), cmd.K8s.Static(), false, clusterInfo, hostsTemplate); err != nil {
 		return err
 	}
 

--- a/cmd/kyma/alpha/deploy/cmd.go
+++ b/cmd/kyma/alpha/deploy/cmd.go
@@ -158,7 +158,7 @@ func (cmd *command) deploy(start time.Time) error {
 
 	clusterInfo, err := clusterinfo.Discover(context.Background(), cmd.K8s.Static())
 	if err != nil {
-		return errors.Wrap(err, "failed to discover underlying cluster type")
+		return err
 	}
 
 	deployStep := cmd.NewStep("Deploying Kyma")

--- a/cmd/kyma/deploy/cmd.go
+++ b/cmd/kyma/deploy/cmd.go
@@ -154,7 +154,7 @@ func (cmd *command) deploy(start time.Time) error {
 	}
 
 	hasCustomDomain := cmd.opts.Domain != ""
-	if _, err := coredns.Patch(l.Desugar(), cmd.K8s.Static(), hasCustomDomain, clusterInfo); err != nil {
+	if _, err := coredns.Patch(l.Desugar(), cmd.K8s.Static(), hasCustomDomain, clusterInfo, ""); err != nil {
 		return err
 	}
 

--- a/internal/coredns/coredns.go
+++ b/internal/coredns/coredns.go
@@ -49,6 +49,7 @@ const (
 `
 	hostsTemplate = `
     {{ .K3dRegistryIP}} {{ .K3dRegistryHost}}
+	{{ .K3dRegistryIP}} {{ .K3dRegistryHost}}.localhost
 `
 	// Default domain names for coreDNS patch
 	coreDNSLocalDomainName  = `(.*)\.local\.kyma\.dev`

--- a/internal/coredns/coredns.go
+++ b/internal/coredns/coredns.go
@@ -47,9 +47,8 @@ const (
     loadbalance
 }
 `
-	hostsTemplate = `
+	defaultHostsTemplate = `
     {{ .K3dRegistryIP}} {{ .K3dRegistryHost}}
-	{{ .K3dRegistryIP}} {{ .K3dRegistryHost}}.localhost
 `
 	// Default domain names for coreDNS patch
 	coreDNSLocalDomainName  = `(.*)\.local\.kyma\.dev`
@@ -57,7 +56,7 @@ const (
 )
 
 // Patch patches the CoreDNS configuration based on the overrides and the cloud provider.
-func Patch(logger *zap.Logger, kubeClient kubernetes.Interface, hasCustomDomain bool, clusterInfo clusterinfo.Info) (cm *v1.ConfigMap, err error) {
+func Patch(logger *zap.Logger, kubeClient kubernetes.Interface, hasCustomDomain bool, clusterInfo clusterinfo.Info, customHostsTemplate string) (cm *v1.ConfigMap, err error) {
 	err = retry.Do(func() error {
 		_, err := kubeClient.AppsV1().Deployments("kube-system").Get(context.TODO(), "coredns", metav1.GetOptions{})
 		if err != nil {
@@ -69,7 +68,7 @@ func Patch(logger *zap.Logger, kubeClient kubernetes.Interface, hasCustomDomain 
 		}
 
 		// patches contain each key and value that needs to be patched in the coredns configmap data field.
-		patches, err := generatePatches(hasCustomDomain, clusterInfo)
+		patches, err := generatePatches(hasCustomDomain, clusterInfo, customHostsTemplate)
 		if err != nil {
 			return err
 		}
@@ -135,7 +134,7 @@ func newCoreDNSConfigMap(data map[string]string) *v1.ConfigMap {
 	}
 }
 
-func generatePatches(hasCustomDomain bool, clusterInfo clusterinfo.Info) (map[string]string, error) {
+func generatePatches(hasCustomDomain bool, clusterInfo clusterinfo.Info, customHostsTemplate string) (map[string]string, error) {
 	var err error
 	patches := make(map[string]string)
 
@@ -156,7 +155,7 @@ func generatePatches(hasCustomDomain bool, clusterInfo clusterinfo.Info) (map[st
 
 	// Patch NodeHosts only on K3d
 	if k3d, isK3d := clusterInfo.(clusterinfo.K3d); isK3d {
-		patches["NodeHosts"], err = generateHosts(k3d.ClusterName)
+		patches["NodeHosts"], err = generateHosts(k3d.ClusterName, customHostsTemplate)
 		if err != nil {
 			return nil, err
 		}
@@ -180,12 +179,16 @@ func generateCorefile(domainName string) (coreFile string, err error) {
 	return
 }
 
-func generateHosts(clusterName string) (string, error) {
+func generateHosts(clusterName string, customHostsTemplate string) (string, error) {
+
 	registryIP, err := k3dRegistryIP(clusterName)
 	if err != nil {
 		return "", err
 	}
-
+	hostsTemplate := defaultHostsTemplate
+	if customHostsTemplate != "" {
+		hostsTemplate = customHostsTemplate
+	}
 	patchVars := struct {
 		K3dRegistryHost string
 		K3dRegistryIP   string


### PR DESCRIPTION
Changes proposed in this pull request:

- patch coredns not only for `deploy` but also for `alpha deploy` command
- update the `NodeHosts` template to include `k3d-{clustername}-registry.localhost` variant 


**Related issue(s)**
https://github.com/kyma-project/cli/issues/1454
Found by https://github.com/kyma-project/keda-manager/issues/57