### PR TITLE
Setup kustomize on kyma alpha create module

### DIFF
--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/kyma-project/cli/internal/cli"
+	"github.com/kyma-project/cli/internal/cli/setup"
 	"github.com/kyma-project/cli/pkg/module"
 )
 
@@ -93,6 +94,10 @@ func (cmd *command) Run(args []string) error {
 		Overwrite:     cmd.opts.Overwrite,
 		RegistryURL:   cmd.opts.RegistryURL,
 		DefaultCRPath: cmd.opts.DefaultCRPath,
+	}
+
+	if err := setup.Kustomize(&cmd.Command); err != nil {
+		return err
 	}
 
 	/* -- Inspect and build Module -- */

--- a/cmd/kyma/alpha/deploy/cmd.go
+++ b/cmd/kyma/alpha/deploy/cmd.go
@@ -2,12 +2,10 @@ package deploy
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"time"
 
 	"github.com/kyma-project/cli/internal/deploy"
-	"github.com/kyma-project/cli/internal/kustomize"
 	"github.com/kyma-project/cli/pkg/errs"
 
 	"github.com/pkg/errors"
@@ -17,6 +15,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/kyma-project/cli/internal/cli"
+	"github.com/kyma-project/cli/internal/cli/setup"
 	"github.com/kyma-project/cli/internal/kube"
 	"github.com/kyma-project/cli/internal/nice"
 )
