### PR TITLE
fix: use insecure as hint on whether to append http:// or not

### DIFF
--- a/pkg/module/remote.go
+++ b/pkg/module/remote.go
@@ -48,10 +48,14 @@ func (r *Remote) GetRepository(ctx cpi.Context) (cpi.Repository, error) {
 	} else {
 		repoType = oci.Type
 	}
+	url := NoSchemeURL(r.Registry)
+	if r.Insecure {
+		url = fmt.Sprintf("http://%s", url)
+	}
 
 	ociRepoSpec := &oci.RepositorySpec{
 		ObjectVersionedType: runtime.NewVersionedObjectType(repoType),
-		BaseURL:             NoSchemeURL(r.Registry),
+		BaseURL:             url,
 	}
 	genericSpec := genericocireg.NewRepositorySpec(
 		ociRepoSpec, &ocireg.ComponentRepositoryMeta{


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Allows HTTP based schemed registries when using insecure flag, otherwise registry gets stripped


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
