### PR TITLE
Release 2.9 cherry-pick: adapt to recent changes in operators

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 * @clebs @jeremyharisch @khlifi411 @ruanxin @Tomasz-Smelcerz-SAP @jakobmoellersap @adityabhatia @lindnerby @adityabhatia @dennis-ge
 
 # All .md files
-*.md @mmitoraj @NHingerl @grego952
+*.md @mmitoraj @NHingerl @grego952 @IwonaLanger

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -64,7 +64,7 @@ Build module modB in version 3.2.1 and push it to a local registry "unsigned" su
 	cmd.Flags().StringVarP(&o.Credentials, "credentials", "c", "", "Basic authentication credentials for the given registry in the format user:password")
 	cmd.Flags().StringVar(&o.DefaultCRPath, "default-cr", "", "File containing the default custom resource of the module. If the module is a kubebuilder project, the default CR will be automatically detected.")
 	cmd.Flags().StringVarP(&o.TemplateOutput, "output", "o", "template.yaml", "File to which to output the module template if the module is uploaded to a registry")
-	cmd.Flags().StringVar(&o.Channel, "channel", "stable", "Channel to use for the module template.")
+	cmd.Flags().StringVar(&o.Channel, "channel", "regular", "Channel to use for the module template.")
 	cmd.Flags().StringVarP(&o.Token, "token", "t", "", "Authentication token for the given registry (alternative to basic authentication).")
 	cmd.Flags().BoolVarP(&o.Overwrite, "overwrite", "w", false, "overwrites the existing mod-path directory if it exists")
 	cmd.Flags().BoolVar(&o.Insecure, "insecure", false, "Use an insecure connection to access the registry.")

--- a/cmd/kyma/alpha/deploy/cmd.go
+++ b/cmd/kyma/alpha/deploy/cmd.go
@@ -45,9 +45,9 @@ func NewCmd(o *Options) *cobra.Command {
 	Defaults to deploying Lifecycle Manager and Module Manager from GitHub main branch.
 	Examples:
 	- Deploy a specific release of the Lifecycle Manager: "kyma deploy -k https://github.com/kyma-project/lifecycle-manager/config/default@1.2.3"
-	- Deploy a local Module Manager: "kyma deploy --kustomization /path/to/repo/module-manager/operator/config/default"
+	- Deploy a local Module Manager: "kyma deploy --kustomization /path/to/repo/module-manager/config/default"
 	- Deploy a branch of Lifecycle Manager with a custom URL: "kyma deploy -k https://gitlab.com/forked-from-github/lifecycle-manager/config/default@feature-branch-1"
-	- Deploy the main branch of Lifecycle Manager while using local sources of Module Manager: "kyma deploy -k /path/to/repo/module-manager/operator/config/default -k https://github.com/kyma-project/lifecycle-manager/config/default@main"`)
+	- Deploy the main branch of Lifecycle Manager while using local sources of Module Manager: "kyma deploy -k /path/to/repo/module-manager/config/default -k https://github.com/kyma-project/lifecycle-manager/config/default@main"`)
 	cobraCmd.Flags().StringArrayVarP(&o.Modules, "module", "m", []string{}, `Provide one or more modules to activate after the deployment is finished. Example: "--module name@namespace" (namespace is optional).`)
 	cobraCmd.Flags().StringVarP(&o.ModulesFile, "modules-file", "f", "", `Path to file containing a list of modules.`)
 	cobraCmd.Flags().StringVarP(&o.Channel, "channel", "c", "stable", `Select which channel to deploy from: stable, fast, nightly.`)

--- a/docs/gen-docs/kyma_alpha_create_module.md
+++ b/docs/gen-docs/kyma_alpha_create_module.md
@@ -39,7 +39,7 @@ Build module modB in version 3.2.1 and push it to a local registry "unsigned" su
 ## Flags
 
 ```bash
-      --channel string         Channel to use for the module template. (default "stable")
+      --channel string         Channel to use for the module template. (default "regular")
       --clean                  Remove the mod-path folder and all its contents at the end.
   -c, --credentials string     Basic authentication credentials for the given registry in the format user:password
       --default-cr string      File containing the default custom resource of the module. If the module is a kubebuilder project, the default CR will be automatically detected.

--- a/docs/gen-docs/kyma_alpha_deploy.md
+++ b/docs/gen-docs/kyma_alpha_deploy.md
@@ -21,9 +21,9 @@ kyma alpha deploy [flags]
                                     	Defaults to deploying Lifecycle Manager and Module Manager from GitHub main branch.
                                     	Examples:
                                     	- Deploy a specific release of the Lifecycle Manager: "kyma deploy -k https://github.com/kyma-project/lifecycle-manager/config/default@1.2.3"
-                                    	- Deploy a local Module Manager: "kyma deploy --kustomization /path/to/repo/module-manager/operator/config/default"
+                                    	- Deploy a local Module Manager: "kyma deploy --kustomization /path/to/repo/module-manager/config/default"
                                     	- Deploy a branch of Lifecycle Manager with a custom URL: "kyma deploy -k https://gitlab.com/forked-from-github/lifecycle-manager/config/default@feature-branch-1"
-                                    	- Deploy the main branch of Lifecycle Manager while using local sources of Module Manager: "kyma deploy -k /path/to/repo/module-manager/operator/config/default -k https://github.com/kyma-project/lifecycle-manager/config/default@main"
+                                    	- Deploy the main branch of Lifecycle Manager while using local sources of Module Manager: "kyma deploy -k /path/to/repo/module-manager/config/default -k https://github.com/kyma-project/lifecycle-manager/config/default@main"
       --kyma-cr string              Provide a custom Kyma CR file for the deployment.
   -m, --module stringArray          Provide one or more modules to activate after the deployment is finished. Example: "--module name@namespace" (namespace is optional).
   -f, --modules-file string         Path to file containing a list of modules.

--- a/internal/deploy/bootstrap.go
+++ b/internal/deploy/bootstrap.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	defaultLifecycleManager = "https://github.com/kyma-project/lifecycle-manager/config/default"
-	defaultModuleManager    = "https://github.com/kyma-project/module-manager/operator/config/default"
+	defaultModuleManager    = "https://github.com/kyma-project/module-manager/config/default"
 	defaultRetries          = 3
 	defaultInitialBackoff   = 3 * time.Second
 )

--- a/internal/deploy/kyma.go
+++ b/internal/deploy/kyma.go
@@ -43,7 +43,7 @@ func Kyma(k8s kube.KymaKube, channel, kymaCRpath string, dryRun bool) error {
 		}
 
 		if channel == "" {
-			channel = "stable"
+			channel = "regular"
 		}
 		data := struct {
 			Channel string


### PR DESCRIPTION
**Description**

Cherry-pick of "remove module-manager 'operator' folder" into the release 2.9 branch
Changes proposed in this pull request:

- remove module-manager 'operator' folder


**Related issue(s)**
#1459 