### PR TITLE
Replace key parsing logic with ocm signing

### DIFF
--- a/pkg/module/sign.go
+++ b/pkg/module/sign.go
@@ -131,11 +131,7 @@ func publicKey(pathToPublicKey string) (interface{}, error) {
 		return nil, fmt.Errorf("unable to open key file: %w", err)
 	}
 
-	block, _ := pem.Decode(publicKeyFile)
-	if block == nil {
-		return nil, fmt.Errorf("unable to decode pem formatted block in key: %w", err)
-	}
-	key, err := x509.ParsePKIXPublicKey(block.Bytes)
+	key, err := signing.ParsePublicKey(publicKeyFile)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse public key: %w", err)
 	}

--- a/pkg/module/sign.go
+++ b/pkg/module/sign.go
@@ -20,8 +20,8 @@ type ComponentSignConfig struct {
 }
 
 const (
-	SignatureName = "kyma-project.io/module-signature"
-	Issuer        = "kyma-project.io/cli"
+	SignatureName = "kyma-module-signature"
+	Issuer        = "kyma-cli"
 )
 
 func Sign(cfg *ComponentSignConfig, remote *Remote) error {

--- a/pkg/module/sign.go
+++ b/pkg/module/sign.go
@@ -1,8 +1,6 @@
 package module
 
 import (
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
 	"os"
 
@@ -109,16 +107,12 @@ func (cfg *ComponentSignConfig) validate() error {
 }
 
 func privateKey(pathToPrivateKey string) (interface{}, error) {
-	privKeyFile, err := os.ReadFile(pathToPrivateKey)
+	privateKeyFile, err := os.ReadFile(pathToPrivateKey)
 	if err != nil {
 		return nil, fmt.Errorf("unable to open key file: %w", err)
 	}
 
-	block, _ := pem.Decode(privKeyFile)
-	if block == nil {
-		return nil, fmt.Errorf("unable to decode pem formatted block in key: %w", err)
-	}
-	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	key, err := signing.ParsePrivateKey(privateKeyFile)
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse private key: %w", err)
 	}


### PR DESCRIPTION
This PR addresses an issue with the verification of RSA public keys generated by  [ocm](https://ocm.software/docs/cli/create/rsakeypair/). Currently, our `cli alpha verify` only supports `x509.ParsePKIXPublicKey`, which expects the public key to be in PKIX format. However, ocm also supports `x509.ParsePKCS1PublicKey` as a fallback, which expects the public key to be in PKCS1 format. This means that the keys generated by ocm using the command `ocm create rsakeypair` cannot be used for verification by our code. To fix this, I replace our custom code with the `signing.ParsePublicKey` function provided by ocm, which can handle both PKIX and PKCS1 formats. This way, we can ensure compatibility and interoperability with ocm.

In addition:

- replaced the private key parsing logic with `signing.ParsePrivateKey`.

- changed signature name and issuer, these two variable will be used as selector value, should not contains invalid symbol `/`. 