### PR TITLE
Revert "gomod(deps): bump github.com/docker/cli from 20.10.21+incompatible to 23.0.0+incompatible"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/briandowns/spinner v1.21.0
 	github.com/containerd/containerd v1.6.15
 	github.com/daviddengcn/go-colortext v1.0.0
-	github.com/docker/cli v23.0.0+incompatible
+	github.com/docker/cli v20.10.21+incompatible
 	github.com/docker/docker v20.10.21+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/fatih/color v1.14.1

--- a/go.sum
+++ b/go.sum
@@ -417,8 +417,8 @@ github.com/distribution/distribution/v3 v3.0.0-20221208165359-362910506bc2 h1:aB
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/dnephin/pflag v1.0.7/go.mod h1:uxE91IoWURlOiTUIA8Mq5ZZkAv3dPUfZNaT80Zm7OQE=
 github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
-github.com/docker/cli v23.0.0+incompatible h1:bcM4syaQ+EM/iczJTimMOGzvnzJBFPFEf4acS7sZ+RM=
-github.com/docker/cli v23.0.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v20.10.21+incompatible h1:qVkgyYUnOLQ98LtXBrwd/duVqPT2X4SHndOuGsfwyhU=
+github.com/docker/cli v20.10.21+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=


### PR DESCRIPTION
Reverts kyma-project/cli#1518

**Reason:** We can't easily bump "docker/docker" in the same way: `20.10.21` to `23.0.0`.
This is because of the API changes that make both our code and some external dependencies we use to not compile anymore.
Interestingly, the updated `docker/cli` is also using `docker/docker` in the updated version (23.0.0+incompatible), but the overall resolution of `docker/docker` in go.sum still points to `v20.10.21+` - it is the latest version that works for this whole setup.

Apart from that, we're also using `moby/moby` that seems to be an alias for `docker/docker`: If I try to open `https://github.com/docker/docker` I am redirected to `https://github.com/moby/moby`. If that is the case, we should bump these two together or, even better, get rid of one of them to avoid possible version inconsistencies.