### PR TITLE
Use URL and Version from Components file

### DIFF
--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -139,6 +139,8 @@ func prepareKebComponents(components component.List, vals values.Values) ([]*keb
 		kebComponent := keb.Component{
 			Component: c.Name,
 			Namespace: c.Namespace,
+			URL:       c.URL,
+			Version:   c.Version,
 		}
 		if componentVals, exists := vals[c.Name]; exists {
 			valsMap, ok := componentVals.(map[string]interface{})

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -99,6 +99,7 @@ func TestPrepareKebComponents(t *testing.T) {
 	require.Equal(t, expected[2].Namespace, (result)[2].Namespace)
 	require.Equal(t, expected[3].Component, (result)[3].Component)
 	require.ElementsMatch(t, expected[3].Configuration, (result)[3].Configuration)
+	require.Equal(t, expected[3].Namespace, (result)[3].Namespace)
 	require.Equal(t, expected[3].URL, (result)[3].URL)
 	require.Equal(t, expected[3].Version, (result)[3].Version)
 }

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -15,7 +15,11 @@ func TestPrepareKebComponents(t *testing.T) {
 	var components = component.List{
 		DefaultNamespace: "ns-1",
 		Prerequisites:    []component.Definition{{Name: "pre-1", Namespace: "ns-1"}},
-		Components:       []component.Definition{{Name: "comp-1", Namespace: "ns-2"}, {Name: "comp-2", Namespace: "ns-1"}},
+		Components: []component.Definition{
+			{Name: "comp-1", Namespace: "ns-2"},
+			{Name: "comp-2", Namespace: "ns-1"},
+			{Name: "comp-4", Namespace: "ns-4", URL: "https://someurl.com", Version: "version-4"},
+		},
 	}
 
 	var vals = values.Values{
@@ -67,11 +71,23 @@ func TestPrepareKebComponents(t *testing.T) {
 			},
 			Namespace: "ns-1",
 		},
+		{
+			Component: "comp-4",
+			Configuration: []keb.Configuration{
+				{Key: "global.domainName", Value: "domain-1"},
+				{Key: "global.tlsCrt", Value: "tls-crt-1"},
+				{Key: "global.tlsKey", Value: "tls-key-1"},
+			},
+			Namespace: "ns-4",
+			URL:       "https://someurl.com",
+			Version:   "version-4",
+		},
 	}
 
 	result, err := prepareKebComponents(components, vals)
 	require.NoError(t, err)
-	require.Len(t, expected, 3)
+	require.Len(t, result, 4)
+	require.Len(t, expected, 4)
 	require.Equal(t, expected[0].Component, (result)[0].Component)
 	require.ElementsMatch(t, expected[0].Configuration, (result)[0].Configuration)
 	require.Equal(t, expected[0].Namespace, (result)[0].Namespace)
@@ -81,6 +97,10 @@ func TestPrepareKebComponents(t *testing.T) {
 	require.Equal(t, expected[2].Component, (result)[2].Component)
 	require.ElementsMatch(t, expected[2].Configuration, (result)[2].Configuration)
 	require.Equal(t, expected[2].Namespace, (result)[2].Namespace)
+	require.Equal(t, expected[3].Component, (result)[3].Component)
+	require.ElementsMatch(t, expected[3].Configuration, (result)[3].Configuration)
+	require.Equal(t, expected[3].URL, (result)[3].URL)
+	require.Equal(t, expected[3].Version, (result)[3].Version)
 }
 func TestPrepareKebCluster(t *testing.T) {
 	var expected = []*keb.Component{


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Use URL and Version from Components file. I found that when you specify the URL in the components file it's not actually used anywhere. This PR should fix this problem and use a URL and Version that can be specified while running `kyma deploy --components-file components-file.yaml`. Here is an example of such `components-file.yaml`:

```yaml
---
defaultNamespace: kyma-system
prerequisites:
  - name: "cluster-essentials"
  - name: "istio"
    namespace: "istio-system"
  - name: "certificates"
    namespace: "istio-system"
components:
  - name: "istio-resources"
  - name: "some-external-component"
    namespace: "some-namespace"
    url: "https://some-external-registry/org/some-external-component.git"
    version: "some-version"
```
