### PR TITLE
add enable-registry-cred flag to cli

### DIFF
--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -66,6 +66,7 @@ Build module my-domain/modB in version 3.2.1 and push it to a local registry "un
 	cmd.Flags().StringVar(&o.ModCache, "mod-cache", "./mod", "Specifies the path where the module artifacts are locally cached to generate the image. If the path already has a module, use the overwrite flag to overwrite it.")
 	cmd.Flags().StringArrayVarP(&o.ResourcePaths, "resource", "r", []string{}, "Add an extra resource in a new layer with format <NAME:TYPE@PATH>. It is also possible to provide only a path; name will default to the last path element and type to 'helm-chart'")
 	cmd.Flags().StringVar(&o.RegistryURL, "registry", "", "Repository context url for module to upload. The repository url will be automatically added to the repository contexts in the module")
+	cmd.Flags().BoolVar(&o.EnableRegistryCred, "enable-registry-cred", false, "Enable this flag to append a label into each descriptor resource, it indicates the dockerconfigjson secret (config separately) which provide credential for private repository.")
 	cmd.Flags().StringVarP(&o.Credentials, "credentials", "c", "", "Basic authentication credentials for the given registry in the format user:password")
 	cmd.Flags().StringVar(&o.DefaultCRPath, "default-cr", "", "File containing the default custom resource of the module. If the module is a kubebuilder project, the default CR will be automatically detected.")
 	cmd.Flags().StringVarP(&o.TemplateOutput, "output", "o", "template.yaml", "File to which to output the module template if the module is uploaded to a registry")
