### PR TITLE
internal/kube/client: Modify Watch Timeout Strategy

### DIFF
--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -406,13 +406,15 @@ func (c *client) DefaultNamespace() string {
 }
 
 // watch provides a unified implementation to watch resources.
-// timeout of zero does NOT mean "no timeout", i.e. "wait forever" - it means the function will time-out almost immediately - at the discretion of the golang scheduler.
+// timeout of zero means "no timeout", i.e. "wait forever"
 func watch(
 	ctx context.Context, res string, watchFn func(ctx context.Context) (bool, error), timeout time.Duration,
 ) error {
-
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
+	if timeout.Milliseconds() != 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
 
 	for {
 		finished, err := watchFn(ctx)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Change the meaning of timeout of 0 to no timeout,
i.e. waiting forever.
Closes #1492 
