### PR TITLE
Improve managed runtime detection

### DIFF
--- a/cmd/kyma/deploy/cmd.go
+++ b/cmd/kyma/deploy/cmd.go
@@ -123,7 +123,7 @@ func (cmd *command) run() error {
 	}
 
 	if !cmd.opts.NonInteractive {
-		if err := cli.DetectManagedEnvironment(cmd.K8s, cmd.Factory.NewStep("")); err != nil {
+		if err := cli.DetectManagedEnvironment(context.Background(), cmd.K8s, cmd.Factory.NewStep("")); err != nil {
 			return err
 		}
 	}

--- a/cmd/kyma/undeploy/cmd.go
+++ b/cmd/kyma/undeploy/cmd.go
@@ -41,7 +41,7 @@ func NewCmd(o *Options) *cobra.Command {
 		Use:   "undeploy",
 		Short: "Undeploys Kyma from a running Kubernetes cluster.",
 		Long:  `Use this command to undeploy Kyma from a running Kubernetes cluster.`,
-		RunE:  func(_ *cobra.Command, _ []string) error { return cmd.Run() },
+		RunE:  func(cc *cobra.Command, _ []string) error { return cmd.Run(cc.Context()) },
 	}
 
 	cobraCmd.Flags().StringSliceVarP(&o.Components, "component", "", []string{}, "Provide one or more components to undeploy (e.g. --component componentName@namespace)")
@@ -68,7 +68,7 @@ func NewCmd(o *Options) *cobra.Command {
 }
 
 // Run runs the command
-func (cmd *command) Run() error {
+func (cmd *command) Run(ctx context.Context) error {
 	var err error
 
 	if cmd.opts.CI {
@@ -84,7 +84,7 @@ func (cmd *command) Run() error {
 	}
 
 	if !cmd.opts.NonInteractive {
-		if err := cli.DetectManagedEnvironment(context.Background(), cmd.K8s, cmd.Factory.NewStep("")); err != nil {
+		if err := cli.DetectManagedEnvironment(ctx, cmd.K8s, cmd.Factory.NewStep("")); err != nil {
 			return err
 		}
 	}
@@ -112,7 +112,7 @@ func (cmd *command) Run() error {
 		return err
 	}
 
-	clusterInfo, err := clusterinfo.Discover(context.Background(), cmd.K8s.Static())
+	clusterInfo, err := clusterinfo.Discover(ctx, cmd.K8s.Static())
 	if err != nil {
 		return errors.Wrap(err, "failed to discover underlying cluster type")
 	}

--- a/cmd/kyma/undeploy/cmd.go
+++ b/cmd/kyma/undeploy/cmd.go
@@ -84,7 +84,7 @@ func (cmd *command) Run() error {
 	}
 
 	if !cmd.opts.NonInteractive {
-		if err := cli.DetectManagedEnvironment(cmd.K8s, cmd.Factory.NewStep("")); err != nil {
+		if err := cli.DetectManagedEnvironment(context.Background(), cmd.K8s, cmd.Factory.NewStep("")); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/managed.go
+++ b/internal/cli/managed.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"errors"
 
 	"github.com/kyma-project/cli/internal/clusterinfo"
@@ -8,11 +9,15 @@ import (
 	"github.com/kyma-project/cli/pkg/step"
 )
 
-const managedKymaWarning = "CAUTION: You are trying to use Kyma CLI to change a managed Kyma runtime (SAP Kyma Runtime). This action may corrupt the Kyma runtime. Proceed at your own risk."
+const managedKymaWarning = "CAUTION: You are trying to use Kyma CLI to change a managed Kyma runtime (SAP BTP, Kyma runtime). This action may corrupt the existing installation. Proceed at your own risk."
 
 // DetectManagedEnvironment introduces a step that checks if the target runtime is a managed Kyma runtime. CLI should be used with caution in such environment and user is prompted for confirmation.
-func DetectManagedEnvironment(k kube.KymaKube, s step.Step) error {
-	if clusterinfo.IsManagedKyma(k.RestConfig()) {
+func DetectManagedEnvironment(ctx context.Context, k kube.KymaKube, s step.Step) error {
+	managed, err := clusterinfo.IsManagedKyma(ctx, k.RestConfig(), k.Static())
+	if err != nil {
+		return err
+	}
+	if managed {
 		s.LogWarn(managedKymaWarning)
 		if !s.PromptYesNo("Do you really want to proceed? ") {
 			return errors.New("Command stopped by user")

--- a/internal/cli/managed.go
+++ b/internal/cli/managed.go
@@ -20,7 +20,7 @@ func DetectManagedEnvironment(ctx context.Context, k kube.KymaKube, s step.Step)
 	if managed {
 		s.LogInfo(managedKymaWarning)
 		if !s.PromptYesNo("Do you really want to proceed? ") {
-			return errors.New("Command stopped by user")
+			return errors.New("command stopped by user")
 		}
 	}
 	return nil

--- a/internal/cli/managed.go
+++ b/internal/cli/managed.go
@@ -18,7 +18,7 @@ func DetectManagedEnvironment(ctx context.Context, k kube.KymaKube, s step.Step)
 		return err
 	}
 	if managed {
-		s.LogWarn(managedKymaWarning)
+		s.LogInfo(managedKymaWarning)
 		if !s.PromptYesNo("Do you really want to proceed? ") {
 			return errors.New("Command stopped by user")
 		}

--- a/internal/clusterinfo/clusterinfo.go
+++ b/internal/clusterinfo/clusterinfo.go
@@ -100,7 +100,7 @@ func lookupConfigMapMarker(ctx context.Context, kubeClient kubernetes.Interface)
 		if k8sErrors.IsNotFound(err) {
 			return false, nil
 		}
-		return false, fmt.Errorf("Error getting ConfigMaps in the \"kyma-system\" namespace: %w", err)
+		return false, fmt.Errorf("failed to get ConfigMap \"skr-configmap\"  in the \"kyma-system\" namespace: %w", err)
 	}
 
 	if cm == nil || cm.ObjectMeta.Labels == nil || cm.Data == nil {

--- a/internal/clusterinfo/clusterinfo.go
+++ b/internal/clusterinfo/clusterinfo.go
@@ -78,11 +78,9 @@ func Discover(ctx context.Context, kubeClient kubernetes.Interface) (Info, error
 	return K3d{ClusterName: k3dClusterName}, nil
 }
 
-// IsManagedKyma returns true if the k8s go-client is configured to access a managed kyma runtime
+// IsManagedKyma returns true if the k8s go-client is configured to access a managed Kyma runtime
 func IsManagedKyma(ctx context.Context, restConfig *rest.Config, kubeClient kubernetes.Interface) (bool, error) {
-	//1) Verfiy the domain
 	if strings.HasSuffix(restConfig.Host, legacyEnvAPIServerSuffix) {
-		//Legacy, may be removed in the future
 		return lookupConfigMapMarker(ctx, kubeClient)
 	}
 	if strings.HasSuffix(restConfig.Host, skrEnvAPIServerSuffix) {
@@ -92,7 +90,7 @@ func IsManagedKyma(ctx context.Context, restConfig *rest.Config, kubeClient kube
 	return false, nil
 }
 
-// lookupConfigMapMarker tries to find a "kyma-system/skr-configmap" "marker" ConfigMap with specific labels and payload.
+// lookupConfigMapMarker tries to find a "kyma-system/skr-configmap" marker ConfigMap with specific labels and payload.
 func lookupConfigMapMarker(ctx context.Context, kubeClient kubernetes.Interface) (bool, error) {
 	cm, err := kubeClient.CoreV1().ConfigMaps("kyma-system").Get(ctx, "skr-configmap", metav1.GetOptions{})
 


### PR DESCRIPTION
**Description**

This PR improves detection of managed Kyma runtimes in the CLI.
This is a temporary solution that addresses the current runtimes managed by the reconciler.
In the future, when we completely switch to the modularization-based solution, we'll have to adjust this logic.
See https://github.com/kyma-project/cli/issues/1472 for details. 

Changes proposed in this pull request:

- Add "marker" ConfigMap detection. This ConfigMap is only installed on SKR's
- Improve message handling (no more stack trace in the console)

**Related issue(s)**
- https://github.com/kyma-project/cli/issues/1472
- https://github.com/kyma-project/cli/issues/1460