### PR TITLE
provision/k3d: Add "k3d-registry-arg" Flag

### DIFF
--- a/cmd/kyma/provision/k3d/opts.go
+++ b/cmd/kyma/provision/k3d/opts.go
@@ -17,6 +17,7 @@ type Options struct {
 	UseRegistry       []string
 	RegistryPort      string
 	K3dArgs           []string
+	K3dRegistryArgs   []string
 	KubernetesVersion string
 	PortMapping       []string
 }

--- a/docs/gen-docs/kyma_provision_k3d.md
+++ b/docs/gen-docs/kyma_provision_k3d.md
@@ -15,15 +15,16 @@ kyma provision k3d [flags]
 ## Flags
 
 ```bash
-      --k3d-arg strings        One or more arguments passed to the k3d provisioning command (e.g. --k3d-arg='--no-rollback')
-  -s, --k3s-arg strings        One or more arguments passed from k3d to the k3s command (format: ARG@NODEFILTER[;@NODEFILTER])
-  -k, --kube-version string    Kubernetes version of the cluster (default "1.25.6")
-      --name string            Name of the Kyma cluster (default "kyma")
-  -p, --port strings           Map ports 80 and 443 of K3D loadbalancer (e.g. -p 80:80@loadbalancer -p 443:443@loadbalancer) (default [80:80@loadbalancer,443:443@loadbalancer])
-      --registry-port string   Specify the port on which the k3d registry will be exposed (default "5001")
-      --registry-use strings   Connect to one or more k3d-managed registries. Kyma automatically creates a registry for Serverless images.
-      --timeout duration       Maximum time for the provisioning. If you want no timeout, enter "0". (default 5m0s)
-      --workers int            Number of worker nodes (k3d agents) (default 1)
+      --k3d-arg strings            One or more arguments passed to the k3d provisioning command (e.g. --k3d-arg='--no-rollback')
+      --k3d-registry-arg strings   One or more arguments passed to the k3d registry create command (e.g. --k3d-registry-arg='--default-network podman')
+  -s, --k3s-arg strings            One or more arguments passed from k3d to the k3s command (format: ARG@NODEFILTER[;@NODEFILTER])
+  -k, --kube-version string        Kubernetes version of the cluster (default "1.25.6")
+      --name string                Name of the Kyma cluster (default "kyma")
+  -p, --port strings               Map ports 80 and 443 of K3D loadbalancer (e.g. -p 80:80@loadbalancer -p 443:443@loadbalancer) (default [80:80@loadbalancer,443:443@loadbalancer])
+      --registry-port string       Specify the port on which the k3d registry will be exposed (default "5001")
+      --registry-use strings       Connect to one or more k3d-managed registries. Kyma automatically creates a registry for Serverless images.
+      --timeout duration           Maximum time for the provisioning. If you want no timeout, enter "0". (default 5m0s)
+      --workers int                Number of worker nodes (k3d agents) (default 1)
 ```
 
 ## Flags inherited from parent commands

--- a/internal/k3d/k3d.go
+++ b/internal/k3d/k3d.go
@@ -28,7 +28,7 @@ type Client interface {
 	ClusterExists() (bool, error)
 	RegistryExists() (bool, error)
 	CreateCluster(settings CreateClusterSettings) error
-	CreateRegistry(registryPort string) (string, error)
+	CreateRegistry(registryPort string, args []string) (string, error)
 	DeleteCluster() error
 	DeleteRegistry() error
 }
@@ -227,10 +227,11 @@ func (c *client) CreateCluster(settings CreateClusterSettings) error {
 }
 
 // CreateRegistry creates a k3d registry with the default name
-func (c *client) CreateRegistry(registryPort string) (string, error) {
+func (c *client) CreateRegistry(registryPort string, args []string) (string, error) {
 	registryName := fmt.Sprintf(defaultRegistryNamePattern, c.clusterName)
 
-	out, err := c.runCmd("registry", "create", registryName, "--port", registryPort)
+	cmd := append([]string{"registry", "create", registryName, "--port", registryPort}, args...)
+	out, err := c.runCmd(cmd...)
 	if err != nil {
 		return "", err
 	}

--- a/internal/k3d/k3d_test.go
+++ b/internal/k3d/k3d_test.go
@@ -159,7 +159,7 @@ func (suite *K3dTestSuite) TestCreateRegistry() {
 	suite.mockCmdRunner.On("Run", mock.Anything, "k3d", "registry", "create", "kyma-registry",
 		"--port", "5001").Return("", nil)
 
-	registryName, err := suite.client.CreateRegistry("5001")
+	registryName, err := suite.client.CreateRegistry("5001", []string{})
 	suite.Nil(err)
 	suite.Equal("kyma-registry:5001", registryName)
 }


### PR DESCRIPTION
## Changes
The `--k3d-registry-arg` flag was added to the `kyma provision k3d` command. The arguments passed through this flag are passed on to the `k3d registry create` command and offer extra control over registry creation before cluster provisioning.

Closes #1475 