### PR TITLE
chore: migrate alpha list modules to structured api and rewrite tabwriter

### DIFF
--- a/cmd/kyma/alpha/list/list.go
+++ b/cmd/kyma/alpha/list/list.go
@@ -9,8 +9,9 @@ import (
 // NewCmd creates a new Kyma CLI command
 func NewCmd(o *cli.Options) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list",
-		Short: "Lists resources on the Kyma cluster.",
+		Use:     "list",
+		Aliases: []string{"get"},
+		Short:   "Lists resources on the Kyma cluster.",
 		Long: `Use this command to list resources on the Kyma cluster.
 `,
 	}

--- a/cmd/kyma/alpha/list/module/list.tmpl
+++ b/cmd/kyma/alpha/list/module/list.tmpl
@@ -1,3 +1,0 @@
-{{- range .Items -}}
-{{$descriptor := .Object.spec.descriptor.component}}{{$metadata := .Object.metadata}}{{ index $metadata.labels "operator.kyma-project.io/module-name" }}{{"\t"}}{{ $descriptor.name }}{{"\t"}}{{ .Object.spec.channel }}{{"\t"}}{{ $descriptor.version }}{{"\t"}}{{ $metadata.namespace }}/{{ $metadata.name }}{{"\t"}}{{ index $metadata.annotations "state.cmd.kyma-project.io" }}{{"\n"}}
-{{- end -}}

--- a/cmd/kyma/alpha/list/module/module.go
+++ b/cmd/kyma/alpha/list/module/module.go
@@ -96,12 +96,6 @@ func (cmd *command) Run(ctx context.Context, args []string) error {
 		cmd.Factory.UseLogger = true
 	}
 
-	//if !cmd.opts.Verbose {
-	//	stderr := os.Stderr
-	//	os.Stderr = nil
-	//	defer func() { os.Stderr = stderr }()
-	//}
-
 	if !cmd.opts.NonInteractive {
 		cli.AlphaWarn()
 	}

