### PR TITLE
Fix panic on gathering repository metadata

### DIFF
--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -28,7 +28,7 @@ func NewCmd(o *Options) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "module OCI_IMAGE_NAME MODULE_VERSION <CONTENT_PATH> [flags]",
+		Use:   "module [flags]",
 		Short: "Creates a module bundled as an OCI image with the given OCI image name from the contents of the given path",
 		Long: `Use this command to create a Kyma module and bundle it as an OCI image.
 
@@ -37,8 +37,12 @@ func NewCmd(o *Options) *cobra.Command {
 Kyma modules are individual components that can be deployed into a Kyma runtime. Modules are built and distributed as OCI container images. 
 With this command, you can create such images out of a folder's contents.
 
-This command creates a component descriptor in the descriptor path (./mod as a default) and packages all the contents on the provided content path as a single layer.
-Optionally, you can create additional layers with contents in other paths.
+This command creates a component descriptor in the descriptor path (./mod as a default) and packages all the contents on the provided path as an OCI image.
+Kubebuilder projects are supported, if the path contains a kubebuilder project, it will be built and pre-defined layers will be created based on its known contents.
+
+Alternatively, a custom (non kubebuilder) module can be created by providing a path that does not contain a kubebuilder project. In that case all the contents of the path will be bundled as a single layer.
+
+Optionally, you can manually add additional layers with contents in other paths (see the "resource" flag for more information).
 
 Finally, if you provided a registry to which to push the artifact, the created module is validated and pushed. For example, the default CR defined in the \"default.yaml\" file is validated against CustomResourceDefinition.
 
@@ -46,10 +50,10 @@ Alternatively, if you don't push to registry, you can trigger an on-demand valid
 `,
 
 		Example: `Examples:
-Build module modA in version 1.2.3 and push it to a remote registry
-		kyma alpha create module modA 1.2.3 /path/to/module --registry https://dockerhub.com
-Build module modB in version 3.2.1 and push it to a local registry "unsigned" subfolder without tls
-		kyma alpha create module modA 3.2.1 /path/to/module --registry http://localhost:5001/unsigned --insecure
+Build module my-domain/modA in version 1.2.3 and push it to a remote registry
+		kyma alpha create module -n my-domain/modA --version 1.2.3 -p /path/to/module --registry https://dockerhub.com
+Build module my-domain/modB in version 3.2.1 and push it to a local registry "unsigned" subfolder without tls
+		kyma alpha create module -n my-domain/modB --version 3.2.1 -p /path/to/module --registry http://localhost:5001/unsigned --insecure
 `,
 		RunE:    func(_ *cobra.Command, args []string) error { return c.Run(args) },
 		Aliases: []string{"mod"},

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -38,11 +38,11 @@ Kyma modules are individual components that can be deployed into a Kyma runtime.
 With this command, you can create such images out of a folder's contents.
 
 This command creates a component descriptor in the descriptor path (./mod as a default) and packages all the contents on the provided path as an OCI image.
-Kubebuilder projects are supported, if the path contains a kubebuilder project, it will be built and pre-defined layers will be created based on its known contents.
+Kubebuilder projects are supported. If the path contains a kubebuilder project, it will be built and pre-defined layers will be created based on its known contents.
 
 Alternatively, a custom (non kubebuilder) module can be created by providing a path that does not contain a kubebuilder project. In that case all the contents of the path will be bundled as a single layer.
 
