### PR TITLE
Add new API subscription version

### DIFF
--- a/cmd/kyma/apply/function/function.go
+++ b/cmd/kyma/apply/function/function.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kyma-project/hydroform/function/pkg/client"
 	"github.com/kyma-project/hydroform/function/pkg/manager"
 	"github.com/kyma-project/hydroform/function/pkg/operator"
+	operator_types "github.com/kyma-project/hydroform/function/pkg/operator/types"
 	resources "github.com/kyma-project/hydroform/function/pkg/resources/unstructured"
 	"github.com/kyma-project/hydroform/function/pkg/workspace"
 	"github.com/pkg/errors"
@@ -81,7 +82,7 @@ func (c *command) Run() error {
 	}
 
 	if configuration.SchemaVersion == "" {
-		configuration.SchemaVersion = workspace.SchemaVersionV0
+		configuration.SchemaVersion = workspace.SchemaVersionDefault
 	}
 
 	if configuration.Source.SourcePath == "" {
@@ -119,12 +120,13 @@ func (c *command) Run() error {
 		return err
 	}
 
+	subscriptionGVR := operator.SubscriptionGVR(configuration.SchemaVersion)
 	mgr.AddParent(
-		operator.NewGenericOperator(client.Resource(operator.GVRFunction).Namespace(configuration.Namespace), function),
+		operator.NewGenericOperator(client.Resource(operator_types.GVRFunction).Namespace(configuration.Namespace), function),
 		[]operator.Operator{
-			operator.NewSubscriptionOperator(client.Resource(operator.GVRSubscriptionV1alpha1).Namespace(configuration.Namespace),
+			operator.NewSubscriptionOperator(client.Resource(subscriptionGVR).Namespace(configuration.Namespace),
 				configuration.Name, configuration.Namespace, subscriptions...),
-			operator.NewAPIRuleOperator(client.Resource(operator.GVRApiRule).Namespace(configuration.Namespace),
+			operator.NewAPIRuleOperator(client.Resource(operator_types.GVRApiRule).Namespace(configuration.Namespace),
 				configuration.Name, apiRules...),
 		},
 	)

--- a/cmd/kyma/apply/function/function.go
+++ b/cmd/kyma/apply/function/function.go
@@ -80,6 +80,10 @@ func (c *command) Run() error {
 		return errors.Wrap(err, "Could not decode the configuration file")
 	}
 
+	if configuration.SchemaVersion == "" {
+		configuration.SchemaVersion = workspace.SchemaVersionV0
+	}
+
 	if configuration.Source.SourcePath == "" {
 		configuration.Source.SourcePath = filepath.Dir(c.opts.Filename)
 	}
@@ -118,7 +122,7 @@ func (c *command) Run() error {
 	mgr.AddParent(
 		operator.NewGenericOperator(client.Resource(operator.GVRFunction).Namespace(configuration.Namespace), function),
 		[]operator.Operator{
-			operator.NewSubscriptionOperator(client.Resource(operator.GVRSubscription).Namespace(configuration.Namespace),
+			operator.NewSubscriptionOperator(client.Resource(operator.GVRSubscriptionV1alpha1).Namespace(configuration.Namespace),
 				configuration.Name, configuration.Namespace, subscriptions...),
 			operator.NewAPIRuleOperator(client.Resource(operator.GVRApiRule).Namespace(configuration.Namespace),
 				configuration.Name, apiRules...),

--- a/cmd/kyma/init/function/function.go
+++ b/cmd/kyma/init/function/function.go
@@ -2,6 +2,7 @@ package function
 
 import (
 	"fmt"
+	"github.com/kyma-project/cli/cmd/kyma/sync/function"
 	"os"
 	"path"
 
@@ -54,9 +55,10 @@ Use the flags to specify the initial configuration for your Function or to choos
 		&o.Runtime, "runtime", "r", defaultRuntime,
 		`Flag used to define the environment for running your Function. Use one of these options:
 	- nodejs14 (deprecated)
-	- nodejs16	
+	- nodejs16
 	- python39`,
 	)
+	cmd.Flags().StringVar(&o.SchemaVersion, "schema-version", string(workspace.SchemaVersionDefault), `Version of the config API.`)
 
 	// git function options
 	cmd.Flags().StringVar(&o.URL, "url", "", `Git repository URL`)
@@ -101,13 +103,19 @@ func (c *command) Run() error {
 		)
 	}
 
+	schemaVersion, err := function.ParseSchemaVersion(c.opts.SchemaVersion)
+	if err != nil {
+		s.Failure()
+		return err
+	}
+
 	configuration := workspace.Cfg{
 		Runtime:              c.opts.Runtime,
 		RuntimeImageOverride: c.opts.RuntimeImageOverride,
 		Name:                 c.opts.Name,
 		Namespace:            c.opts.Namespace,
 		Source:               c.opts.source(),
-		SchemaVersion:        workspace.SchemaVersionDefault,
+		SchemaVersion:        schemaVersion,
 	}
 
 	err = workspace.Initialize(configuration, c.opts.Dir)

--- a/cmd/kyma/init/function/function.go
+++ b/cmd/kyma/init/function/function.go
@@ -102,12 +102,12 @@ func (c *command) Run() error {
 	}
 
 	configuration := workspace.Cfg{
-		SchemaVersion:        workspace.SchemaVersionDefault,
 		Runtime:              c.opts.Runtime,
 		RuntimeImageOverride: c.opts.RuntimeImageOverride,
 		Name:                 c.opts.Name,
 		Namespace:            c.opts.Namespace,
 		Source:               c.opts.source(),
+		SchemaVersion:        workspace.SchemaVersionDefault,
 	}
 
 	err = workspace.Initialize(configuration, c.opts.Dir)

--- a/cmd/kyma/init/function/function.go
+++ b/cmd/kyma/init/function/function.go
@@ -102,6 +102,7 @@ func (c *command) Run() error {
 	}
 
 	configuration := workspace.Cfg{
+		SchemaVersion:        workspace.SchemaVersionDefault,
 		Runtime:              c.opts.Runtime,
 		RuntimeImageOverride: c.opts.RuntimeImageOverride,
 		Name:                 c.opts.Name,

--- a/cmd/kyma/init/function/opts.go
+++ b/cmd/kyma/init/function/opts.go
@@ -23,6 +23,7 @@ type Options struct {
 	BaseDir              string
 	SourcePath           string
 	VsCode               bool
+	SchemaVersion        string
 }
 
 // NewOptions creates options with default values

--- a/cmd/kyma/sync/function/function.go
+++ b/cmd/kyma/sync/function/function.go
@@ -43,7 +43,7 @@ Use the flags to specify the name of your Function, the Namespace, or the locati
 
 	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", "", `Namespace from which you want to sync the Function.`)
 	cmd.Flags().StringVarP(&o.Dir, "dir", "d", "", `Full path to the directory where you want to save the project.`)
-	cmd.Flags().StringVar(&o.SchemaVersion, "schemaVersion", string(workspace.SchemaVersionDefault), `Version of the config API.`)
+	cmd.Flags().StringVar(&o.SchemaVersion, "schema-version", string(workspace.SchemaVersionDefault), `Version of the config API.`)
 
 	return cmd
 }
@@ -73,7 +73,7 @@ func (c *command) Run(name string) error {
 		return c.K8s.Dynamic().Resource(resource).Namespace(namespace)
 	}
 
-	schemaVersion, err := parseSchemaVersion(c.opts.SchemaVersion)
+	schemaVersion, err := ParseSchemaVersion(c.opts.SchemaVersion)
 	if err != nil {
 		s.Failure()
 		return err
@@ -95,7 +95,7 @@ func (c *command) Run(name string) error {
 	return nil
 }
 
-func parseSchemaVersion(version string) (workspace.SchemaVersion, error) {
+func ParseSchemaVersion(version string) (workspace.SchemaVersion, error) {
 	for _, value := range workspace.AllowedSchemaVersions {
 		if version == string(value) {
 			return value, nil

--- a/cmd/kyma/sync/function/function.go
+++ b/cmd/kyma/sync/function/function.go
@@ -2,6 +2,7 @@ package function
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/kyma-project/cli/internal/cli"
@@ -42,6 +43,7 @@ Use the flags to specify the name of your Function, the Namespace, or the locati
 
 	cmd.Flags().StringVarP(&o.Namespace, "namespace", "n", "", `Namespace from which you want to sync the Function.`)
 	cmd.Flags().StringVarP(&o.Dir, "dir", "d", "", `Full path to the directory where you want to save the project.`)
+	cmd.Flags().StringVar(&o.SchemaVersion, "schemaVersion", string(workspace.SchemaVersionDefault), `Version of the config API.`)
 
 	return cmd
 }
@@ -71,9 +73,16 @@ func (c *command) Run(name string) error {
 		return c.K8s.Dynamic().Resource(resource).Namespace(namespace)
 	}
 
+	schemaVersion, err := parseSchemaVersion(c.opts.SchemaVersion)
+	if err != nil {
+		s.Failure()
+		return err
+	}
+
 	cfg := workspace.Cfg{
-		Name:      name,
-		Namespace: c.opts.Namespace,
+		Name:          name,
+		Namespace:     c.opts.Namespace,
+		SchemaVersion: schemaVersion,
 	}
 
 	err = workspace.Synchronise(ctx, cfg, c.opts.Dir, buildClient)
@@ -84,4 +93,13 @@ func (c *command) Run(name string) error {
 
 	s.Successf("Function synchronised in %s", c.opts.Dir)
 	return nil
+}
+
+func parseSchemaVersion(version string) (workspace.SchemaVersion, error) {
+	for _, value := range workspace.AllowedSchemaVersions {
+		if version == string(value) {
+			return value, nil
+		}
+	}
+	return "", fmt.Errorf("unexpected schema version %s", version)
 }

--- a/cmd/kyma/sync/function/opts.go
+++ b/cmd/kyma/sync/function/opts.go
@@ -11,9 +11,10 @@ import (
 type Options struct {
 	*cli.Options
 
-	Namespace string
-	Dir       string
-	Timeout   time.Duration
+	Namespace     string
+	Dir           string
+	Timeout       time.Duration
+	SchemaVersion string
 }
 
 // NewOptions creates options with default values

--- a/docs/gen-docs/kyma_init_function.md
+++ b/docs/gen-docs/kyma_init_function.md
@@ -24,11 +24,10 @@ kyma init function [flags]
       --repository-name string          The name of the Git repository to be created
   -r, --runtime string                  Flag used to define the environment for running your Function. Use one of these options:
                                         	- nodejs14 (deprecated)
-                                        	- nodejs16	
+                                        	- nodejs16
                                         	- python39 (default "nodejs16")
-                                        	- python39 (default "nodejs14")
-      --schema-version string   Version of the config API. (default "v0")
       --runtime-image-override string   Set custom runtime image base.
+      --schema-version string           Version of the config API. (default "v0")
       --url string                      Git repository URL
       --vscode                          Generate VS Code settings containing config.yaml JSON schema for autocompletion (see "kyma get schema -h" for more info)
 ```

--- a/docs/gen-docs/kyma_init_function.md
+++ b/docs/gen-docs/kyma_init_function.md
@@ -26,6 +26,8 @@ kyma init function [flags]
                                         	- nodejs14 (deprecated)
                                         	- nodejs16	
                                         	- python39 (default "nodejs16")
+                                        	- python39 (default "nodejs14")
+      --schema-version string   Version of the config API. (default "v0")
       --runtime-image-override string   Set custom runtime image base.
       --url string                      Git repository URL
       --vscode                          Generate VS Code settings containing config.yaml JSON schema for autocompletion (see "kyma get schema -h" for more info)

--- a/docs/gen-docs/kyma_sync_function.md
+++ b/docs/gen-docs/kyma_sync_function.md
@@ -18,7 +18,7 @@ kyma sync function [flags]
 ```bash
   -d, --dir string             Full path to the directory where you want to save the project.
   -n, --namespace string       Namespace from which you want to sync the Function.
-      --schemaVersion string   Version of the config API. (default "v0")
+      --schema-version string   Version of the config API. (default "v0")
 ```
 
 ## Flags inherited from parent commands

--- a/docs/gen-docs/kyma_sync_function.md
+++ b/docs/gen-docs/kyma_sync_function.md
@@ -16,8 +16,8 @@ kyma sync function [flags]
 ## Flags
 
 ```bash
-  -d, --dir string             Full path to the directory where you want to save the project.
-  -n, --namespace string       Namespace from which you want to sync the Function.
+  -d, --dir string              Full path to the directory where you want to save the project.
+  -n, --namespace string        Namespace from which you want to sync the Function.
       --schema-version string   Version of the config API. (default "v0")
 ```
 

--- a/docs/gen-docs/kyma_sync_function.md
+++ b/docs/gen-docs/kyma_sync_function.md
@@ -16,8 +16,9 @@ kyma sync function [flags]
 ## Flags
 
 ```bash
-  -d, --dir string         Full path to the directory where you want to save the project.
-  -n, --namespace string   Namespace from which you want to sync the Function.
+  -d, --dir string             Full path to the directory where you want to save the project.
+  -n, --namespace string       Namespace from which you want to sync the Function.
+      --schemaVersion string   Version of the config API. (default "v0")
 ```
 
 ## Flags inherited from parent commands

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.18
 // required to avoid locking with gardner dependency updates
 replace k8s.io/client-go => k8s.io/client-go v0.26.1
 
+replace github.com/kyma-project/hydroform/function => /Users/mk/go/src/github.com/kyma-project/hydroform/function
+
 require (
 	github.com/Masterminds/semver/v3 v3.2.0
 	github.com/avast/retry-go v3.0.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,6 @@ go 1.18
 // required to avoid locking with gardner dependency updates
 replace k8s.io/client-go => k8s.io/client-go v0.26.1
 
-replace github.com/kyma-project/hydroform/function => /Users/mk/go/src/github.com/kyma-project/hydroform/function
-
 require (
 	github.com/Masterminds/semver/v3 v3.2.0
 	github.com/avast/retry-go v3.0.0+incompatible
@@ -23,7 +21,7 @@ require (
 	github.com/go-logr/zapr v1.2.3
 	github.com/imdario/mergo v0.3.13
 	github.com/kyma-incubator/reconciler v0.0.0-20230203092534-fd85106be3cd
-	github.com/kyma-project/hydroform/function v0.0.0-20221202082519-8cd1c2a4c268
+	github.com/kyma-project/hydroform/function v0.0.0-20230228113933-44a09e52d52f
 	github.com/kyma-project/hydroform/provision v0.0.0-20230127124234-b67611c40868
 	github.com/kyma-project/lifecycle-manager v0.0.0-20230228084539-adc0e4a5f93a
 	github.com/mandelsoft/vfs v0.0.0-20220805210647-bf14a11bfe31

--- a/go.sum
+++ b/go.sum
@@ -1104,8 +1104,6 @@ github.com/ktrysmt/go-bitbucket v0.6.4/go.mod h1:9u0v3hsd2rqCHRIpbir1oP7F58uo5dq
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kyma-incubator/reconciler v0.0.0-20230203092534-fd85106be3cd h1:BycDCodhNQG1248zSobgE6I/T6nGN8qlHVgcBSVb91k=
 github.com/kyma-incubator/reconciler v0.0.0-20230203092534-fd85106be3cd/go.mod h1:VNUfzgLpmNa02/+LGNbW4zhh1X/PaJwQ1IeCM1uA2A0=
-github.com/kyma-project/hydroform/function v0.0.0-20221202082519-8cd1c2a4c268 h1:97Aryt87+s68D9d9bQnKdE6tuULMdCIIaMpFX5LVsTQ=
-github.com/kyma-project/hydroform/function v0.0.0-20221202082519-8cd1c2a4c268/go.mod h1:uNaUYcFyK100sIiokOJ07/rPXSvvG2gRNbXt4wRM4ks=
 github.com/kyma-project/hydroform/provision v0.0.0-20230127124234-b67611c40868 h1:RV2QLbL7Za94O62CvDlrdcLRK5GFI2Zq0GNUe0mCMZk=
 github.com/kyma-project/hydroform/provision v0.0.0-20230127124234-b67611c40868/go.mod h1:ttfW/oPcTIMMtAqY9qpocdAaQ2A+5nN8ZQl2L+1rIac=
 github.com/kyma-project/istio/operator v0.0.0-20221129102055-d37c5c8e6add h1:ohTtnIlNXSQPHB/nMZvBXs+uBnTqQ6HRSgAvptyWzlc=

--- a/go.sum
+++ b/go.sum
@@ -1104,6 +1104,8 @@ github.com/ktrysmt/go-bitbucket v0.6.4/go.mod h1:9u0v3hsd2rqCHRIpbir1oP7F58uo5dq
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kyma-incubator/reconciler v0.0.0-20230203092534-fd85106be3cd h1:BycDCodhNQG1248zSobgE6I/T6nGN8qlHVgcBSVb91k=
 github.com/kyma-incubator/reconciler v0.0.0-20230203092534-fd85106be3cd/go.mod h1:VNUfzgLpmNa02/+LGNbW4zhh1X/PaJwQ1IeCM1uA2A0=
+github.com/kyma-project/hydroform/function v0.0.0-20230228113933-44a09e52d52f h1:uosw8xrrtcYcka/IWsceW0U1oqsEXDmCl+p5vp9PfUo=
+github.com/kyma-project/hydroform/function v0.0.0-20230228113933-44a09e52d52f/go.mod h1:uNaUYcFyK100sIiokOJ07/rPXSvvG2gRNbXt4wRM4ks=
 github.com/kyma-project/hydroform/provision v0.0.0-20230127124234-b67611c40868 h1:RV2QLbL7Za94O62CvDlrdcLRK5GFI2Zq0GNUe0mCMZk=
 github.com/kyma-project/hydroform/provision v0.0.0-20230127124234-b67611c40868/go.mod h1:ttfW/oPcTIMMtAqY9qpocdAaQ2A+5nN8ZQl2L+1rIac=
 github.com/kyma-project/istio/operator v0.0.0-20221129102055-d37c5c8e6add h1:ohTtnIlNXSQPHB/nMZvBXs+uBnTqQ6HRSgAvptyWzlc=


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Update `apply`, `init` and `sync` commands to be compatible with `hydroform main` and new subscription API with versioning.  

Changes proposed in this pull request:

- update `apply/function` to set `schemaVersion` to default when the version is not provided
- update `init/function` to pass the `SchemaVersion` to the config
- add in `sync/function` the flag to set the `schemaVersion`
- add in `kyma_sync_function.md` description of `--schemaVersion` flag

**Related issue(s)**
https://github.com/kyma-project/cli/issues/1532
[hydroform](https://github.com/kyma-project/hydroform/pull/397)