@@ -173,7 +174,7 @@ func (cmd *command) Run(args []string) error {
 		cmd.CurrentStep.Success()
 
 		cmd.NewStep("Generating module template")
-		t, err := module.Template(archive, cmd.opts.Channel, modDef.DefaultCR)
+		t, err := module.Template(archive, cmd.opts.Channel, modDef.DefaultCR, cmd.opts.EnableRegistryCred)
 		if err != nil {
 			cmd.CurrentStep.Failure()
 			return err

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -67,7 +67,7 @@ Build module my-domain/modB in version 3.2.1 and push it to a local registry "un
 	cmd.Flags().StringArrayVarP(&o.ResourcePaths, "resource", "r", []string{}, "Add an extra resource in a new layer with format <NAME:TYPE@PATH>. It is also possible to provide only a path; name will default to the last path element and type to 'helm-chart'")
 	cmd.Flags().StringVar(&o.RegistryURL, "registry", "", "Repository context url for module to upload. The repository url will be automatically added to the repository contexts in the module")
 	cmd.Flags().StringVar(&o.RegistryCredSelector, "registry-cred-selector", "",
-		"Use this flag to config label selectors to identify the dockerconfigjson secret (config separately) which provide credential for private repository. Example: \"label1=value1,label2=value2\"")
+		"label selector to identify a secret of type kubernetes.io/dockerconfigjson (that needs to be created externally) which allows the image to be accessed in private image registries. This can be used if you push your module to a registry with authenticated access. Example: \"label1=value1,label2=value2\"")
 	cmd.Flags().StringVarP(&o.Credentials, "credentials", "c", "", "Basic authentication credentials for the given registry in the format user:password")
 	cmd.Flags().StringVar(&o.DefaultCRPath, "default-cr", "", "File containing the default custom resource of the module. If the module is a kubebuilder project, the default CR will be automatically detected.")
 	cmd.Flags().StringVarP(&o.TemplateOutput, "output", "o", "template.yaml", "File to which to output the module template if the module is uploaded to a registry")

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -66,7 +66,7 @@ Build module my-domain/modB in version 3.2.1 and push it to a local registry "un
 	cmd.Flags().StringVar(&o.ModCache, "mod-cache", "./mod", "Specifies the path where the module artifacts are locally cached to generate the image. If the path already has a module, use the overwrite flag to overwrite it.")
 	cmd.Flags().StringArrayVarP(&o.ResourcePaths, "resource", "r", []string{}, "Add an extra resource in a new layer with format <NAME:TYPE@PATH>. It is also possible to provide only a path; name will default to the last path element and type to 'helm-chart'")
 	cmd.Flags().StringVar(&o.RegistryURL, "registry", "", "Repository context url for module to upload. The repository url will be automatically added to the repository contexts in the module")
-	cmd.Flags().BoolVar(&o.EnableRegistryCred, "enable-registry-cred", false, "Enable this flag to append a label into each descriptor resource, it indicates the dockerconfigjson secret (config separately) which provide credential for private repository.")
+	cmd.Flags().StringVar(&o.RegistryCredLabelValue, "registry-cred-label", "", "Use this flag to config a label value, the generated label should be assigned to the dockerconfigjson secret (config separately) which provide credential for private repository.")
 	cmd.Flags().StringVarP(&o.Credentials, "credentials", "c", "", "Basic authentication credentials for the given registry in the format user:password")
 	cmd.Flags().StringVar(&o.DefaultCRPath, "default-cr", "", "File containing the default custom resource of the module. If the module is a kubebuilder project, the default CR will be automatically detected.")
 	cmd.Flags().StringVarP(&o.TemplateOutput, "output", "o", "template.yaml", "File to which to output the module template if the module is uploaded to a registry")
@@ -174,7 +174,7 @@ func (cmd *command) Run(args []string) error {
 		cmd.CurrentStep.Success()
 
 		cmd.NewStep("Generating module template")
-		t, err := module.Template(archive, cmd.opts.Channel, modDef.DefaultCR, cmd.opts.EnableRegistryCred)
+		t, err := module.Template(archive, cmd.opts.Channel, modDef.DefaultCR, cmd.opts.RegistryCredLabelValue)
 		if err != nil {
 			cmd.CurrentStep.Failure()
 			return err

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -66,7 +66,8 @@ Build module my-domain/modB in version 3.2.1 and push it to a local registry "un
 	cmd.Flags().StringVar(&o.ModCache, "mod-cache", "./mod", "Specifies the path where the module artifacts are locally cached to generate the image. If the path already has a module, use the overwrite flag to overwrite it.")
 	cmd.Flags().StringArrayVarP(&o.ResourcePaths, "resource", "r", []string{}, "Add an extra resource in a new layer with format <NAME:TYPE@PATH>. It is also possible to provide only a path; name will default to the last path element and type to 'helm-chart'")
 	cmd.Flags().StringVar(&o.RegistryURL, "registry", "", "Repository context url for module to upload. The repository url will be automatically added to the repository contexts in the module")
-	cmd.Flags().StringVar(&o.RegistryCredLabelValue, "registry-cred-label", "", "Use this flag to config a label value, the generated label should be assigned to the dockerconfigjson secret (config separately) which provide credential for private repository.")
+	cmd.Flags().StringVar(&o.RegistryCredSelector, "registry-cred-selector", "",
+		"Use this flag to config label selectors to identify the dockerconfigjson secret (config separately) which provide credential for private repository. Example: \"label1=value1,label2=value2\"")
 	cmd.Flags().StringVarP(&o.Credentials, "credentials", "c", "", "Basic authentication credentials for the given registry in the format user:password")
 	cmd.Flags().StringVar(&o.DefaultCRPath, "default-cr", "", "File containing the default custom resource of the module. If the module is a kubebuilder project, the default CR will be automatically detected.")
 	cmd.Flags().StringVarP(&o.TemplateOutput, "output", "o", "template.yaml", "File to which to output the module template if the module is uploaded to a registry")
@@ -174,7 +175,7 @@ func (cmd *command) Run(args []string) error {
 		cmd.CurrentStep.Success()
 
 		cmd.NewStep("Generating module template")
-		t, err := module.Template(archive, cmd.opts.Channel, modDef.DefaultCR, cmd.opts.RegistryCredLabelValue)
+		t, err := module.Template(archive, cmd.opts.Channel, modDef.DefaultCR, cmd.opts.RegistryCredSelector)
 		if err != nil {
 			cmd.CurrentStep.Failure()
 			return err

--- a/cmd/kyma/alpha/create/module/opts.go
+++ b/cmd/kyma/alpha/create/module/opts.go
@@ -14,20 +14,21 @@ import (
 type Options struct {
 	*cli.Options
 
-	Name           string
-	Version        string
-	Path           string
-	ModCache       string
-	RegistryURL    string
-	Credentials    string
-	TemplateOutput string
-	DefaultCRPath  string
-	Channel        string
-	Token          string
-	Insecure       bool
-	ResourcePaths  []string
-	Overwrite      bool
-	Clean          bool
+	Name               string
+	Version            string
+	Path               string
+	ModCache           string
+	RegistryURL        string
+	Credentials        string
+	TemplateOutput     string
+	DefaultCRPath      string
+	Channel            string
+	Token              string
+	Insecure           bool
+	ResourcePaths      []string
+	Overwrite          bool
+	Clean              bool
+	EnableRegistryCred bool
 }
 
 const (

--- a/cmd/kyma/alpha/create/module/opts.go
+++ b/cmd/kyma/alpha/create/module/opts.go
@@ -14,21 +14,21 @@ import (
 type Options struct {
 	*cli.Options
 
-	Name               string
-	Version            string
-	Path               string
-	ModCache           string
-	RegistryURL        string
-	Credentials        string
-	TemplateOutput     string
-	DefaultCRPath      string
-	Channel            string
-	Token              string
-	Insecure           bool
-	ResourcePaths      []string
-	Overwrite          bool
-	Clean              bool
-	EnableRegistryCred bool
+	Name                   string
+	Version                string
+	Path                   string
+	ModCache               string
+	RegistryURL            string
+	Credentials            string
+	TemplateOutput         string
+	DefaultCRPath          string
+	Channel                string
+	Token                  string
+	Insecure               bool
+	ResourcePaths          []string
+	Overwrite              bool
+	Clean                  bool
+	RegistryCredLabelValue string
 }
 
 const (

--- a/cmd/kyma/alpha/create/module/opts.go
+++ b/cmd/kyma/alpha/create/module/opts.go
@@ -14,21 +14,21 @@ import (
 type Options struct {
 	*cli.Options
 
-	Name                   string
-	Version                string
-	Path                   string
-	ModCache               string
-	RegistryURL            string
-	Credentials            string
-	TemplateOutput         string
-	DefaultCRPath          string
-	Channel                string
-	Token                  string
-	Insecure               bool
-	ResourcePaths          []string
-	Overwrite              bool
-	Clean                  bool
-	RegistryCredLabelValue string
+	Name                 string
+	Version              string
+	Path                 string
+	ModCache             string
+	RegistryURL          string
+	Credentials          string
+	TemplateOutput       string
+	DefaultCRPath        string
+	Channel              string
+	Token                string
+	Insecure             bool
+	ResourcePaths        []string
+	Overwrite            bool
+	Clean                bool
+	RegistryCredSelector string
 }
 
 const (

--- a/docs/gen-docs/kyma_alpha_create_module.md
+++ b/docs/gen-docs/kyma_alpha_create_module.md
@@ -43,21 +43,21 @@ Build module my-domain/modB in version 3.2.1 and push it to a local registry "un
 ## Flags
 
 ```bash
-      --channel string         Channel to use for the module template. (default "regular")
-      --clean                  Remove the mod-path folder and all its contents at the end.
-  -c, --credentials string     Basic authentication credentials for the given registry in the format user:password
-      --default-cr string      File containing the default custom resource of the module. If the module is a kubebuilder project, the default CR will be automatically detected.
-      --enable-registry-cred   Enable this flag to append a label into each descriptor resource, it indicates the dockerconfigjson secret (config separately) which provide credential for private repository.
-      --insecure               Use an insecure connection to access the registry.
-      --mod-cache string       Specifies the path where the module artifacts are locally cached to generate the image. If the path already has a module, use the overwrite flag to overwrite it. (default "./mod")
-  -n, --name string            Override the module name of the kubebuilder project. If the module is not a kubebuilder project, this flag is mandatory.
-  -o, --output string          File to which to output the module template if the module is uploaded to a registry (default "template.yaml")
-  -w, --overwrite              overwrites the existing mod-path directory if it exists
-  -p, --path string            Path to the module contents. (default current directory)
-      --registry string        Repository context url for module to upload. The repository url will be automatically added to the repository contexts in the module
-  -r, --resource stringArray   Add an extra resource in a new layer with format <NAME:TYPE@PATH>. It is also possible to provide only a path; name will default to the last path element and type to 'helm-chart'
-  -t, --token string           Authentication token for the given registry (alternative to basic authentication).
-      --version string         Version of the module. This flag is mandatory.
+      --channel string               Channel to use for the module template. (default "regular")
+      --clean                        Remove the mod-path folder and all its contents at the end.
+  -c, --credentials string           Basic authentication credentials for the given registry in the format user:password
+      --default-cr string            File containing the default custom resource of the module. If the module is a kubebuilder project, the default CR will be automatically detected.
+      --insecure                     Use an insecure connection to access the registry.
+      --mod-cache string             Specifies the path where the module artifacts are locally cached to generate the image. If the path already has a module, use the overwrite flag to overwrite it. (default "./mod")
+  -n, --name string                  Override the module name of the kubebuilder project. If the module is not a kubebuilder project, this flag is mandatory.
+  -o, --output string                File to which to output the module template if the module is uploaded to a registry (default "template.yaml")
+  -w, --overwrite                    overwrites the existing mod-path directory if it exists
+  -p, --path string                  Path to the module contents. (default current directory)
+      --registry string              Repository context url for module to upload. The repository url will be automatically added to the repository contexts in the module
+      --registry-cred-label string   Use this flag to config a label value, the generated label should be assigned to the dockerconfigjson secret (config separately) which provide credential for private repository.
+  -r, --resource stringArray         Add an extra resource in a new layer with format <NAME:TYPE@PATH>. It is also possible to provide only a path; name will default to the last path element and type to 'helm-chart'
+  -t, --token string                 Authentication token for the given registry (alternative to basic authentication).
+      --version string               Version of the module. This flag is mandatory.
 ```
 
 ## Flags inherited from parent commands

--- a/docs/gen-docs/kyma_alpha_create_module.md
+++ b/docs/gen-docs/kyma_alpha_create_module.md
@@ -47,6 +47,7 @@ Build module my-domain/modB in version 3.2.1 and push it to a local registry "un
       --clean                  Remove the mod-path folder and all its contents at the end.
   -c, --credentials string     Basic authentication credentials for the given registry in the format user:password
       --default-cr string      File containing the default custom resource of the module. If the module is a kubebuilder project, the default CR will be automatically detected.
+      --enable-registry-cred   Enable this flag to append a label into descriptor resource which indicate the dockerconfigjson secret (config separately) provide credential for private repository.
       --insecure               Use an insecure connection to access the registry.
       --mod-cache string       Specifies the path where the module artifacts are locally cached to generate the image. If the path already has a module, use the overwrite flag to overwrite it. (default "./mod")
   -n, --name string            Override the module name of the kubebuilder project. If the module is not a kubebuilder project, this flag is mandatory.

--- a/docs/gen-docs/kyma_alpha_create_module.md
+++ b/docs/gen-docs/kyma_alpha_create_module.md
@@ -54,7 +54,7 @@ Build module my-domain/modB in version 3.2.1 and push it to a local registry "un
   -w, --overwrite                       overwrites the existing mod-path directory if it exists
   -p, --path string                     Path to the module contents. (default current directory)
       --registry string                 Repository context url for module to upload. The repository url will be automatically added to the repository contexts in the module
-      --registry-cred-selector string   Use this flag to config label selectors to identify the dockerconfigjson secret (config separately) which provide credential for private repository. Example: "label1=value1,label2=value2"
+      --registry-cred-selector string   label selector to identify a secret of type kubernetes.io/dockerconfigjson (that needs to be created externally) which allows the image to be accessed in private image registries. This can be used if you push your module to a registry with authenticated access. Example: "label1=value1,label2=value2"
   -r, --resource stringArray            Add an extra resource in a new layer with format <NAME:TYPE@PATH>. It is also possible to provide only a path; name will default to the last path element and type to 'helm-chart'
   -t, --token string                    Authentication token for the given registry (alternative to basic authentication).
       --version string                  Version of the module. This flag is mandatory.

--- a/docs/gen-docs/kyma_alpha_create_module.md
+++ b/docs/gen-docs/kyma_alpha_create_module.md
@@ -43,21 +43,21 @@ Build module my-domain/modB in version 3.2.1 and push it to a local registry "un
 ## Flags
 
 ```bash
-      --channel string               Channel to use for the module template. (default "regular")
-      --clean                        Remove the mod-path folder and all its contents at the end.
-  -c, --credentials string           Basic authentication credentials for the given registry in the format user:password
-      --default-cr string            File containing the default custom resource of the module. If the module is a kubebuilder project, the default CR will be automatically detected.
-      --insecure                     Use an insecure connection to access the registry.
-      --mod-cache string             Specifies the path where the module artifacts are locally cached to generate the image. If the path already has a module, use the overwrite flag to overwrite it. (default "./mod")
-  -n, --name string                  Override the module name of the kubebuilder project. If the module is not a kubebuilder project, this flag is mandatory.
-  -o, --output string                File to which to output the module template if the module is uploaded to a registry (default "template.yaml")
-  -w, --overwrite                    overwrites the existing mod-path directory if it exists
-  -p, --path string                  Path to the module contents. (default current directory)
-      --registry string              Repository context url for module to upload. The repository url will be automatically added to the repository contexts in the module
-      --registry-cred-label string   Use this flag to config a label value, the generated label should be assigned to the dockerconfigjson secret (config separately) which provide credential for private repository.
-  -r, --resource stringArray         Add an extra resource in a new layer with format <NAME:TYPE@PATH>. It is also possible to provide only a path; name will default to the last path element and type to 'helm-chart'
-  -t, --token string                 Authentication token for the given registry (alternative to basic authentication).
-      --version string               Version of the module. This flag is mandatory.
+      --channel string                  Channel to use for the module template. (default "regular")
+      --clean                           Remove the mod-path folder and all its contents at the end.
+  -c, --credentials string              Basic authentication credentials for the given registry in the format user:password
+      --default-cr string               File containing the default custom resource of the module. If the module is a kubebuilder project, the default CR will be automatically detected.
+      --insecure                        Use an insecure connection to access the registry.
+      --mod-cache string                Specifies the path where the module artifacts are locally cached to generate the image. If the path already has a module, use the overwrite flag to overwrite it. (default "./mod")
+  -n, --name string                     Override the module name of the kubebuilder project. If the module is not a kubebuilder project, this flag is mandatory.
+  -o, --output string                   File to which to output the module template if the module is uploaded to a registry (default "template.yaml")
+  -w, --overwrite                       overwrites the existing mod-path directory if it exists
+  -p, --path string                     Path to the module contents. (default current directory)
+      --registry string                 Repository context url for module to upload. The repository url will be automatically added to the repository contexts in the module
+      --registry-cred-selector string   Use this flag to config label selectors to identify the dockerconfigjson secret (config separately) which provide credential for private repository. Example: "label1=value1,label2=value2"
+  -r, --resource stringArray            Add an extra resource in a new layer with format <NAME:TYPE@PATH>. It is also possible to provide only a path; name will default to the last path element and type to 'helm-chart'
+  -t, --token string                    Authentication token for the given registry (alternative to basic authentication).
+      --version string                  Version of the module. This flag is mandatory.
 ```
 
 ## Flags inherited from parent commands

--- a/docs/gen-docs/kyma_alpha_create_module.md
+++ b/docs/gen-docs/kyma_alpha_create_module.md
@@ -47,7 +47,7 @@ Build module my-domain/modB in version 3.2.1 and push it to a local registry "un
       --clean                  Remove the mod-path folder and all its contents at the end.
   -c, --credentials string     Basic authentication credentials for the given registry in the format user:password
       --default-cr string      File containing the default custom resource of the module. If the module is a kubebuilder project, the default CR will be automatically detected.
-      --enable-registry-cred   Enable this flag to append a label into descriptor resource which indicate the dockerconfigjson secret (config separately) provide credential for private repository.
+      --enable-registry-cred   Enable this flag to append a label into each descriptor resource, it indicates the dockerconfigjson secret (config separately) which provide credential for private repository.
       --insecure               Use an insecure connection to access the registry.
       --mod-cache string       Specifies the path where the module artifacts are locally cached to generate the image. If the path already has a module, use the overwrite flag to overwrite it. (default "./mod")
   -n, --name string            Override the module name of the kubebuilder project. If the module is not a kubebuilder project, this flag is mandatory.

--- a/pkg/module/template.go
+++ b/pkg/module/template.go
@@ -42,20 +42,20 @@ spec:
 	//nolint:gosec
 	OCIRegistryCredLabel = "oci-registry-cred"
 	//nolint:gosec
-	credSecretLabel = "operator.kyma-project.io/oci-registry-cred"
+	registryCredLabelKey = "operator.kyma-project.io/oci-registry-cred"
 )
 
-func Template(archive *ctf.ComponentArchive, channel string, data []byte, enableRegistryCred bool) ([]byte, error) {
+func Template(archive *ctf.ComponentArchive, channel string, data []byte, registryCredLabelValue string) ([]byte, error) {
 	descriptor, err := remoteDescriptor(archive)
 	if err != nil {
 		return nil, err
 	}
-	if enableRegistryCred {
+	if registryCredLabelValue != "" {
 		for i := range descriptor.Resources {
 			resource := &descriptor.Resources[i]
 			resource.SetLabels([]v2.Label{{
 				Name:  OCIRegistryCredLabel,
-				Value: json.RawMessage(fmt.Sprintf(`{"%s": "%s"}`, credSecretLabel, descriptor.Name)),
+				Value: json.RawMessage(fmt.Sprintf(`{"%s": "%s"}`, registryCredLabelKey, registryCredLabelValue)),
 			}})
 		}
 	}

--- a/pkg/module/template.go
+++ b/pkg/module/template.go
@@ -39,8 +39,10 @@ spec:
 {{yaml .Descriptor | printf "%s" | indent 4}}
 `
 
+	//nolint:gosec
 	OCIRegistryCredLabel = "oci-registry-cred"
-	credSecretLabel      = "operator.kyma-project.io/oci-registry-cred"
+	//nolint:gosec
+	credSecretLabel = "operator.kyma-project.io/oci-registry-cred"
 )
 
 func Template(archive *ctf.ComponentArchive, channel string, data []byte, enableRegistryCred bool) ([]byte, error) {

--- a/pkg/module/template.go
+++ b/pkg/module/template.go
@@ -41,8 +41,6 @@ spec:
 
 	//nolint:gosec
 	OCIRegistryCredLabel = "oci-registry-cred"
-	//nolint:gosec
-	registryCredLabelKey = "operator.kyma-project.io/oci-registry-cred"
 )
 
 func Template(archive *ctf.ComponentArchive, channel string, data []byte, registryCredSelector string) ([]byte, error) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
For private oci registry, this feature request introduce a flag to automatically appended label into component descriptor resources, which can be used for the secret label which provide registry credentials.

**Related issue(s)**
https://github.com/kyma-project/module-manager/issues/201
