### PR TITLE
fix-dashboard:  mount kubeconfig to wrong path

### DIFF
--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -120,7 +120,7 @@ func (c *Container) containerOpts(envs []string) docker.ContainerRunOpts {
 			{
 				Type:   mount.TypeBind,
 				Source: kubeconfigPath,
-				Target: fmt.Sprintf("/app/core/kubeconfig/%s", containerKubeconfigFile),
+				Target: fmt.Sprintf("/app/core-ui/kubeconfig/%s", containerKubeconfigFile),
 			},
 		}
 		c.kubeconfigMounted = true

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -120,7 +120,7 @@ func (c *Container) containerOpts(envs []string) docker.ContainerRunOpts {
 			{
 				Type:   mount.TypeBind,
 				Source: kubeconfigPath,
-				Target: fmt.Sprintf("/app/core-ui/kubeconfig/%s", containerKubeconfigFile),
+				Target: fmt.Sprintf("/app/core-ui/public/kubeconfig/%s", containerKubeconfigFile),
 			},
 		}
 		c.kubeconfigMounted = true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- fix path of mounting the kubeconfig

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
