### PR TITLE
Fix timeout issues in tests

### DIFF
--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -356,7 +356,7 @@ func (c *client) DefaultNamespace() string {
 }
 
 // watch provides a unified implementation to watch resources.
-// Note: the timeout of zero does NOT mean "no timeout", i.e. "wait forever" - it means the function will time-out almost immediately - at the discretion of the golang scheduler.
+// timeout of zero does NOT mean "no timeout", i.e. "wait forever" - it means the function will time-out almost immediately - at the discretion of the golang scheduler.
 func watch(res string, watchFn func() (bool, error), timeout time.Duration) error {
 	timeChan := time.After(timeout)
 

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -356,6 +356,7 @@ func (c *client) DefaultNamespace() string {
 }
 
 // watch provides a unified implementation to watch resources.
+// Note: the timeout of zero does NOT mean "no timeout", i.e. "wait forever" - it means the function will time-out almost immediately - at the discretion of the golang scheduler.
 func watch(res string, watchFn func() (bool, error), timeout time.Duration) error {
 	timeChan := time.After(timeout)
 

--- a/internal/kube/client_test.go
+++ b/internal/kube/client_test.go
@@ -161,7 +161,9 @@ func TestWaitPodStatusByLabel(t *testing.T) {
 func TestWatchResource(t *testing.T) {
 	t.Parallel()
 	c := &client{
-		restCfg: &rest.Config{},
+		restCfg: &rest.Config{
+			Timeout: 1 * time.Second,
+		},
 		dynamic: dynamicK8s(
 			&unstructured.Unstructured{
 				Object: map[string]interface{}{
@@ -186,7 +188,7 @@ func TestWatchResource(t *testing.T) {
 		return exists && status == "partying", nil
 	}
 
-	// non namepsaced
+	// non namespaced
 	err := c.WatchResource(schema.GroupVersionResource{Group: "fakeAPI", Version: "fakeVersion", Resource: "fakes"}, "samus", "", checkFn)
 	require.NoError(t, err)
 


### PR DESCRIPTION
**Description**

[Some](https://storage.googleapis.com/kyma-prow-logs/logs/unstable-cli/1605943000838443008/build-log.txt) pipeline runs are failing with the `Timeout reached while waiting for fakes` message.
This is not deterministic.

After investigation, it turned out the reason is a missing timeout in the test configuration.

**Details**
The `watch` function in the `internal/kube/client.go` has a `timeout` parameter. In the failing test case this parameter is taken from the configured k8s `restConfig` object.
This parameter was not configured at all in the failing test setup, which means it's value defaults to zero.
The `watch` function takes the zero timeout as it is - it "tries" to time-out immediately, so, in theory, it should time-out almost always.
This is not what happens though.
Because there is a channel involved, even for a zero timeout there is a non-zero time delay here: The golang scheduler, and the underlying OS scheduler are adding their unpredictable latency, which heavily depends on the environment / machine type  used.
This explains why, with a timeout of zero, the `watch` function is usually passing and the failures are quite rare.

**Summary**: It's enough to provide a timeout of about 100ms to be sure the `watch` function works reliably. In case of a very low resource VM, it may be necessary to raise it even more to ensure the time-outs are not happening, I've used 1 second.

Changes proposed in this pull request:

- Add the missing timeout 

**Related issue(s)**
