### PR TITLE
Fix defaultCRPath

### DIFF
--- a/pkg/module/resources.go
+++ b/pkg/module/resources.go
@@ -217,11 +217,10 @@ func inspectProject(def *Definition, p *kubebuilder.Project, layers []Layer, s s
 				return err
 			}
 		} else {
-			cr, err := os.ReadFile(def.DefaultCRPath)
+			cr, err = os.ReadFile(def.DefaultCRPath)
 			if err != nil {
 				return fmt.Errorf("could not read CR file %q: %w", def.DefaultCRPath, err)
 			}
-			def.DefaultCR = cr
 		}
 	}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Fixes bug for `defaultCRPath` flag. Reason why this was not working, was that the var `cr` was shadowed in the if clause, thus when setting the path in the definition, it will use the empty var and not the shadowed one. Fixed by removing shadow variable.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes #1540 