### PR TITLE
fix: add retry on module template apply

### DIFF
--- a/cmd/kyma/alpha/deploy/cmd.go
+++ b/cmd/kyma/alpha/deploy/cmd.go
@@ -237,19 +237,14 @@ func (cmd *command) deploy(ctx context.Context, start time.Time) error {
 	// deploy modules and kyma CR
 	if hasKyma {
 		// TODO change to fetch templates from release artifacts
-		modStep := cmd.NewStep("Modules deployed")
-		for _, t := range cmd.opts.Templates {
-			b, err := os.ReadFile(t)
-			if err != nil {
+		if len(cmd.opts.Templates) > 0 {
+			modStep := cmd.NewStep("Modules deployed")
+			if err := deploy.ModuleTemplates(ctx, cmd.K8s, cmd.opts.Templates); err != nil {
 				modStep.Failuref("Failed to deploy modules")
 				return err
 			}
-			if err := cmd.K8s.Apply(ctx, b); err != nil {
-				modStep.Failuref("Failed to deploy modules")
-				return err
-			}
+			modStep.Success()
 		}
-		modStep.Success()
 		kymaStep := cmd.NewStep("Kyma CR deployed")
 		if err := deploy.Kyma(ctx, cmd.K8s, cmd.opts.Namespace, cmd.opts.Channel, cmd.opts.KymaCR, false); err != nil {
 			kymaStep.Failuref("Failed to deploy Kyma CR")

--- a/internal/deploy/module_templates.go
+++ b/internal/deploy/module_templates.go
@@ -1,0 +1,28 @@
+package deploy
+
+import (
+	"context"
+	"os"
+
+	"github.com/avast/retry-go"
+	"github.com/kyma-project/cli/internal/kube"
+)
+
+func ModuleTemplates(ctx context.Context, k8s kube.KymaKube, templates []string) error {
+	for _, t := range templates {
+		b, err := os.ReadFile(t)
+		if err != nil {
+			return err
+		}
+		if err := retry.Do(
+			func() error {
+				return k8s.Apply(context.Background(), b)
+			}, retry.Attempts(defaultRetries), retry.Delay(defaultInitialBackoff), retry.DelayType(retry.BackOffDelay),
+			retry.LastErrorOnly(false), retry.Context(ctx),
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- This adds a missing retry that caused the module template apply to immediately fail if the web hooks of the lifecycle manager are not yet ready to accept connections

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