-Optionally, you can manually add additional layers with contents in other paths (see the "resource" flag for more information).
+Optionally, you can manually add additional layers with contents in other paths (see [resource flag](#flags) for more information).
 
 Finally, if you provided a registry to which to push the artifact, the created module is validated and pushed. For example, the default CR defined in the \"default.yaml\" file is validated against CustomResourceDefinition.
 

--- a/docs/gen-docs/kyma_alpha_create_module.md
+++ b/docs/gen-docs/kyma_alpha_create_module.md
@@ -14,11 +14,11 @@ Kyma modules are individual components that can be deployed into a Kyma runtime.
 With this command, you can create such images out of a folder's contents.
 
 This command creates a component descriptor in the descriptor path (./mod as a default) and packages all the contents on the provided path as an OCI image.
-Kubebuilder projects are supported, if the path contains a kubebuilder project, it will be built and pre-defined layers will be created based on its known contents.
+Kubebuilder projects are supported. If the path contains a kubebuilder project, it will be built, and the pre-defined layers will be created based on its known contents.
 
 Alternatively, a custom (non kubebuilder) module can be created by providing a path that does not contain a kubebuilder project. In that case all the contents of the path will be bundled as a single layer.
 
-Optionally, you can manually add additional layers with contents in other paths (see the "resource" flag for more information).
+Optionally, you can manually add additional layers with contents in other paths (see the [`resource` flag](#flags) for more information).
 
 Finally, if you provided a registry to which to push the artifact, the created module is validated and pushed. For example, the default CR defined in the \"default.yaml\" file is validated against CustomResourceDefinition.
 

--- a/docs/gen-docs/kyma_alpha_create_module.md
+++ b/docs/gen-docs/kyma_alpha_create_module.md
@@ -13,8 +13,12 @@ Use this command to create a Kyma module and bundle it as an OCI image.
 Kyma modules are individual components that can be deployed into a Kyma runtime. Modules are built and distributed as OCI container images. 
 With this command, you can create such images out of a folder's contents.
 
-This command creates a component descriptor in the descriptor path (./mod as a default) and packages all the contents on the provided content path as a single layer.
-Optionally, you can create additional layers with contents in other paths.
+This command creates a component descriptor in the descriptor path (./mod as a default) and packages all the contents on the provided path as an OCI image.
+Kubebuilder projects are supported, if the path contains a kubebuilder project, it will be built and pre-defined layers will be created based on its known contents.
+
+Alternatively, a custom (non kubebuilder) module can be created by providing a path that does not contain a kubebuilder project. In that case all the contents of the path will be bundled as a single layer.
+
+Optionally, you can manually add additional layers with contents in other paths (see the "resource" flag for more information).
 
 Finally, if you provided a registry to which to push the artifact, the created module is validated and pushed. For example, the default CR defined in the \"default.yaml\" file is validated against CustomResourceDefinition.
 
@@ -22,17 +26,17 @@ Alternatively, if you don't push to registry, you can trigger an on-demand valid
 
 
 ```bash
-kyma alpha create module OCI_IMAGE_NAME MODULE_VERSION <CONTENT_PATH> [flags]
+kyma alpha create module [flags]
 ```
 
 ## Examples
 
 ```bash
 Examples:
-Build module modA in version 1.2.3 and push it to a remote registry
-		kyma alpha create module modA 1.2.3 /path/to/module --registry https://dockerhub.com
-Build module modB in version 3.2.1 and push it to a local registry "unsigned" subfolder without tls
-		kyma alpha create module modA 3.2.1 /path/to/module --registry http://localhost:5001/unsigned --insecure
+Build module my-domain/modA in version 1.2.3 and push it to a remote registry
+		kyma alpha create module -n my-domain/modA --version 1.2.3 -p /path/to/module --registry https://dockerhub.com
+Build module my-domain/modB in version 3.2.1 and push it to a local registry "unsigned" subfolder without tls
+		kyma alpha create module -n my-domain/modB --version 3.2.1 -p /path/to/module --registry http://localhost:5001/unsigned --insecure
 
 ```
 

--- a/docs/gen-docs/kyma_alpha_create_module.md
+++ b/docs/gen-docs/kyma_alpha_create_module.md
@@ -14,11 +14,11 @@ Kyma modules are individual components that can be deployed into a Kyma runtime.
 With this command, you can create such images out of a folder's contents.
 
 This command creates a component descriptor in the descriptor path (./mod as a default) and packages all the contents on the provided path as an OCI image.
-Kubebuilder projects are supported. If the path contains a kubebuilder project, it will be built, and the pre-defined layers will be created based on its known contents.
+Kubebuilder projects are supported. If the path contains a kubebuilder project, it will be built and pre-defined layers will be created based on its known contents.
 
 Alternatively, a custom (non kubebuilder) module can be created by providing a path that does not contain a kubebuilder project. In that case all the contents of the path will be bundled as a single layer.
 
-Optionally, you can manually add additional layers with contents in other paths (see the [`resource` flag](#flags) for more information).
+Optionally, you can manually add additional layers with contents in other paths (see [resource flag](#flags) for more information).
 
 Finally, if you provided a registry to which to push the artifact, the created module is validated and pushed. For example, the default CR defined in the \"default.yaml\" file is validated against CustomResourceDefinition.
 

--- a/pkg/module/build.go
+++ b/pkg/module/build.go
@@ -118,6 +118,8 @@ func addSources(cd *cdv2.ComponentDescriptor, def *Definition) error {
 	if err != nil {
 		return err
 	}
-	cd.Sources = append(cd.Sources, *src)
+	if src != nil {
+		cd.Sources = append(cd.Sources, *src)
+	}
 	return nil
 }

--- a/pkg/module/git/source.go
+++ b/pkg/module/git/source.go
@@ -19,23 +19,22 @@ const (
 var errNotGit = errors.New("not a git repository")
 
 func Source(path, repo, version string) (*cdv2.Source, error) {
-	u, err := url.Parse(repo)
-	if err != nil {
-		return nil, fmt.Errorf("could not parse repository URL %q: %w", repo, err)
-	}
-
-	pieces := strings.Split(u.Path, "/")
-	repoName := pieces[len(pieces)-1]
-
+	var repoURL *url.URL
 	src := &cdv2.Source{
 		IdentityObjectMeta: cdv2.IdentityObjectMeta{
-			Name:    repoName,
 			Version: version,
 			Type:    "git",
 		},
 		Access: &cdv2.UnstructuredTypedObject{
-			Object: map[string]interface{}{"repoUrl": repo, "type": domain(u)},
+			Object: make(map[string]interface{}),
 		},
+	}
+	if repo != "" {
+		var err error
+		repoURL, err = url.Parse(repo)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse repository URL %q: %w", repo, err)
+		}
 	}
 
 	// check for .git
@@ -44,6 +43,29 @@ func Source(path, repo, version string) (*cdv2.Source, error) {
 		if err != nil {
 			return src, fmt.Errorf("could not get git information from %q: %w", gitPath, err)
 		}
+
+		// get URL from git info if not provided in the project
+		if repo == "" {
+			remotes, err := r.Remotes()
+			if err != nil {
+				return src, err
+			}
+
+			if len(remotes) > 0 {
+				var err error
+				// get remote URL and convert to HTTP in case it is an SSH URL
+				u := remotes[0].Config().URLs[0]
+				u = strings.Replace(u, ":", "/", 1)
+				u = strings.Replace(u, "git@", "https://", 1)
+				u = strings.TrimSuffix(u, ".git")
+				repoURL, err = url.Parse(u)
+
+				if err != nil {
+					return src, fmt.Errorf("could not parse repository URL %q: %w", repo, err)
+				}
+			}
+		}
+
 		head, err := r.Head()
 		if err != nil {
 			return src, fmt.Errorf("could not get git information from %q: %w", gitPath, err)
@@ -51,6 +73,16 @@ func Source(path, repo, version string) (*cdv2.Source, error) {
 
 		src.Access.Object["ref"] = head.Name().String()
 		src.Access.Object["commit"] = head.Hash().String()
+	}
+
+	if repoURL != nil {
+		pieces := strings.Split(repoURL.Path, "/")
+		repoName := pieces[len(pieces)-1]
+
+		src.IdentityObjectMeta.Name = repoName
+		fmt.Println(repoName)
+		src.Access.Object["repoUrl"] = repoURL.String()
+		src.Access.Object["type"] = domain(repoURL)
 	}
 
 	return src, nil

--- a/pkg/module/oci/ref.go
+++ b/pkg/module/oci/ref.go
@@ -57,7 +57,7 @@ func ParseRef(ref string) (RefSpec, error) {
 
 	parsedRef, err := dockerreference.ParseDockerRef(ref)
 	if err != nil {
-		return RefSpec{}, err
+		return RefSpec{}, fmt.Errorf("could not parse OCI reference: %w", err)
 	}
 
 	spec := RefSpec{


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix panic gathering metadata on a non-kubebuilder module.
- Extract repo name and URL from the git config if not a kubebuilder project.
- Skip sources if no information is available.

**Related issue(s)**
Fixes #1477 
