### PR TITLE
enable dependabot library version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    labels:
+      - "go"
+      - "area/dependency"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "gomod"
+      include: "scope"
+  - package-ecosystem: "docker"
+    directory: "/"
+    labels:
+      - "docker"
+      - "area/dependency"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "docker"
+      include: "scope"


### PR DESCRIPTION
**Description**

For now the configuration of the CLI project only allows dependabot to create version update PR's for security-related alerts.
We also want to keep other dependencies updated in a timely manner. 

Changes proposed in this pull request:

- add `dependabot.yml`

**Related issue(s)**
See: https://github.com/kyma-project/lifecycle-manager/issues/338
