### PR TITLE
credential selector label should save to component descriptor before push to oci

### DIFF
--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -207,7 +207,7 @@ func (cmd *command) Run(ctx context.Context) error {
 
 	cmd.NewStep("Adding layers to archive...")
 
-	if err := module.AddResources(archive, modDef, l, osFS); err != nil {
+	if err := module.AddResources(archive, modDef, l, osFS, cmd.opts.RegistryCredSelector); err != nil {
 		cmd.CurrentStep.Failure()
 		return err
 	}
@@ -264,7 +264,7 @@ func (cmd *command) Run(ctx context.Context) error {
 		}
 
 		cmd.NewStep("Generating module template")
-		t, err := module.Template(componentVersionAccess, cmd.opts.Channel, cmd.opts.Target, modDef.DefaultCR, cmd.opts.RegistryCredSelector)
+		t, err := module.Template(componentVersionAccess, cmd.opts.Channel, cmd.opts.Target, modDef.DefaultCR)
 		if err != nil {
 			cmd.CurrentStep.Failure()
 			return err


### PR DESCRIPTION
At the moment, the credential selector is append to module template after component  descriptor get pushed. But this is not a solid implementation, because it brings inconsistent between module template descriptor and what saved in OCI registry. This PR fix this by add label before the resource layer get pushed.