--- a/cmd/kyma/alpha/list/module/module.go
+++ b/cmd/kyma/alpha/list/module/module.go
@@ -3,7 +3,6 @@ package module
 import (
 	"bytes"
 	"context"
-	_ "embed"
 	"encoding/json"
 	"fmt"
 	"io"

--- a/cmd/kyma/alpha/list/module/module.go
+++ b/cmd/kyma/alpha/list/module/module.go
@@ -1,51 +1,26 @@
 package module
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"os"
-	"strings"
-	"text/tabwriter"
-	"text/template"
+	"io"
 	"time"
 
 	"github.com/kyma-project/cli/internal/cli"
-	"github.com/kyma-project/cli/internal/clusterinfo"
-	"github.com/kyma-project/cli/internal/kube"
+	"github.com/kyma-project/cli/internal/cli/alpha/module"
+	"github.com/kyma-project/lifecycle-manager/api/v1beta1"
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/discovery"
-	memory "k8s.io/client-go/discovery/cached"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/restmapper"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 )
-
-//go:embed list.tmpl
-var moduleTemplates string
-
-var moduleTemplateResource = schema.GroupVersionResource{
-	Group:    "operator.kyma-project.io",
-	Version:  "v1beta1",
-	Resource: "moduletemplates",
-}
-
-var kymaResource = schema.GroupVersionResource{
-	Group:    "operator.kyma-project.io",
-	Version:  "v1beta1",
-	Resource: "kymas",
-}
 
 type command struct {
 	cli.Command
 	opts *Options
-	meta.RESTMapper
 }
 
 // NewCmd creates a new Kyma CLI command
@@ -98,12 +73,8 @@ List all modules for the kyma "some-kyma" in the "alpha" channel
 		"Kyma resource to use.",
 	)
 	cmd.Flags().StringVarP(
-		&o.Namespace, "namespace", "n", cli.KymaNamespaceDefault,
-		"The Namespace to list the modules in.",
-	)
-	cmd.Flags().BoolVarP(
-		&o.AllNamespaces, "all-namespaces", "A", false,
-		"If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace",
+		&o.Namespace, "namespace", "n", metav1.NamespaceAll,
+		"The Namespace to list the modules in. By default uses all namespaces.",
 	)
 	cmd.Flags().BoolVar(
 		&o.NoHeaders, "no-headers", false,
@@ -111,14 +82,27 @@ List all modules for the kyma "some-kyma" in the "alpha" channel
 	)
 
 	cmd.Flags().StringVarP(
-		&o.Output, "output", "o", "go-template-file",
-		"Output format. One of: (json, yaml). By default uses an in-built template file. It is currently impossible to add your own template file.",
+		&o.Output, "output", "o", "tabwriter",
+		fmt.Sprintf("Output format. One of: %s. By default uses https://pkg.go.dev/text/tabwriter. It is currently impossible to add your own template file.", ValidOutputs),
 	)
 
 	return cmd
 }
 
 func (cmd *command) Run(ctx context.Context, args []string) error {
+	if cmd.opts.CI {
+		cmd.Factory.NonInteractive = true
+	}
+	if cmd.opts.Verbose {
+		cmd.Factory.UseLogger = true
+	}
+
+	//if !cmd.opts.Verbose {
+	//	stderr := os.Stderr
+	//	os.Stderr = nil
+	//	defer func() { os.Stderr = stderr }()
+	//}
+
 	if !cmd.opts.NonInteractive {
 		cli.AlphaWarn()
 	}
@@ -134,142 +118,96 @@ func (cmd *command) Run(ctx context.Context, args []string) error {
 }
 
 func (cmd *command) run(ctx context.Context) error {
-	start := time.Now()
-
-	if cmd.K8s == nil {
-		var err error
-		if cmd.K8s, err = kube.NewFromConfigWithTimeout("", cmd.KubeconfigPath, cmd.opts.Timeout); err != nil {
-			return fmt.Errorf("failed to initialize the Kubernetes client from given kubeconfig: %w", err)
-		}
-	}
-
-	if cmd.RESTMapper == nil {
-		disco, err := discovery.NewDiscoveryClientForConfig(cmd.K8s.RestConfig())
-		if err != nil {
-			cmd.RESTMapper = meta.NewDefaultRESTMapper(scheme.Scheme.PreferredVersionAllGroups())
-		} else {
-			cmd.RESTMapper = restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(disco))
-		}
-	}
-
-	if _, err := clusterinfo.Discover(ctx, cmd.K8s.Static()); err != nil {
+	clusterAccess := cmd.NewStep("Ensuring Cluster Access")
+	if _, err := cmd.EnsureClusterAccess(ctx, cmd.opts.Timeout); err != nil {
+		clusterAccess.Failuref("Could not ensure cluster Access")
 		return err
 	}
+	clusterAccess.Successf("Successfully connected to cluster")
+
+	writer := &bytes.Buffer{}
 
 	if cmd.opts.KymaName != "" {
-		kyma, err := cmd.K8s.Dynamic().Resource(kymaResource).Namespace(cmd.opts.Namespace).Get(
-			ctx, cmd.opts.KymaName, metav1.GetOptions{},
-		)
-		if err != nil {
+		cmd.NewStep("Listing Active Modules for Kyma Resource")
+		kyma := &v1beta1.Kyma{}
+
+		if err := cmd.K8s.Ctrl().Get(ctx, ctrl.ObjectKey{
+			Namespace: cmd.opts.Namespace,
+			Name:      cmd.opts.KymaName,
+		}, kyma); err != nil {
+			cmd.CurrentStep.Failure()
 			return fmt.Errorf("could not get kyma %s/%s: %w", cmd.opts.Namespace, cmd.opts.KymaName, err)
 		}
-		if err := cmd.printKymaActiveTemplates(ctx, kyma); err != nil {
+		if err := cmd.printKymaActiveTemplates(ctx, writer, kyma); err != nil {
+			cmd.CurrentStep.Failure()
 			return err
 		}
 	} else {
-		templates, err := cmd.K8s.Dynamic().Resource(moduleTemplateResource).Namespace(cmd.opts.Namespace).List(
-			ctx, metav1.ListOptions{},
-		)
-		if err != nil {
+		cmd.NewStep("Listing Available Modules in the Cluster")
+		templates := v1beta1.ModuleTemplateList{}
+		if err := cmd.K8s.Ctrl().List(ctx, &templates, &ctrl.ListOptions{Namespace: cmd.opts.Namespace}); err != nil {
+			cmd.CurrentStep.Failure()
 			return err
 		}
-		if err := cmd.printModuleTemplates(templates); err != nil {
+		if err := cmd.printModuleTemplates(writer, templates.Items, false); err != nil {
+			cmd.CurrentStep.Failure()
 			return err
 		}
 	}
+	cmd.CurrentStep.Success()
 
-	l := cli.NewLogger(cmd.opts.Verbose).Sugar()
-	l.Infof("listing module template(s) took %s", time.Since(start))
+	fmt.Print(writer.String())
 
 	return nil
 }
 
-func (cmd *command) printKymaActiveTemplates(ctx context.Context, kyma *unstructured.Unstructured) error {
-	statusItems, _, err := unstructured.NestedSlice(kyma.UnstructuredContent(), "status", "modules")
-	if err != nil {
-		return fmt.Errorf("could not parse moduleStatus: %w", err)
-	}
-	templateList := &unstructured.UnstructuredList{Items: make([]unstructured.Unstructured, 0, len(statusItems))}
-
-	for i := range statusItems {
-		item, _ := statusItems[i].(map[string]interface{})
-		tmplt, _, err := unstructured.NestedMap(item, "template")
-		if err != nil {
-			return fmt.Errorf("could not parse template: %w", err)
-		}
+func (cmd *command) printKymaActiveTemplates(ctx context.Context, writer io.Writer, kyma *v1beta1.Kyma) error {
+	templates := make([]v1beta1.ModuleTemplate, 0)
+	for _, status := range kyma.Status.Modules {
+		tmpltStatus := status.Template
 		obj := &metav1.PartialObjectMetadata{}
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(tmplt, obj); err != nil {
-			return fmt.Errorf("could not parse template info into obj %s: %w", obj, err)
-		}
-		mapping, err := cmd.RESTMapping(obj.GroupVersionKind().GroupKind(), obj.GroupVersionKind().Version)
-		var resource schema.GroupVersionResource
-		if err != nil {
-			resource, _ = meta.UnsafeGuessKindToResource(obj.GroupVersionKind())
-		} else {
-			resource = mapping.Resource
-		}
-		tpl, err := cmd.K8s.Dynamic().Resource(resource).Namespace(obj.GetNamespace()).Get(
-			ctx, obj.GetName(), metav1.GetOptions{},
-		)
-		if err != nil {
+		obj.SetGroupVersionKind(tmpltStatus.GroupVersionKind())
+		obj.SetName(tmpltStatus.GetName())
+		obj.SetNamespace(tmpltStatus.GetNamespace())
+		key := ctrl.ObjectKeyFromObject(obj)
+		tmplt := v1beta1.ModuleTemplate{}
+		if err := cmd.K8s.Ctrl().Get(ctx, key, &tmplt); err != nil {
 			return err
 		}
-		anns := tpl.GetAnnotations()
+		anns := tmplt.GetAnnotations()
 		if anns == nil {
 			anns = make(map[string]string)
 		}
-		anns["state.cmd.kyma-project.io"] = item["state"].(string)
-		tpl.SetAnnotations(anns)
-		templateList.Items = append(templateList.Items, *tpl)
-		if templateList.GetKind() == "" {
-			templateList.SetGroupVersionKind(moduleTemplateResource.GroupVersion().WithKind(tpl.GetKind() + "List"))
-		}
+		anns[module.TemplateStateAnnotation] = string(status.State)
+		tmplt.SetAnnotations(anns)
+		templates = append(templates, tmplt)
 	}
-	return cmd.printModuleTemplates(templateList)
+	return cmd.printModuleTemplates(writer, templates, true)
 }
 
-func (cmd *command) printModuleTemplates(templates *unstructured.UnstructuredList) error {
+func (cmd *command) printModuleTemplates(writer io.Writer, templates []v1beta1.ModuleTemplate, appendState bool) error {
+	var err error
+
 	switch cmd.opts.Output {
-	case "go-template-file":
-		return cmd.printModuleTemplatesTable(templates)
+	case "tabwriter":
+		err = module.NewDefaultTemplateTable(cmd.opts.NoHeaders, appendState).Print(writer, templates)
 	case "yaml":
-		data, err := yaml.Marshal(templates)
+		var data []byte
+		data, err = yaml.Marshal(&v1beta1.ModuleTemplateList{Items: templates})
 		if err != nil {
-			return err
+			break
 		}
-		_, err = fmt.Printf("%s\n", data)
-		return err
+		_, err = writer.Write(data)
+	case "json":
+		var data []byte
+		data, err = json.MarshalIndent(&v1beta1.ModuleTemplateList{Items: templates}, "", "  ")
+		if err != nil {
+			break
+		}
+		_, err = writer.Write(data)
 	default:
-		data, err := json.MarshalIndent(templates, "", "  ")
-		if err != nil {
-			return err
-		}
-		_, err = fmt.Printf("%s\n", data)
-		return err
+		return ErrNoValidOutput
 	}
-}
 
-func (cmd *command) printModuleTemplatesTable(templates *unstructured.UnstructuredList) error {
-	tmpl, err := template.New("module-template").Parse(moduleTemplates)
-	if err != nil {
-		return err
-	}
-	tabWriter := tabwriter.NewWriter(os.Stdout, 0, 8, 2, '\t', 0)
-	if !cmd.opts.NoHeaders {
-		headers := []string{
-			"operator.kyma-project.io/module-name",
-			"Domain Name (FQDN)",
-			"Channel",
-			"Version",
-			"Template",
-			"State",
-		}
-		if _, err := tabWriter.Write([]byte(strings.Join(headers, "\t") + "\n")); err != nil {
-			return err
-		}
-	}
-	if err := tmpl.Execute(tabWriter, templates); err != nil {
-		return fmt.Errorf("could not print table: %w", err)
-	}
-	return tabWriter.Flush()
+	return err
 }

--- a/cmd/kyma/alpha/list/module/opts.go
+++ b/cmd/kyma/alpha/list/module/opts.go
@@ -8,20 +8,18 @@ import (
 
 	"github.com/kyma-project/cli/internal/cli"
 	"github.com/pkg/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Options defines available options for the create module command
 type Options struct {
 	*cli.Options
 
-	KymaName      string
-	Channel       string
-	Timeout       time.Duration
-	Namespace     string
-	AllNamespaces bool
-	NoHeaders     bool
-	Output        string
+	KymaName  string
+	Channel   string
+	Timeout   time.Duration
+	Namespace string
+	NoHeaders bool
+	Output    string
 }
 
 const (
@@ -50,25 +48,28 @@ func (o *Options) validateFlags() error {
 		return err
 	}
 
-	if o.AllNamespaces {
-		o.Namespace = metav1.NamespaceAll
+	if o.KymaName != "" && o.Namespace == "" {
+		o.Namespace = cli.KymaNamespaceDefault
 	}
 
 	return nil
 }
 
+var ValidOutputs = []string{
+	"json",
+	"yaml",
+	"tabwriter",
+}
+
+var ErrNoValidOutput = fmt.Errorf("output must be one of: (%s)", strings.Join(ValidOutputs, ", "))
+
 func (o *Options) validateOutput() error {
-	valids := []string{
-		"json",
-		"yaml",
-		"go-template-file",
-	}
-	for _, valid := range valids {
+	for _, valid := range ValidOutputs {
 		if o.Output == valid {
 			return nil
 		}
 	}
-	return fmt.Errorf("output must be one of: (%s)", strings.Join(valids, ", "))
+	return ErrNoValidOutput
 }
 
 func (o *Options) validateTimeout() error {

--- a/docs/gen-docs/kyma_alpha_list_module.md
+++ b/docs/gen-docs/kyma_alpha_list_module.md
@@ -45,12 +45,11 @@ List all modules for the kyma "some-kyma" in the "alpha" channel
 ## Flags
 
 ```bash
-  -A, --all-namespaces     If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace
   -c, --channel string     Channel to use for the module template.
   -k, --kyma-name string   Kyma resource to use.
-  -n, --namespace string   The Namespace to list the modules in. (default "kyma-system")
+  -n, --namespace string   The Namespace to list the modules in. By default uses all namespaces.
       --no-headers         When using the default output format, don't print headers. (default print headers)
-  -o, --output string      Output format. One of: (json, yaml). By default uses an in-built template file. It is currently impossible to add your own template file. (default "go-template-file")
+  -o, --output string      Output format. One of: [json yaml tabwriter]. By default uses https://pkg.go.dev/text/tabwriter. It is currently impossible to add your own template file. (default "tabwriter")
   -t, --timeout duration   Maximum time for the list operation to retrieve ModuleTemplates. (default 1m0s)
 ```
 

--- a/internal/cli/alpha/module/tabwriter.go
+++ b/internal/cli/alpha/module/tabwriter.go
@@ -68,8 +68,7 @@ func NewDefaultTemplateTable(noHeaders, appendState bool) *DefaultTemplateTable 
 }
 
 type DefaultTemplateTable struct {
-	noHeaders   bool
-	appendState bool
+	noHeaders bool
 	templateTableEntries
 }
 
@@ -82,8 +81,8 @@ func (t *DefaultTemplateTable) Print(writer io.Writer, templates []v1beta1.Modul
 			return err
 		}
 	}
-	for _, tplt := range templates {
-		values, err := t.templateTableEntries.values(&tplt)
+	for i := range templates {
+		values, err := t.templateTableEntries.values(&templates[i])
 		if err != nil {
 			return err
 		}

--- a/internal/cli/alpha/module/tabwriter.go
+++ b/internal/cli/alpha/module/tabwriter.go
@@ -1,0 +1,118 @@
+package module
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/kyma-project/lifecycle-manager/api/v1beta1"
+)
+
+const (
+	TemplateStateAnnotation = "state.cmd.kyma-project.io"
+	TemplateModuleNameLabel = v1beta1.ModuleName
+)
+
+type TemplateTable interface {
+	Print(writer io.Writer, templates []v1beta1.ModuleTemplate) error
+}
+
+var _ TemplateTable = &DefaultTemplateTable{}
+
+func NewDefaultTemplateTable(noHeaders, appendState bool) *DefaultTemplateTable {
+	entries := templateTableEntries{
+		{
+			name: "Template",
+			valueFn: func(template *v1beta1.ModuleTemplate, descriptor *v1beta1.Descriptor) string {
+				return fmt.Sprintf("%s/%s", template.GetNamespace(), template.GetName())
+			},
+		},
+		{
+			name: TemplateModuleNameLabel,
+			valueFn: func(template *v1beta1.ModuleTemplate, descriptor *v1beta1.Descriptor) string {
+				return template.GetLabels()[TemplateModuleNameLabel]
+			},
+		},
+		{
+			name: "Domain Name (FQDN)",
+			valueFn: func(template *v1beta1.ModuleTemplate, descriptor *v1beta1.Descriptor) string {
+				return descriptor.GetName()
+			},
+		},
+		{
+			name: "Channel",
+			valueFn: func(template *v1beta1.ModuleTemplate, descriptor *v1beta1.Descriptor) string {
+				return template.Spec.Channel
+			},
+		},
+		{
+			name: "Version",
+			valueFn: func(template *v1beta1.ModuleTemplate, descriptor *v1beta1.Descriptor) string {
+				return descriptor.GetVersion()
+			},
+		},
+	}
+	if appendState {
+		entries = append(entries, templateTableEntry{
+			name: "State",
+			valueFn: func(template *v1beta1.ModuleTemplate, descriptor *v1beta1.Descriptor) string {
+				return template.GetAnnotations()[TemplateStateAnnotation]
+			},
+		})
+	}
+	return &DefaultTemplateTable{
+		noHeaders:            noHeaders,
+		templateTableEntries: entries,
+	}
+}
+
+type DefaultTemplateTable struct {
+	noHeaders   bool
+	appendState bool
+	templateTableEntries
+}
+
+func (t *DefaultTemplateTable) Print(writer io.Writer, templates []v1beta1.ModuleTemplate) error {
+	separator := '\t'
+	tabWriter := tabwriter.NewWriter(writer, 0, 8, 2, byte(separator), 0)
+	if !t.noHeaders {
+		header := strings.TrimSuffix(strings.Join(t.templateTableEntries.headerNames(), string(separator)), string(separator))
+		if _, err := tabWriter.Write([]byte(header + "\n")); err != nil {
+			return err
+		}
+	}
+	for _, tplt := range templates {
+		values, err := t.templateTableEntries.values(&tplt)
+		if err != nil {
+			return err
+		}
+		_, _ = tabWriter.Write([]byte(fmt.Sprintf(strings.TrimSuffix(strings.Repeat("%s"+string(separator), len(t.templateTableEntries)), string(separator))+"\n", values...)))
+	}
+	return tabWriter.Flush()
+}
+
+type templateTableEntries []templateTableEntry
+type templateTableEntry struct {
+	name    string
+	valueFn func(template *v1beta1.ModuleTemplate, descriptor *v1beta1.Descriptor) string
+}
+
+func (e templateTableEntries) headerNames() []string {
+	names := make([]string, 0, len(e))
+	for i := range e {
+		names = append(names, e[i].name)
+	}
+	return names
+}
+func (e templateTableEntries) values(template *v1beta1.ModuleTemplate) ([]any, error) {
+	descriptor, err := template.Spec.GetDescriptor()
+	if err != nil {
+		return nil, err
+	}
+	values := make([]any, 0, len(e))
+	for i := range e {
+		values = append(values, e[i].valueFn(template, descriptor))
+	}
+	return values, nil
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Refactors `kyma alpha list module` to also work with `kyma alpha get module`
- Refactors the tablewriter to be more generic and extracted into internal
- Uses typed v1beta1 instead of a golang text template to change the implementation more easily
- Add conditional so that empty state is not displayed when viewing module templates without a kyma as context providing a state
- Changes order of fields in default tabwriter output to order of fields in constructor of `TemplateTable`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
