### PR TITLE
refactor: remove module-manager 'operator' folder

### DIFF
--- a/cmd/kyma/alpha/deploy/cmd.go
+++ b/cmd/kyma/alpha/deploy/cmd.go
@@ -45,9 +45,9 @@ func NewCmd(o *Options) *cobra.Command {
 	Defaults to deploying Lifecycle Manager and Module Manager from GitHub main branch.
 	Examples:
 	- Deploy a specific release of the Lifecycle Manager: "kyma deploy -k https://github.com/kyma-project/lifecycle-manager/config/default@1.2.3"
-	- Deploy a local Module Manager: "kyma deploy --kustomization /path/to/repo/module-manager/operator/config/default"
+	- Deploy a local Module Manager: "kyma deploy --kustomization /path/to/repo/module-manager/config/default"
 	- Deploy a branch of Lifecycle Manager with a custom URL: "kyma deploy -k https://gitlab.com/forked-from-github/lifecycle-manager/config/default@feature-branch-1"
-	- Deploy the main branch of Lifecycle Manager while using local sources of Module Manager: "kyma deploy -k /path/to/repo/module-manager/operator/config/default -k https://github.com/kyma-project/lifecycle-manager/config/default@main"`)
+	- Deploy the main branch of Lifecycle Manager while using local sources of Module Manager: "kyma deploy -k /path/to/repo/module-manager/config/default -k https://github.com/kyma-project/lifecycle-manager/config/default@main"`)
 	cobraCmd.Flags().StringArrayVarP(&o.Modules, "module", "m", []string{}, `Provide one or more modules to activate after the deployment is finished. Example: "--module name@namespace" (namespace is optional).`)
 	cobraCmd.Flags().StringVarP(&o.ModulesFile, "modules-file", "f", "", `Path to file containing a list of modules.`)
 	cobraCmd.Flags().StringVarP(&o.Channel, "channel", "c", "stable", `Select which channel to deploy from: stable, fast, nightly.`)

--- a/docs/gen-docs/kyma_alpha_deploy.md
+++ b/docs/gen-docs/kyma_alpha_deploy.md
@@ -21,9 +21,9 @@ kyma alpha deploy [flags]
                                     	Defaults to deploying Lifecycle Manager and Module Manager from GitHub main branch.
                                     	Examples:
                                     	- Deploy a specific release of the Lifecycle Manager: "kyma deploy -k https://github.com/kyma-project/lifecycle-manager/config/default@1.2.3"
-                                    	- Deploy a local Module Manager: "kyma deploy --kustomization /path/to/repo/module-manager/operator/config/default"
+                                    	- Deploy a local Module Manager: "kyma deploy --kustomization /path/to/repo/module-manager/config/default"
                                     	- Deploy a branch of Lifecycle Manager with a custom URL: "kyma deploy -k https://gitlab.com/forked-from-github/lifecycle-manager/config/default@feature-branch-1"
-                                    	- Deploy the main branch of Lifecycle Manager while using local sources of Module Manager: "kyma deploy -k /path/to/repo/module-manager/operator/config/default -k https://github.com/kyma-project/lifecycle-manager/config/default@main"
+                                    	- Deploy the main branch of Lifecycle Manager while using local sources of Module Manager: "kyma deploy -k /path/to/repo/module-manager/config/default -k https://github.com/kyma-project/lifecycle-manager/config/default@main"
       --kyma-cr string              Provide a custom Kyma CR file for the deployment.
   -m, --module stringArray          Provide one or more modules to activate after the deployment is finished. Example: "--module name@namespace" (namespace is optional).
   -f, --modules-file string         Path to file containing a list of modules.

--- a/internal/deploy/bootstrap.go
+++ b/internal/deploy/bootstrap.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	defaultLifecycleManager = "https://github.com/kyma-project/lifecycle-manager/config/default"
-	defaultModuleManager    = "https://github.com/kyma-project/module-manager/operator/config/default"
+	defaultModuleManager    = "https://github.com/kyma-project/module-manager/config/default"
 	defaultRetries          = 3
 	defaultInitialBackoff   = 3 * time.Second
 )


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Move module-manager up by one level by removing the 'operator' folder

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/module-manager/issues/156