@@ -107,7 +106,7 @@ func (cmd *command) run() error {
 }
 
 func (cmd *command) deploy(start time.Time) error {
-	if err := cmd.initialSetup(); err != nil {
+	if err := setup.Kustomize(&cmd.Command); err != nil {
 		return err
 	}
 
@@ -177,15 +176,6 @@ func (cmd *command) deploy(start time.Time) error {
 
 	deployTime := time.Since(start)
 	return summary.Print(deployTime)
-}
-
-func (cmd *command) initialSetup() error {
-	s := cmd.NewStep("Setting up kustomize...")
-	if err := kustomize.Setup(s, true); err != nil {
-		log.Fatal(err)
-	}
-	s.Successf("Kustomize ready")
-	return nil
 }
 
 func (cmd *command) dryRun() error {

--- a/internal/cli/setup/kustomize.go
+++ b/internal/cli/setup/kustomize.go
@@ -1,0 +1,129 @@
+package setup
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/kyma-project/cli/internal/cli"
+	"github.com/kyma-project/cli/internal/envtest"
+	"github.com/kyma-project/cli/internal/files"
+	"github.com/kyma-project/cli/internal/kustomize"
+	"github.com/kyma-project/cli/pkg/step"
+)
+
+const (
+	DefaultVersion  = "1.24.x!" //1.24.x! means the latest available patch version for 1.24 branch
+	versionEnv      = "ENVTEST_K8S_VERSION"
+	envtestSetupBin = "setup-envtest"
+)
+
+// based on "kubernetes-sigs/controller-runtime/tools/setup-envtest/versions/parse.go", but more strict
+var envtestVersionRegexp = regexp.MustCompile(`^(0|[1-9]\d{0,2})\.(0|[1-9]\d{0,2})\.(0|[1-9]\d{0,3})$`)
+
+func Kustomize(cmd *cli.Command) error {
+	s := cmd.NewStep("Setting up kustomize...")
+	if err := kustomize.Setup(s, true); err != nil {
+		log.Fatal(err)
+	}
+	s.Successf("Kustomize ready")
+	return nil
+}
+
+func EnvTest(step step.Step, verbose bool) (*envtest.Runner, error) {
+	p, err := files.KymaHome()
+	if err != nil {
+		return nil, err
+	}
+
+	//Install setup-envtest
+	if _, err := os.Stat(filepath.Join(p, envtestSetupBin)); os.IsNotExist(err) {
+		kymaGobinEnv := "GOBIN=" + p
+		envtestSetupCmd := exec.Command("go", "install", "sigs.k8s.io/controller-runtime/tools/setup-envtest@latest")
+		envtestSetupCmd.Env = os.Environ()
+		envtestSetupCmd.Env = append(envtestSetupCmd.Env, kymaGobinEnv)
+
+		//go install is silent when executed successfully
+		out, err := envtestSetupCmd.CombinedOutput()
+		if err != nil {
+			return nil, fmt.Errorf("error installing setup-envtest: %w. Details: %s", err, string(out))
+		} else if verbose {
+			step.LogInfof("Installed setup-envtest in: %q", p)
+		}
+
+	}
+
+	//Install envtest binaries using setup-envtest
+	envtestSetupBinPath := filepath.Join(p, envtestSetupBin)
+
+	version, err := resolveEnvtestVersion()
+	if err != nil {
+		return nil, err
+	}
+
+	envtestInstallBinariesCmd := exec.Command(envtestSetupBinPath, "use", version, "--bin-dir", p)
+	out, err := envtestInstallBinariesCmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("error installing envtest binaries: %w. Details: %s", err, string(out))
+	}
+
+	envtestBinariesPath, err := extractPath(string(out))
+	if err != nil {
+		return nil, fmt.Errorf("error installing envtest binaries: %w", err)
+	}
+
+	if verbose {
+		version, err := extractVersion(string(out))
+		if err == nil {
+			step.LogInfof("Installed envtest binaries in version %s, path: %q", version, envtestBinariesPath)
+		} else {
+			step.LogInfof("Installed envtest binaries in: %q", envtestBinariesPath)
+		}
+	}
+
+	return envtest.NewRunner(envtestBinariesPath, nil, nil), nil
+}
+
+// resolveEnvtestVersion validates the envtest version provided via the environment variable. It returns the default version if the variable is not found.
+func resolveEnvtestVersion() (string, error) {
+	v, defined := os.LookupEnv(versionEnv)
+	if !defined {
+		return DefaultVersion, nil
+	}
+
+	trimmed := strings.TrimSpace(v)
+	if !envtestVersionRegexp.MatchString(trimmed) {
+		return "", errors.New("Invalid value of \"ENVTEST_K8S_VERSION\" variable, only proper semversions are allowed, e.g: 1.24.2")
+	}
+
+	return trimmed, nil
+}
+
+// extractPath extracts the envtest binaries path from the "setup-envtest" command output
+func extractPath(envtestSetupMsg string) (string, error) {
+	return parseEnvtestSetupMsg(envtestSetupMsg, `[pP]ath:(.+)`, "envtest binaries path")
+
+}
+
+// extractVersion extracts the envtest binaries version from the "setup-envtest" command output
+func extractVersion(envtestSetupMsg string) (string, error) {
+	return parseEnvtestSetupMsg(envtestSetupMsg, `[vV]ersion:(.+)`, "envtest version")
+}
+
+func parseEnvtestSetupMsg(envtestSetupMsg, rgxp, objName string) (string, error) {
+	r, err := regexp.Compile(rgxp)
+	if err != nil {
+		return "", err
+	}
+	matches := r.FindStringSubmatch(envtestSetupMsg)
+	if len(matches) != 2 {
+		return "", fmt.Errorf("Couldn't find %s in the \"setup-envtest\" command output", objName)
+	}
+
+	return strings.TrimSpace(matches[1]), nil
+}

--- a/internal/envtest/envtest.go
+++ b/internal/envtest/envtest.go
@@ -1,90 +1,23 @@
 package envtest
 
 import (
-	"errors"
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"regexp"
-	"strings"
 
-	"github.com/kyma-project/cli/internal/files"
-	"github.com/kyma-project/cli/pkg/step"
 	"go.uber.org/zap"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
-const (
-	DefaultVersion  = "1.24.x!" //1.24.x! means the latest available patch version for 1.24 branch
-	versionEnv      = "ENVTEST_K8S_VERSION"
-	envtestSetupBin = "setup-envtest"
-)
-
-// based on "kubernetes-sigs/controller-runtime/tools/setup-envtest/versions/parse.go", but more strict
-var envtestVersionRegexp = regexp.MustCompile(`^(0|[1-9]\d{0,2})\.(0|[1-9]\d{0,2})\.(0|[1-9]\d{0,3})$`)
+func NewRunner(binPath string, env *envtest.Environment, restClient *rest.Config) *Runner {
+	return &Runner{
+		binPath, env, restClient,
+	}
+}
 
 type Runner struct {
 	binPath    string
 	env        *envtest.Environment
 	restClient *rest.Config
-}
-
-func Setup(step step.Step, verbose bool) (*Runner, error) {
-	p, err := files.KymaHome()
-	if err != nil {
-		return nil, err
-	}
-
-	//Install setup-envtest
-	if _, err := os.Stat(filepath.Join(p, envtestSetupBin)); os.IsNotExist(err) {
-		kymaGobinEnv := "GOBIN=" + p
-		envtestSetupCmd := exec.Command("go", "install", "sigs.k8s.io/controller-runtime/tools/setup-envtest@latest")
-		envtestSetupCmd.Env = os.Environ()
-		envtestSetupCmd.Env = append(envtestSetupCmd.Env, kymaGobinEnv)
-
-		//go install is silent when executed successfully
-		out, err := envtestSetupCmd.CombinedOutput()
-		if err != nil {
-			return nil, fmt.Errorf("error installing setup-envtest: %w. Details: %s", err, string(out))
-		} else if verbose {
-			step.LogInfof("Installed setup-envtest in: %q", p)
-		}
-
-	}
-
-	//Install envtest binaries using setup-envtest
-	envtestSetupBinPath := filepath.Join(p, envtestSetupBin)
-
-	version, err := resolveEnvtestVersion()
-	if err != nil {
-		return nil, err
-	}
-
-	envtestInstallBinariesCmd := exec.Command(envtestSetupBinPath, "use", version, "--bin-dir", p)
-	out, err := envtestInstallBinariesCmd.CombinedOutput()
-	if err != nil {
-		return nil, fmt.Errorf("error installing envtest binaries: %w. Details: %s", err, string(out))
-	}
-
-	envtestBinariesPath, err := extractPath(string(out))
-	if err != nil {
-		return nil, fmt.Errorf("error installing envtest binaries: %w", err)
-	}
-
-	if verbose {
-		version, err := extractVersion(string(out))
-		if err == nil {
-			step.LogInfof("Installed envtest binaries in version %s, path: %q", version, envtestBinariesPath)
-		} else {
-			step.LogInfof("Installed envtest binaries in: %q", envtestBinariesPath)
-		}
-	}
-
-	return &Runner{
-		binPath: envtestBinariesPath,
-	}, nil
 }
 
 func (r *Runner) RestClient() *rest.Config {
@@ -117,43 +50,4 @@ func (r *Runner) Stop() error {
 		return fmt.Errorf("could not stop CR validation: %w", err)
 	}
 	return nil
-}
-
-// extractPath extracts the envtest binaries path from the "setup-envtest" command output
-func extractPath(envtestSetupMsg string) (string, error) {
-	return parseEnvtestSetupMsg(envtestSetupMsg, `[pP]ath:(.+)`, "envtest binaries path")
-
-}
-
-// extractVersion extracts the envtest binaries version from the "setup-envtest" command output
-func extractVersion(envtestSetupMsg string) (string, error) {
-	return parseEnvtestSetupMsg(envtestSetupMsg, `[vV]ersion:(.+)`, "envtest version")
-}
-
-func parseEnvtestSetupMsg(envtestSetupMsg, rgxp, objName string) (string, error) {
-	r, err := regexp.Compile(rgxp)
-	if err != nil {
-		return "", err
-	}
-	matches := r.FindStringSubmatch(envtestSetupMsg)
-	if len(matches) != 2 {
-		return "", fmt.Errorf("Couldn't find %s in the \"setup-envtest\" command output", objName)
-	}
-
-	return strings.TrimSpace(matches[1]), nil
-}
-
-// resolveEnvtestVersion validates the envtest version provided via the environment variable. It returns the default version if the variable is not found.
-func resolveEnvtestVersion() (string, error) {
-	v, defined := os.LookupEnv(versionEnv)
-	if !defined {
-		return DefaultVersion, nil
-	}
-
-	trimmed := strings.TrimSpace(v)
-	if !envtestVersionRegexp.MatchString(trimmed) {
-		return "", errors.New("Invalid value of \"ENVTEST_K8S_VERSION\" variable, only proper semversions are allowed, e.g: 1.24.2")
-	}
-
-	return trimmed, nil
 }

--- a/pkg/module/validation.go
+++ b/pkg/module/validation.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kyma-project/cli/internal/envtest"
+	"github.com/kyma-project/cli/internal/cli/setup"
 	"github.com/kyma-project/cli/internal/kube"
 	"github.com/kyma-project/cli/pkg/step"
 	"go.uber.org/zap"
@@ -38,7 +38,7 @@ func (v *DefaultCRValidator) Run(s step.Step, verbose bool, log *zap.SugaredLogg
 	}
 
 	// setup test env
-	runner, err := envtest.Setup(s, verbose)
+	runner, err := setup.EnvTest(s, verbose)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Description**

kustomize installation is not ensured in `kyma alpha create module` command, although kustomize binary may be used during the execution of this command

Changes proposed in this pull request:

- Add kustomize setup step to the `kyma alpha create module` command
- Extract kustomize and envTest setup code to a separate package: `internal/cli/setup`

**Related issue(s)**
Fixes: #1470 