### PR TITLE
kyma alpha create module using config file

### DIFF
--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -61,7 +61,7 @@ The module config file is a YAML file used to configure the following attributes
 - channel:      a string, required, channel that should be used in the ModuleTemplate CR
 - manifest:     a string, required, reference to the manifest, must be a relative file name
 - defaultCR:    a string, optional, reference to a YAML file containing the default CR for the module, must be a relative file name.
-- resourceName: a string, optional, default={NAME}-{CHANNEL}, the name for the ModuleTemplate that will be created
+- resourceName: a string, optional, default={NAME}-{CHANNEL}, the name for the ModuleTemplate CR that will be created
 - security:     a string, optional, name of the security scanners config file
 - internal:     a bool, optional, default=false, determines whether the ModuleTemplate should have the internal flag or not
 - beta:         a bool, optional, default=false, determines whether the ModuleTemplate should have the beta flag or not

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -42,7 +42,7 @@ func NewCmd(o *Options) *cobra.Command {
 ### Detailed description
 
 This command allows you to create a Kyma module as an OCI artifact and optionally push it to the OCI registry of your choice.
-For more information about what is a Kyma module see the [documentation](https://github.com/kyma-project/lifecycle-manager)
+For more information about a Kyma module see the [documentation](https://github.com/kyma-project/lifecycle-manager).
 
 This command creates a module from an existing directory containing module's source files.
 The directory MUST be a valid git project that is publicly available.

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -49,18 +49,18 @@ The directory must be a valid git project that is publicly available.
 The command supports two types of directory layouts for the module:
 - Simple: Just a directory with a valid git configuration. All the module's sources are defined in this directory.
 - Kubebuilder (DEPRECATED): A directory with a valid Kubebuilder project. Module operator(s) are created using the Kubebuilder toolset.
-Both simple and Kubebuilder projects require providing an explicit path to the module's project directory using the `--path` flag or invoking the command from within that directory.
+Both simple and Kubebuilder projects require providing an explicit path to the module's project directory using the "--path" flag or invoking the command from within that directory.
 
 ### Simple mode configuration
 
-To configure the simple mode, provide the `--module-config-file` flag with a config file path.
+To configure the simple mode, provide the "--module-config-file" flag with a config file path.
 The module config file is a YAML file used to configure the following attributes for the module:
 
 - name:         a string, required, the name of the module
 - version:      a string, required, the version of the module
 - channel:      a string, required, channel that should be used in the ModuleTemplate CR
 - manifest:     a string, required, reference to the manifest, must be a relative file name
-- defaultCR:    a string, optional, reference to a yaml file containing the default CR for the module, must be a relative file name
+- defaultCR:    a string, optional, reference to a YAML file containing the default CR for the module, must be a relative file name
 - resourceName: a string, optional, default={NAME}-{CHANNEL}, the name for the ModuleTemplate CR that will be created
 - security:     a string, optional, name of the security scanners config file
 - internal:     a boolean, optional, default=false, determines whether the ModuleTemplate CR should have the internal flag or not
@@ -68,16 +68,16 @@ The module config file is a YAML file used to configure the following attributes
 - labels:       a map with string keys and values, optional, additional labels for the generated ModuleTemplate CR
 - annotations:  a map with string keys and values, optional, additional annotations for the generated ModuleTemplate CR
 
-The**manifes** and **defaultCR** paths are resolved against the module's directory, as configured with the `--path` flag.
-The **manifest** file contains all the module's resources in a single, multi-document yaml file. These resources will be created in the Kyma cluster when the module is activated.
+The**manifes** and **defaultCR** paths are resolved against the module's directory, as configured with the "--path" flag.
+The **manifest** file contains all the module's resources in a single, multi-document YAML file. These resources will be created in the Kyma cluster when the module is activated.
 The **defaultCR** file contains a default custom resource for the module that will be installed along with the module.
 The Default CR is additionally schema-validated against the Custom Resource Definition. The CRD used for the validation must exist in the set of the module's resources.
 
 ### Kubebuilder mode configuration
 The Kubebuilder mode is DEPRECATED.
-The Kubebuilder mode is configured automatically if the `--module-config-file` flag is not provided.
+The Kubebuilder mode is configured automatically if the "--module-config-file" flag is not provided.
 
-In this mode, you have to explicitly provide the module name and version using the `--name` and `--version` flags, respectively.
+In this mode, you have to explicitly provide the module name and version using the "--name" and "--version" flags, respectively.
 Some defaults, like the module manifest file location and the default CR file location, are then resolved automatically, but you can override these with the available flags.
 
 ### Modules as OCI artifacts
@@ -85,12 +85,12 @@ Modules are built and distributed as OCI artifacts.
 This command creates a component descriptor in the configured descriptor path (./mod as a default) and packages all the contents on the provided path as an OCI artifact.
 The internal structure of the artifact conforms to the [Open Component Model](https://ocm.software/) scheme version 3.
 
-If you configured the `--registry` flag, the created module is validated and pushed to the configured registry.
+If you configured the "--registry" flag, the created module is validated and pushed to the configured registry.
 During the validation the **defaultCR** resource, if defined, is validated against a corresponding CustomResourceDefinition.
-You can also trigger an on-demand **defaultCR** validation with `--validateCR=true`, in case you don't push the module to the registry.
+You can also trigger an on-demand **defaultCR** validation with "--validateCR=true", in case you don't push the module to the registry.
 
 #### Name Mapping
-To push the artifact into some registries, for example, the central docker.io registry, you have to change the OCM Component Name Mapping with the following flag: `--name-mapping=sha256-digest`. This is necessary because the registry does not accept artifact URLs with more than two path segments, and such URLs are generated with the default name mapping: **urlPath**. In the case of the `sha256-digest` mapping, the artifact URL contains just a sha256 digest of the full Component Name and fits the path length restrictions. The downside of the `sha256-mapping` is that the module name is no longer visible in the artifact URL, as it contains the sha256 digest of the defined name.
+To push the artifact into some registries, for example, the central docker.io registry, you have to change the OCM Component Name Mapping with the following flag: "--name-mapping=sha256-digest". This is necessary because the registry does not accept artifact URLs with more than two path segments, and such URLs are generated with the default name mapping: **urlPath**. In the case of the "sha256-digest" mapping, the artifact URL contains just a sha256 digest of the full Component Name and fits the path length restrictions. The downside of the "sha256-mapping" is that the module name is no longer visible in the artifact URL, as it contains the sha256 digest of the defined name.
 
 `,
 

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -68,7 +68,7 @@ The module config file is a YAML file used to configure the following attributes
 - labels:       a map with string keys and values, optional, additional labels for the generated ModuleTemplate CR
 - annotations:  a map with string keys and values, optional, additional annotations for the generated ModuleTemplate CR
 
-The**manifes** and **defaultCR** paths are resolved against the module's directory, as configured with the "--path" flag.
+The **manifest** and **defaultCR** paths are resolved against the module's directory, as configured with the "--path" flag.
 The **manifest** file contains all the module's resources in a single, multi-document YAML file. These resources will be created in the Kyma cluster when the module is activated.
 The **defaultCR** file contains a default custom resource for the module that will be installed along with the module.
 The Default CR is additionally schema-validated against the Custom Resource Definition. The CRD used for the validation must exist in the set of the module's resources.

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -65,7 +65,7 @@ The module config file is a YAML file used to configure the following attributes
 - security:     a string, optional, name of the security scanners config file
 - internal:     a boolean, optional, default=false, determines whether the ModuleTemplate CR should have the internal flag or not
 - beta:         a boolean, optional, default=false, determines whether the ModuleTemplate CR should have the beta flag or not
-- labels:       a map with string keys and values, optional, additional labels for the generated ModuleTemplate
+- labels:       a map with string keys and values, optional, additional labels for the generated ModuleTemplate CR
 - annotations:  a map with string keys and values, optional, additional annotations for the generated ModuleTemplate
 
 The "manifest" and "defaultCR" paths are resolved against the module's directory, as configured with "--path" flag.

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -45,7 +45,7 @@ This command allows you to create a Kyma module as an OCI artifact and optionall
 For more information about a Kyma module see the [documentation](https://github.com/kyma-project/lifecycle-manager).
 
 This command creates a module from an existing directory containing the module's source files.
-The directory MUST be a valid git project that is publicly available.
+The directory must be a valid git project that is publicly available.
 The command supports two types of directory layouts for the module:
 - Simple: Just a directory with a valid git configuration. All the module's sources are defined in this directory.
 - Kubebuilder (DEPRECATED): A directory with a valid Kubebuilder project. Module operator(s) are created using the Kubebuilder toolset.

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -70,7 +70,7 @@ The module config file is a YAML file used to configure the following attributes
 
 The**manifes** and **defaultCR** paths are resolved against the module's directory, as configured with the `--path` flag.
 The "manifest" file contains all the module's resources in a single, multi-document YAML file. These resources will be created in the Kyma cluster when the module is activated.
-The "defaultCR" file contain a default Custom Resource for the module that will be installed along with the module.
+The **defaultCR** file contains a default custom resource for the module that will be installed along with the module.
 It is additionally schema-validated against the Custom Resource Definition for it's Group/Kind that must exists is the set of resources in the "manifest" file.
 
 ### Kubebuilder mode configuration

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -56,7 +56,7 @@ Both simple and Kubebuilder projects require providing an explicit path to the m
 To configure the simple mode, provide the `--module-config-file` flag with a config file path.
 The module config file is a YAML file used to configure the following attributes for the module:
 
-- name:         a string, required, the name of the Module
+- name:         a string, required, the name of the module
 - version:      a string, required, the version of the Module
 - channel:      a string, required, channel that should be used in the ModuleTemplate
 - manifest:     a string, required, reference to the manifests, must be a relative file name.

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -89,7 +89,7 @@ If you configured the `--registry` flag, the created module is validated and pus
 During the validation the **defaultCR** resource, if defined, is validated against a corresponding CustomResourceDefinition.
 You can also trigger an on-demand **defaultCR** validation with `--validateCR=true`, in case you don't push the module to the registry.
 
-#### Name Mapping Modes
+#### Name Mapping
 To push the artifact into some registries, for example, the central docker.io registry, you have to change the OCM Component Name Mapping with the following flag: `--name-mapping=sha256-digest`. This is necessary because the registry does not accept artifact URLs with more than two path segments, and such URLs are generated with the default name mapping: **urlPath**. In the case of the `sha256-digest` mapping, the artifact URL contains just a sha256 digest of the full Component Name and fits the path length restrictions. The downside of the `sha256-mapping` is that the module name is no longer visible in the artifact URL, as it contains the sha256 digest of the defined name.
 
 `,

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -48,7 +48,7 @@ This command creates a module from an existing directory containing the module's
 The directory MUST be a valid git project that is publicly available.
 The command supports two directory layouts for the module:
 - Simple: Just a directory with a valid git configuration. All the module's sources are defined in this directory.
-- Kubebuild projects (DEPRECATED): A directory with a valid Kubebuilder project. This is a convenience mode for the users who are creating the module operator(s) using the Kubebuilder toolset.
+- Kubebuilder (DEPRECATED): A directory with a valid Kubebuilder project. Module operator(s) are created using the Kubebuilder toolset.
 Both modes require providing an explicit path to the module's project directory using "--path" flag or invoking the command from within the that directory.
 
 ### Simple mode configuration

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -53,7 +53,7 @@ Both simple and Kubebuilder projects require providing an explicit path to the m
 
 ### Simple mode configuration
 
-You configure the simple mode by providing the "--module-config-file" flag with a config file path.
+To configure the simple mode, provide the `--module-config-file` flag with a config file path.
 The module config file is a YAML file used to configure the following attributes for the module:
 
 - name:         a string, required, the name of the Module

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -77,7 +77,7 @@ It is additionally schema-validated against the Custom Resource Definition for i
 The Kubebuilder mode is DEPRECATED.
 The Kubebuilder mode is configured automatically if the `--module-config-file` flag is not provided.
 
-In this mode you have to explicitly provide the module name and version using "--name" and "--version" flags, respectively.
+In this mode, you have to explicitly provide the module name and version using the `--name` and `--version` flags, respectively.
 Some defaults, like the module manifest file location and the default CR file location are then resolved automatically, but you can override these with available flags.
 
 ### Modules as OCI artifacts

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -446,9 +446,12 @@ func (cmd *command) moduleDefinitionFromOptions() (*module.Definition, *Config, 
 			return nil, nil, err
 		}
 
-		defaultCRPath, err := resolveFilePath(moduleConfig.DefaultCRPath, cmd.opts.Path)
-		if err != nil {
-			return nil, nil, fmt.Errorf("%w,  %w", ErrDefaultCRPathValidation, err)
+		var defaultCRPath string
+		if moduleConfig.DefaultCRPath != "" {
+			defaultCRPath, err = resolveFilePath(moduleConfig.DefaultCRPath, cmd.opts.Path)
+			if err != nil {
+				return nil, nil, fmt.Errorf("%w,  %w", ErrDefaultCRPathValidation, err)
+			}
 		}
 
 		moduleManifestPath, err := resolveFilePath(moduleConfig.ManifestPath, cmd.opts.Path)

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -68,7 +68,7 @@ The module config file is a YAML file used to configure the following attributes
 - labels:       a map with string keys and values, optional, additional labels for the generated ModuleTemplate CR
 - annotations:  a map with string keys and values, optional, additional annotations for the generated ModuleTemplate CR
 
-The "manifest" and "defaultCR" paths are resolved against the module's directory, as configured with "--path" flag.
+The**manifes** and **defaultCR** paths are resolved against the module's directory, as configured with the `--path` flag.
 The "manifest" file contains all the module's resources in a single, multi-document YAML file. These resources will be created in the Kyma cluster when the module is activated.
 The "defaultCR" file contain a default Custom Resource for the module that will be installed along with the module.
 It is additionally schema-validated against the Custom Resource Definition for it's Group/Kind that must exists is the set of resources in the "manifest" file.

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -85,7 +85,7 @@ Modules are built and distributed as OCI artifacts.
 This command creates a component descriptor in the configured descriptor path (./mod as a default) and packages all the contents on the provided path as an OCI artifact.
 The internal structure of the artifact conforms to the [Open Component Model](https://ocm.software/) scheme version 3.
 
-If you configured the "--registry" flag, the created module is validated and pushed to the configured registry.
+If you configured the `--registry` flag, the created module is validated and pushed to the configured registry.
 During the validation the default CR resource, if defined, is validated against a corresponding CustomResourceDefinition.
 You can also trigger an on-demand default CR validation with "--validateCR=true", in case you don't push to the registry.
 

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -49,7 +49,7 @@ The directory MUST be a valid git project that is publicly available.
 The command supports two directory layouts for the module:
 - Simple: Just a directory with a valid git configuration. All the module's sources are defined in this directory.
 - Kubebuilder (DEPRECATED): A directory with a valid Kubebuilder project. Module operator(s) are created using the Kubebuilder toolset.
-Both modes require providing an explicit path to the module's project directory using "--path" flag or invoking the command from within the that directory.
+Both simple and Kubebuilder projects require providing an explicit path to the module's project directory using the `--path` flag or invoking the command from within that directory.
 
 ### Simple mode configuration
 

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -64,7 +64,7 @@ The module config file is a YAML file used to configure the following attributes
 - resourceName: a string, optional, default={NAME}-{CHANNEL}, the name for the ModuleTemplate CR that will be created
 - security:     a string, optional, name of the security scanners config file
 - internal:     a boolean, optional, default=false, determines whether the ModuleTemplate CR should have the internal flag or not
-- beta:         a bool, optional, default=false, determines whether the ModuleTemplate should have the beta flag or not
+- beta:         a boolean, optional, default=false, determines whether the ModuleTemplate CR should have the beta flag or not
 - labels:       a map with string keys and values, optional, additional labels for the generated ModuleTemplate
 - annotations:  a map with string keys and values, optional, additional annotations for the generated ModuleTemplate
 

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -66,7 +66,7 @@ The module config file is a YAML file used to configure the following attributes
 - internal:     a boolean, optional, default=false, determines whether the ModuleTemplate CR should have the internal flag or not
 - beta:         a boolean, optional, default=false, determines whether the ModuleTemplate CR should have the beta flag or not
 - labels:       a map with string keys and values, optional, additional labels for the generated ModuleTemplate CR
-- annotations:  a map with string keys and values, optional, additional annotations for the generated ModuleTemplate
+- annotations:  a map with string keys and values, optional, additional annotations for the generated ModuleTemplate CR
 
 The "manifest" and "defaultCR" paths are resolved against the module's directory, as configured with "--path" flag.
 The "manifest" file contains all the module's resources in a single, multi-document YAML file. These resources will be created in the Kyma cluster when the module is activated.

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -63,7 +63,7 @@ The module config file is a YAML file used to configure the following attributes
 - defaultCR:    a string, optional, reference to a YAML file containing the default CR for the module, must be a relative file name.
 - resourceName: a string, optional, default={NAME}-{CHANNEL}, the name for the ModuleTemplate CR that will be created
 - security:     a string, optional, name of the security scanners config file
-- internal:     a bool, optional, default=false, determines whether the ModuleTemplate should have the internal flag or not
+- internal:     a boolean, optional, default=false, determines whether the ModuleTemplate CR should have the internal flag or not
 - beta:         a bool, optional, default=false, determines whether the ModuleTemplate should have the beta flag or not
 - labels:       a map with string keys and values, optional, additional labels for the generated ModuleTemplate
 - annotations:  a map with string keys and values, optional, additional annotations for the generated ModuleTemplate

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -351,7 +351,12 @@ func (cmd *command) Run(ctx context.Context) error {
 			}
 		}
 
-		t, err := module.Template(componentVersionAccess, resourceName, cmd.opts.Channel, modDef.DefaultCR, labels, annotations)
+		var channel = cmd.opts.Channel
+		if modCnf != nil {
+			channel = modCnf.Channel
+		}
+
+		t, err := module.Template(componentVersionAccess, resourceName, channel, modDef.DefaultCR, labels, annotations)
 		if err != nil {
 			cmd.CurrentStep.Failure()
 			return err

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -46,7 +46,7 @@ For more information about a Kyma module see the [documentation](https://github.
 
 This command creates a module from an existing directory containing the module's source files.
 The directory MUST be a valid git project that is publicly available.
-The command supports two directory layouts for the module:
+The command supports two types of directory layouts for the module:
 - Simple: Just a directory with a valid git configuration. All the module's sources are defined in this directory.
 - Kubebuilder (DEPRECATED): A directory with a valid Kubebuilder project. Module operator(s) are created using the Kubebuilder toolset.
 Both simple and Kubebuilder projects require providing an explicit path to the module's project directory using the `--path` flag or invoking the command from within that directory.

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -17,6 +17,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/kyma-project/cli/internal/cli"
+	"github.com/kyma-project/cli/internal/nice"
 	"github.com/kyma-project/cli/pkg/module"
 )
 
@@ -50,7 +51,7 @@ This command creates a module from an existing directory containing module's sou
 The directory MUST be a valid git project that is publicly available.
 The command supports two directory layouts for the module:
 - Simple: Just a directory with a valid git configuration. All the module's sources are defined in this directory.
-- Kubebuild projects: A directory with a valid Kubebuilder project. This is a convenience mode for the users who are creating the module operator(s) using the Kubebuilder toolset.
+- Kubebuild projects (DEPRECATED): A directory with a valid Kubebuilder project. This is a convenience mode for the users who are creating the module operator(s) using the Kubebuilder toolset.
 Both modes require providing an explicit path to the module's project directory using "--path" flag or invoking the command from within the that directory.
 
 ### Simple mode configuration
@@ -58,17 +59,17 @@ Both modes require providing an explicit path to the module's project directory 
 You configure the simple mode by providing the "--module-config-file" flag with a config file path.
 The module config file is a YAML file used to configure the following attributes for the module:
 
-- name          //string, required, the name of the Module
-- version       //string, required, the version of the Module
-- channel       //string, required, channel that should be used in the ModuleTemplate
-- manifest      //string, required, reference to the manifests, must be a relative file name.
-- defaultCR     //string, optional, reference to a YAML file containing the default CR for the module, must be a relative file name.
-- resourceName  //string, optional, default={NAME}-{CHANNEL}, the name for the ModuleTemplate that will be created
-- security      //string, optional, name of the security scanners config file
-- internal      //bool, optional, default=false, determines whether the ModuleTemplate should have the internal flag or not
-- beta          //bool, optional, default=false, determines whether the ModuleTemplate should have the beta flag or not
-- labels        //a map with string keys and values, optional, additional labels for the generated ModuleTemplate
-- annotations   //a map with string keys and values, optional, additional annotations for the generated ModuleTemplate
+- name:         a string, required, the name of the Module
+- version:      a string, required, the version of the Module
+- channel:      a string, required, channel that should be used in the ModuleTemplate
+- manifest:     a string, required, reference to the manifests, must be a relative file name.
+- defaultCR:    a string, optional, reference to a YAML file containing the default CR for the module, must be a relative file name.
+- resourceName: a string, optional, default={NAME}-{CHANNEL}, the name for the ModuleTemplate that will be created
+- security:     a string, optional, name of the security scanners config file
+- internal:     a bool, optional, default=false, determines whether the ModuleTemplate should have the internal flag or not
+- beta:         a bool, optional, default=false, determines whether the ModuleTemplate should have the beta flag or not
+- labels:       a map with string keys and values, optional, additional labels for the generated ModuleTemplate
+- annotations:  a map with string keys and values, optional, additional annotations for the generated ModuleTemplate
 
 The "manifest" and "defaultCR" paths are resolved against the module's directory, as configured with "--path" flag.
 The "manifest" file contains all the module's resources in a single, multi-document YAML file. These resources will be created in the Kyma cluster when the module is activated.
@@ -76,6 +77,7 @@ The "defaultCR" file contain a default Custom Resource for the module that will 
 It is additionally schema-validated against the Custom Resource Definition for it's Group/Kind that must exists is the set of resources in the "manifest" file.
 
 ### Kubebuilder mode configuration
+The Kubebuilder mode is DEPRECATED.
 The Kubebuilder mode is configured automatically if the "--module-config-file" flag is not provided.
 
 In this mode you have to explicitly provide the module name and version using "--name" and "--version" flags, respectively.
@@ -444,6 +446,9 @@ func (cmd *command) moduleDefinitionFromOptions() (*module.Definition, error) {
 			SchemaVersion:      cmd.opts.SchemaVersion,
 		}
 	} else {
+		np := nice.Nice{}
+		np.PrintImportant("WARNING: The Kubebuilder support in this command is DEPRECATED. Use the simple mode by providing the \"--module-config-file\" flag instead.")
+
 		//legacy approach, flag-based
 		res = &module.Definition{
 			Name:            cmd.opts.Name,

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -71,7 +71,7 @@ The module config file is a YAML file used to configure the following attributes
 The**manifes** and **defaultCR** paths are resolved against the module's directory, as configured with the `--path` flag.
 The **manifest** file contains all the module's resources in a single, multi-document yaml file. These resources will be created in the Kyma cluster when the module is activated.
 The **defaultCR** file contains a default custom resource for the module that will be installed along with the module.
-It is additionally schema-validated against the Custom Resource Definition for it's Group/Kind that must exists is the set of resources in the "manifest" file.
+The Default CR is additionally schema-validated against the Custom Resource Definition. The CRD used for the validation must exist in the set of the module's resources.
 
 ### Kubebuilder mode configuration
 The Kubebuilder mode is DEPRECATED.

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -60,7 +60,7 @@ The module config file is a YAML file used to configure the following attributes
 - version:      a string, required, the version of the module
 - channel:      a string, required, channel that should be used in the ModuleTemplate CR
 - manifest:     a string, required, reference to the manifest, must be a relative file name
-- defaultCR:    a string, optional, reference to a YAML file containing the default CR for the module, must be a relative file name.
+- defaultCR:    a string, optional, reference to a yaml file containing the default CR for the module, must be a relative file name
 - resourceName: a string, optional, default={NAME}-{CHANNEL}, the name for the ModuleTemplate CR that will be created
 - security:     a string, optional, name of the security scanners config file
 - internal:     a boolean, optional, default=false, determines whether the ModuleTemplate CR should have the internal flag or not

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -59,7 +59,7 @@ The module config file is a YAML file used to configure the following attributes
 - name:         a string, required, the name of the module
 - version:      a string, required, the version of the module
 - channel:      a string, required, channel that should be used in the ModuleTemplate CR
-- manifest:     a string, required, reference to the manifests, must be a relative file name.
+- manifest:     a string, required, reference to the manifest, must be a relative file name
 - defaultCR:    a string, optional, reference to a YAML file containing the default CR for the module, must be a relative file name.
 - resourceName: a string, optional, default={NAME}-{CHANNEL}, the name for the ModuleTemplate that will be created
 - security:     a string, optional, name of the security scanners config file

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -69,7 +69,7 @@ The module config file is a YAML file used to configure the following attributes
 - annotations:  a map with string keys and values, optional, additional annotations for the generated ModuleTemplate CR
 
 The**manifes** and **defaultCR** paths are resolved against the module's directory, as configured with the `--path` flag.
-The "manifest" file contains all the module's resources in a single, multi-document YAML file. These resources will be created in the Kyma cluster when the module is activated.
+The **manifest** file contains all the module's resources in a single, multi-document yaml file. These resources will be created in the Kyma cluster when the module is activated.
 The **defaultCR** file contains a default custom resource for the module that will be installed along with the module.
 It is additionally schema-validated against the Custom Resource Definition for it's Group/Kind that must exists is the set of resources in the "manifest" file.
 

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -58,7 +58,7 @@ The module config file is a YAML file used to configure the following attributes
 
 - name:         a string, required, the name of the module
 - version:      a string, required, the version of the module
-- channel:      a string, required, channel that should be used in the ModuleTemplate
+- channel:      a string, required, channel that should be used in the ModuleTemplate CR
 - manifest:     a string, required, reference to the manifests, must be a relative file name.
 - defaultCR:    a string, optional, reference to a YAML file containing the default CR for the module, must be a relative file name.
 - resourceName: a string, optional, default={NAME}-{CHANNEL}, the name for the ModuleTemplate that will be created

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -86,7 +86,7 @@ This command creates a component descriptor in the configured descriptor path (.
 The internal structure of the artifact conforms to the [Open Component Model](https://ocm.software/) scheme version 3.
 
 If you configured the `--registry` flag, the created module is validated and pushed to the configured registry.
-During the validation the default CR resource, if defined, is validated against a corresponding CustomResourceDefinition.
+During the validation the **defaultCR** resource, if defined, is validated against a corresponding CustomResourceDefinition.
 You can also trigger an on-demand default CR validation with "--validateCR=true", in case you don't push to the registry.
 
 #### Name Mapping Modes

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -44,7 +44,7 @@ func NewCmd(o *Options) *cobra.Command {
 This command allows you to create a Kyma module as an OCI artifact and optionally push it to the OCI registry of your choice.
 For more information about a Kyma module see the [documentation](https://github.com/kyma-project/lifecycle-manager).
 
-This command creates a module from an existing directory containing module's source files.
+This command creates a module from an existing directory containing the module's source files.
 The directory MUST be a valid git project that is publicly available.
 The command supports two directory layouts for the module:
 - Simple: Just a directory with a valid git configuration. All the module's sources are defined in this directory.

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -75,7 +75,7 @@ It is additionally schema-validated against the Custom Resource Definition for i
 
 ### Kubebuilder mode configuration
 The Kubebuilder mode is DEPRECATED.
-The Kubebuilder mode is configured automatically if the "--module-config-file" flag is not provided.
+The Kubebuilder mode is configured automatically if the `--module-config-file` flag is not provided.
 
 In this mode you have to explicitly provide the module name and version using "--name" and "--version" flags, respectively.
 Some defaults, like the module manifest file location and the default CR file location are then resolved automatically, but you can override these with available flags.

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -41,7 +41,7 @@ func NewCmd(o *Options) *cobra.Command {
 
 ### Detailed description
 
-This command lets you to create a Kyma module as an OCI artifact and optionally push it to the OCI registry of you choice.
+This command allows you to create a Kyma module as an OCI artifact and optionally push it to the OCI registry of your choice.
 For more information about what is a Kyma module see the [documentation](https://github.com/kyma-project/lifecycle-manager)
 
 This command creates a module from an existing directory containing module's source files.

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -383,6 +383,7 @@ func (cmd *command) validateDefaultCR(ctx context.Context, modDef *module.Defini
 	} else {
 		crValidator, err = module.NewDefaultCRValidator(modDef.DefaultCR, modDef.Source)
 	}
+
 	if err != nil {
 		cmd.CurrentStep.Failure()
 		return err

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -87,7 +87,7 @@ The internal structure of the artifact conforms to the [Open Component Model](ht
 
 If you configured the `--registry` flag, the created module is validated and pushed to the configured registry.
 During the validation the **defaultCR** resource, if defined, is validated against a corresponding CustomResourceDefinition.
-You can also trigger an on-demand default CR validation with "--validateCR=true", in case you don't push to the registry.
+You can also trigger an on-demand **defaultCR** validation with `--validateCR=true`, in case you don't push the module to the registry.
 
 #### Name Mapping Modes
 To push the artifact into some registries, for example, the central docker.io registry, you have to change the OCM Component Name Mapping with the following flag: "--name-mapping=sha256-digest". This is necessary because the registry does not accept artifact URLs with more than two path segments, and such URLs are generated with the default name mapping: "urlPath". In the case of the "sha256-digest" mapping, the artifact URL contains just a sha256 digest of the full Component Name and fits the path length restrictions. The downside of the "sha256-mapping" is that the module name is no longer visible in the artifact URL, as it contains the sha256 digest of the defined name.

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -37,35 +37,72 @@ func NewCmd(o *Options) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "module [--module-config-file MODULE_CONFIG_FILE | --name MODULE_NAME --version MODULE_VERSION] [--registry MODULE_REGISTRY] [flags]",
+		Use:   "module [--module-config-file MODULE_CONFIG_FILE | --name MODULE_NAME --version MODULE_VERSION] [--path MODULE_DIRECTORY] [--registry MODULE_REGISTRY] [flags]",
 		Short: "Creates a module bundled as an OCI artifact",
 		Long: `Use this command to create a Kyma module, bundle it as an OCI artifact and optionally push it to the OCI registry.
 
 ### Detailed description
 
-Kyma modules are individual components that can be deployed into a Kyma runtime. Modules are built and distributed as OCI container images. 
-With this command, you can create such images out of a folder's contents.
+This command lets you to create a Kyma module as an OCI artifact and optionally push it to the OCI registry of you choice.
+For more information about what is a Kyma module see the [documentation](https://github.com/kyma-project/lifecycle-manager)
 
+This command creates a module from an existing directory containing module's source files.
+The directory MUST be a valid git project that is publicly available.
+The command supports two directory layouts for the module:
+- Simple: Just a directory with a valid git configuration. All the module's sources are defined in this directory.
+- Kubebuild projects: A directory with a valid Kubebuilder project. This is a convenience mode for the users who are creating the module operator(s) using the Kubebuilder toolset.
+Both modes require providing an explicit path to the module's project directory using "--path" flag or invoking the command from within the that directory.
 
-This command creates a component descriptor in the descriptor path (./mod as a default) and packages all the contents on the provided path as an OCI image.
-Kubebuilder projects are supported. If the path contains a kubebuilder project, it will be built and pre-defined layers will be created based on its known contents.
+### Simple mode configuration
 
-Alternatively, a custom (non kubebuilder) module can be created by providing a path that does not contain a kubebuilder project. In that case all the contents of the path will be bundled as a single layer.
+You configure the simple mode by providing the "--module-config-file" flag with a config file path.
+The module config file is a YAML file used to configure the following attributes for the module:
 
-Optionally, you can manually add additional layers with contents in other paths (see [resource flag](#flags) for more information).
+- name          //string, required, the name of the Module
+- version       //string, required, the version of the Module
+- channel       //string, required, channel that should be used in the ModuleTemplate
+- manifest      //string, required, reference to the manifests, must be a relative file name.
+- defaultCR     //string, optional, reference to a YAML file containing the default CR for the module, must be a relative file name.
+- resourceName  //string, optional, default={NAME}-{CHANNEL}, the name for the ModuleTemplate that will be created
+- security      //string, optional, name of the security scanners config file
+- internal      //bool, optional, default=false, determines whether the ModuleTemplate should have the internal flag or not
+- beta          //bool, optional, default=false, determines whether the ModuleTemplate should have the beta flag or not
+- labels        //a map with string keys and values, optional, additional labels for the generated ModuleTemplate
+- annotations   //a map with string keys and values, optional, additional annotations for the generated ModuleTemplate
 
-Finally, if you provided a registry to which to push the artifact, the created module is validated and pushed. During the validation the default CR defined in the optional "default.yaml" file is validated against CustomResourceDefinition.
-Alternatively, you can trigger an on-demand default CR validation with "--validateCR=true", in case you don't push to the registry.
+The "manifest" and "defaultCR" paths are resolved against the module's directory, as configured with "--path" flag.
+The "manifest" file contains all the module's resources in a single, multi-document YAML file. These resources will be created in the Kyma cluster when the module is activated.
+The "defaultCR" file contain a default Custom Resource for the module that will be installed along with the module.
+It is additionally schema-validated against the Custom Resource Definition for it's Group/Kind that must exists is the set of resources in the "manifest" file.
 
-To push the artifact into some registries, for example, the central docker.io registry, you have to change the OCM Component Name Mapping with the following flag: "--name-mapping=sha256-digest". This is necessary because the registry does not accept artifact URLs with more than two path segments, and such URLs are generated with the default name mapping: "urlPath". In the case of the "sha256-digest" mapping, the artifact URL contains just a sha256 digest of the full Component Name and fits the path length restrictions.
+### Kubebuilder mode configuration
+The Kubebuilder mode is configured automatically if the "--module-config-file" flag is not provided.
+
+In this mode you have to explicitly provide the module name and version using "--name" and "--version" flags, respectively.
+Some defaults, like the module manifest file location and the default CR file location are then resolved automatically, but you can override these with available flags.
+
+### Modules as OCI artifacts
+Modules are built and distributed as OCI artifacts. 
+This command creates a component descriptor in the configured descriptor path (./mod as a default) and packages all the contents on the provided path as an OCI artifact.
+The internal structure of the artifact conforms to the [Open Component Model](https://ocm.software/) scheme version 3.
+
+If you configured the "--registry" flag, the created module is validated and pushed to the configured registry.
+During the validation the default CR resource, if defined, is validated against a corresponding CustomResourceDefinition.
+You can also trigger an on-demand default CR validation with "--validateCR=true", in case you don't push to the registry.
+
+#### Name Mapping Modes
+To push the artifact into some registries, for example, the central docker.io registry, you have to change the OCM Component Name Mapping with the following flag: "--name-mapping=sha256-digest". This is necessary because the registry does not accept artifact URLs with more than two path segments, and such URLs are generated with the default name mapping: "urlPath". In the case of the "sha256-digest" mapping, the artifact URL contains just a sha256 digest of the full Component Name and fits the path length restrictions. The downside of the "sha256-mapping" is that the module name is no longer visible in the artifact URL, as it contains the sha256 digest of the defined name.
 
 `,
 
 		Example: `Examples:
-Build module my-domain/modA in version 1.2.3 and push it to a remote registry
-		kyma alpha create module -n my-domain/modA --version 1.2.3 -p /path/to/module --registry https://dockerhub.com
-Build module my-domain/modB in version 3.2.1 and push it to a local registry "unsigned" subfolder without tls
-		kyma alpha create module -n my-domain/modB --version 3.2.1 -p /path/to/module --registry http://localhost:5001/unsigned --insecure
+Build a simple module and push it to a remote registry
+		kyma alpha create module --module-config-file=/path/to/module-config-file -path /path/to/module --registry http://localhost:5001/unsigned --insecure
+Build a Kubebuilder module my-domain/modB in version 1.2.3 and push it to a remote registry
+		kyma alpha create module --name my-domain/modB --version 1.2.3 --path /path/to/module --registry https://dockerhub.com
+Build a Kubebuilder module my-domain/modC in version 3.2.1 and push it to a local registry "unsigned" subfolder without tls
+		kyma alpha create module --name my-domain/modC --version 3.2.1 --path /path/to/module --registry http://localhost:5001/unsigned --insecure
+
 `,
 		RunE:    func(cobraCmd *cobra.Command, args []string) error { return c.Run(cobraCmd.Context()) },
 		Aliases: []string{"mod"},

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -78,7 +78,7 @@ The Kubebuilder mode is DEPRECATED.
 The Kubebuilder mode is configured automatically if the `--module-config-file` flag is not provided.
 
 In this mode, you have to explicitly provide the module name and version using the `--name` and `--version` flags, respectively.
-Some defaults, like the module manifest file location and the default CR file location are then resolved automatically, but you can override these with available flags.
+Some defaults, like the module manifest file location and the default CR file location, are then resolved automatically, but you can override these with the available flags.
 
 ### Modules as OCI artifacts
 Modules are built and distributed as OCI artifacts. 

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -90,7 +90,7 @@ During the validation the **defaultCR** resource, if defined, is validated again
 You can also trigger an on-demand **defaultCR** validation with `--validateCR=true`, in case you don't push the module to the registry.
 
 #### Name Mapping Modes
-To push the artifact into some registries, for example, the central docker.io registry, you have to change the OCM Component Name Mapping with the following flag: "--name-mapping=sha256-digest". This is necessary because the registry does not accept artifact URLs with more than two path segments, and such URLs are generated with the default name mapping: "urlPath". In the case of the "sha256-digest" mapping, the artifact URL contains just a sha256 digest of the full Component Name and fits the path length restrictions. The downside of the "sha256-mapping" is that the module name is no longer visible in the artifact URL, as it contains the sha256 digest of the defined name.
+To push the artifact into some registries, for example, the central docker.io registry, you have to change the OCM Component Name Mapping with the following flag: `--name-mapping=sha256-digest`. This is necessary because the registry does not accept artifact URLs with more than two path segments, and such URLs are generated with the default name mapping: **urlPath**. In the case of the `sha256-digest` mapping, the artifact URL contains just a sha256 digest of the full Component Name and fits the path length restrictions. The downside of the `sha256-mapping` is that the module name is no longer visible in the artifact URL, as it contains the sha256 digest of the defined name.
 
 `,
 

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -57,7 +57,7 @@ To configure the simple mode, provide the `--module-config-file` flag with a con
 The module config file is a YAML file used to configure the following attributes for the module:
 
 - name:         a string, required, the name of the module
-- version:      a string, required, the version of the Module
+- version:      a string, required, the version of the module
 - channel:      a string, required, channel that should be used in the ModuleTemplate
 - manifest:     a string, required, reference to the manifests, must be a relative file name.
 - defaultCR:    a string, optional, reference to a YAML file containing the default CR for the module, must be a relative file name.

--- a/cmd/kyma/alpha/create/module/moduleconfig.go
+++ b/cmd/kyma/alpha/create/module/moduleconfig.go
@@ -14,14 +14,14 @@ type Config struct {
 	Name          string            `yaml:"name"`         //required, the name of the Module
 	Version       string            `yaml:"version"`      //required, the version of the Module
 	Channel       string            `yaml:"channel"`      //required, channel that should be used in the ModuleTemplate
-	ResourceName  string            `yaml:"resourceName"` //optional, default={NAME}-{CHANNEL}, the name for the ModuleTemplate that will be created
 	ManifestPath  string            `yaml:"manifest"`     //required, reference to the manifests, must be a relative file name.
 	DefaultCRPath string            `yaml:"defaultCR"`    //optional, reference to a YAML file containing the default CR for the module, must be a relative file name.
-	Security      string            `yaml:"security"`     //# optional, name of the security scanners config file
-	Internal      bool              `yaml:"internal"`     //# optional, default=false, determines whether the ModuleTemplate should have the internal flag or not
-	Beta          bool              `yaml:"beta"`         //# optional, default=false, determines whether the ModuleTemplate should have the beta flag or not
-	Labels        map[string]string `yaml:"labels"`       //# optional, additional labels for the ModuleTemplate
-	Annotations   map[string]string `yaml:"annotations"`  //# optional, additional annotations for the ModuleTemplate (operator.kyma-project.io/doc-url={DOCUMENTATION_URL} # required, the link to the Module documentation)
+	ResourceName  string            `yaml:"resourceName"` //optional, default={NAME}-{CHANNEL}, the name for the ModuleTemplate that will be created
+	Security      string            `yaml:"security"`     //optional, name of the security scanners config file
+	Internal      bool              `yaml:"internal"`     //optional, default=false, determines whether the ModuleTemplate should have the internal flag or not
+	Beta          bool              `yaml:"beta"`         //optional, default=false, determines whether the ModuleTemplate should have the beta flag or not
+	Labels        map[string]string `yaml:"labels"`       //optional, additional labels for the ModuleTemplate
+	Annotations   map[string]string `yaml:"annotations"`  //optional, additional annotations for the ModuleTemplate
 }
 
 const (

--- a/cmd/kyma/alpha/create/module/moduleconfig.go
+++ b/cmd/kyma/alpha/create/module/moduleconfig.go
@@ -83,7 +83,7 @@ func (cv *configValidator) validateName() *configValidator {
 		}
 		matched, _ := regexp.MatchString(moduleNamePattern, cv.config.Name)
 		if !matched {
-			return fmt.Errorf("%w for input %q, name does not match %s pattern", ErrNameValidation, cv.config.Name, moduleNamePattern)
+			return fmt.Errorf("%w for input %q, name must match the required pattern, e.g: 'github.com/path-to/your-repo'", ErrNameValidation, cv.config.Name)
 		}
 
 		return nil

--- a/cmd/kyma/alpha/create/module/moduleconfig.go
+++ b/cmd/kyma/alpha/create/module/moduleconfig.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type ModuleConfig struct {
+type Config struct {
 	Name          string            `yaml:"name"`         //required, the name of the Module
 	Version       string            `yaml:"version"`      //required, the version of the Module
 	Channel       string            `yaml:"channel"`      //required, channel that should be used in the ModuleTemplate
@@ -30,14 +30,14 @@ const (
 	moduleNameMaxLen  = 255
 )
 
-func ParseConfig(filePath string) (*ModuleConfig, error) {
+func ParseConfig(filePath string) (*Config, error) {
 	data, err := os.ReadFile(filePath)
 
 	if err != nil {
 		return nil, fmt.Errorf("error reading module config file %q: %w", filePath, err)
 	}
 
-	res := ModuleConfig{}
+	res := Config{}
 	err = yaml.Unmarshal(data, &res)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing module config file %q: %w", filePath, err)
@@ -46,7 +46,7 @@ func ParseConfig(filePath string) (*ModuleConfig, error) {
 	return &res, nil
 }
 
-func (c *ModuleConfig) Validate() error {
+func (c *Config) Validate() error {
 	return newConfigValidator(c).
 		validateName().
 		validateVersion().
@@ -57,11 +57,11 @@ func (c *ModuleConfig) Validate() error {
 type configValidationFunc func() error
 
 type configValidator struct {
-	config     *ModuleConfig
+	config     *Config
 	validators []configValidationFunc
 }
 
-func newConfigValidator(cnf *ModuleConfig) *configValidator {
+func newConfigValidator(cnf *Config) *configValidator {
 	return &configValidator{
 		config:     cnf,
 		validators: []configValidationFunc{},

--- a/cmd/kyma/alpha/create/module/moduleconfig.go
+++ b/cmd/kyma/alpha/create/module/moduleconfig.go
@@ -1,0 +1,149 @@
+package module
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/blang/semver/v4"
+	"gopkg.in/yaml.v3"
+)
+
+type ModuleConfig struct {
+	Name          string            `yaml:"name"`         //required, the name of the Module
+	Version       string            `yaml:"version"`      //required, the version of the Module
+	Channel       string            `yaml:"channel"`      //required, channel that should be used in the ModuleTemplate
+	ResourceName  string            `yaml:"resourceName"` //optional, default={NAME}-{CHANNEL}, the name for the ModuleTemplate that will be created
+	ManifestPath  string            `yaml:"manifest"`     //required, reference to the manifests, must be a relative file name.
+	DefaultCRPath string            `yaml:"defaultCR"`    //optional, reference to a YAML file containing the default CR for the module, must be a relative file name.
+	Security      string            `yaml:"security"`     //# optional, name of the security scanners config file
+	Internal      bool              `yaml:"internal"`     //# optional, default=false, determines whether the ModuleTemplate should have the internal flag or not
+	Beta          bool              `yaml:"beta"`         //# optional, default=false, determines whether the ModuleTemplate should have the beta flag or not
+	Labels        map[string]string `yaml:"labels"`       //# optional, additional labels for the ModuleTemplate
+	Annotations   map[string]string `yaml:"annotations"`  //# optional, additional annotations for the ModuleTemplate (operator.kyma-project.io/doc-url={DOCUMENTATION_URL} # required, the link to the Module documentation)
+}
+
+const (
+	//taken from "github.com/open-component-model/ocm/resources/component-descriptor-v2-schema.yaml"
+	moduleNamePattern = "^[a-z][-a-z0-9]*([.][a-z][-a-z0-9]*)*[.][a-z]{2,}(/[a-z][-a-z0-9_]*([.][a-z][-a-z0-9_]*)*)+$"
+	moduleNameMaxLen  = 255
+)
+
+func ParseConfig(filePath string) (*ModuleConfig, error) {
+	data, err := os.ReadFile(filePath)
+
+	if err != nil {
+		return nil, fmt.Errorf("error reading module config file %q: %w", filePath, err)
+	}
+
+	res := ModuleConfig{}
+	err = yaml.Unmarshal(data, &res)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing module config file %q: %w", filePath, err)
+	}
+
+	return &res, nil
+}
+
+func (c *ModuleConfig) Validate() error {
+	return newConfigValidator(c).
+		validateName().
+		validateVersion().
+		validateChannel().
+		do()
+}
+
+type configValidationFunc func() error
+
+type configValidator struct {
+	config     *ModuleConfig
+	validators []configValidationFunc
+}
+
+func newConfigValidator(cnf *ModuleConfig) *configValidator {
+	return &configValidator{
+		config:     cnf,
+		validators: []configValidationFunc{},
+	}
+}
+
+func (cv *configValidator) addValidator(fn configValidationFunc) *configValidator {
+	cv.validators = append(cv.validators, fn)
+	return cv
+}
+
+func (cv *configValidator) validateName() *configValidator {
+	fn := func() error {
+		if len(cv.config.Name) == 0 {
+			return fmt.Errorf("%w, module name cannot be empty", ErrNameValidation)
+		}
+		if len(cv.config.Name) > moduleNameMaxLen {
+			return fmt.Errorf("%w, module name length cannot exceed 255 characters", ErrNameValidation)
+		}
+		matched, _ := regexp.MatchString(moduleNamePattern, cv.config.Name)
+		if !matched {
+			return fmt.Errorf("%w for input %q, name does not match %s pattern", ErrNameValidation, cv.config.Name, moduleNamePattern)
+		}
+
+		return nil
+	}
+
+	return cv.addValidator(fn)
+}
+
+func (cv *configValidator) validateVersion() *configValidator {
+	fn := func() error {
+
+		prefix := ""
+		val := strings.TrimSpace(cv.config.Version)
+
+		//strip the leading "v", if any, because it's not part of a proper semver
+		if strings.HasPrefix(val, "v") {
+			prefix = "v"
+			val = val[1:]
+		}
+
+		sv, err := semver.Parse(val)
+		if err != nil {
+			return fmt.Errorf("%w for input %q, %w", ErrVersionValidation, cv.config.Version, err)
+		}
+
+		//restore "v" prefix, if any
+		correct := prefix + sv.String()
+
+		if correct != cv.config.Version {
+			return fmt.Errorf("%w for input %q, try with %q", ErrVersionValidation, cv.config.Version, correct)
+		}
+		return nil
+	}
+
+	return cv.addValidator(fn)
+}
+
+func (cv *configValidator) validateChannel() *configValidator {
+	fn := func() error {
+		if len(cv.config.Channel) < ChannelMinLength || len(cv.config.Channel) > ChannelMaxLength {
+			return fmt.Errorf(
+				"%w for input %q, invalid channel length, length should between %d and %d",
+				ErrChannelValidation, cv.config.Channel, ChannelMinLength, ChannelMaxLength)
+		}
+		matched, _ := regexp.MatchString(`^[a-z]+$`, cv.config.Channel)
+		if !matched {
+			return fmt.Errorf("%w for input %q, invalid channel format, only allow characters from a-z", ErrChannelValidation, cv.config.Channel)
+		}
+		return nil
+
+	}
+
+	return cv.addValidator(fn)
+}
+
+func (cv *configValidator) do() error {
+	for _, v := range cv.validators {
+		if err := v(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/kyma/alpha/create/module/moduleconfig_test.go
+++ b/cmd/kyma/alpha/create/module/moduleconfig_test.go
@@ -34,7 +34,7 @@ func TestValidateVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(
 			tt.tCase, func(t *testing.T) {
-				mc := ModuleConfig{
+				mc := Config{
 					Version: tt.version,
 				}
 
@@ -93,7 +93,7 @@ func TestValidateName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(
 			tt.tCase, func(t *testing.T) {
-				mc := ModuleConfig{
+				mc := Config{
 					Name: tt.name,
 				}
 
@@ -147,7 +147,7 @@ func TestValidateChannel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(
 			tt.tCase, func(t *testing.T) {
-				mc := ModuleConfig{
+				mc := Config{
 					Channel: tt.channel,
 				}
 

--- a/cmd/kyma/alpha/create/module/moduleconfig_test.go
+++ b/cmd/kyma/alpha/create/module/moduleconfig_test.go
@@ -1,0 +1,167 @@
+package module
+
+import (
+	"testing"
+)
+
+func TestValidateVersion(t *testing.T) {
+	tests := []struct {
+		tCase   string
+		version string
+		isValid bool
+	}{
+		{
+			tCase:   "proper version without 'v' prefix",
+			version: "1.2.3",
+			isValid: true,
+		},
+		{
+			tCase:   "proper version with 'v' prefix",
+			version: "v1.2.3",
+			isValid: true,
+		},
+		{
+			tCase:   "invalid version - missing patch",
+			version: "v1.2",
+			isValid: false,
+		},
+		{
+			tCase:   "invalid version - just a string",
+			version: "main",
+			isValid: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.tCase, func(t *testing.T) {
+				mc := ModuleConfig{
+					Version: tt.version,
+				}
+
+				err := newConfigValidator(&mc).
+					validateVersion().
+					do()
+
+				if !tt.isValid && err == nil {
+					t.Errorf("Version validation failed for input %q: Expected an error but success is reported", tt.version)
+				}
+				if tt.isValid && err != nil {
+					t.Error(err)
+				}
+			},
+		)
+	}
+}
+
+func TestValidateName(t *testing.T) {
+	tests := []struct {
+		tCase   string
+		name    string
+		isValid bool
+	}{
+		{
+			tCase:   "proper name",
+			name:    "kyma-project.io/foo",
+			isValid: true,
+		},
+		{
+			tCase:   "empty name",
+			name:    "",
+			isValid: false,
+		},
+		{
+			tCase:   "invalid name - whitespaces",
+			name:    " kyma-project.io/foo ",
+			isValid: false,
+		},
+		{
+			tCase:   "invalid name - no path",
+			name:    "kyma-project.io",
+			isValid: false,
+		},
+		{
+			tCase:   "invalid name",
+			name:    "foo",
+			isValid: false,
+		},
+		{
+			tCase:   "invalid name with path",
+			name:    "foo/bar",
+			isValid: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.tCase, func(t *testing.T) {
+				mc := ModuleConfig{
+					Name: tt.name,
+				}
+
+				err := newConfigValidator(&mc).
+					validateName().
+					do()
+
+				if !tt.isValid && err == nil {
+					t.Errorf("Name validation failed for input %q: Expected an error but success is reported", tt.name)
+				}
+				if tt.isValid && err != nil {
+					t.Error(err)
+				}
+			},
+		)
+	}
+}
+
+func TestValidateChannel(t *testing.T) {
+	tests := []struct {
+		tCase   string
+		channel string
+		isValid bool
+	}{
+		{
+			tCase:   "proper channel",
+			channel: "regular",
+			isValid: true,
+		},
+		{
+			tCase:   "empty channel",
+			channel: "",
+			isValid: false,
+		},
+		{
+			tCase:   "channel too short",
+			channel: "ab",
+			isValid: false,
+		},
+		{
+			tCase:   "channel too long",
+			channel: "thisstringvaluehaslengthof33chars",
+			isValid: false,
+		},
+		{
+			tCase:   "channel contains invalid characters",
+			channel: "this value has spaces",
+			isValid: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(
+			tt.tCase, func(t *testing.T) {
+				mc := ModuleConfig{
+					Channel: tt.channel,
+				}
+
+				err := newConfigValidator(&mc).
+					validateChannel().
+					do()
+
+				if !tt.isValid && err == nil {
+					t.Errorf("Channel validation failed for input %q: Expected an error but success is reported", tt.channel)
+				}
+				if tt.isValid && err != nil {
+					t.Error(err)
+				}
+			},
+		)
+	}
+}

--- a/cmd/kyma/alpha/create/module/opts.go
+++ b/cmd/kyma/alpha/create/module/opts.go
@@ -27,7 +27,6 @@ type Options struct {
 	TemplateOutput          string
 	DefaultCRPath           string
 	Channel                 string
-	Target                  string
 	SchemaVersion           string
 	Token                   string
 	Insecure                bool
@@ -101,19 +100,6 @@ func (o *Options) ValidateChannel() error {
 	return nil
 }
 
-func (o *Options) ValidateTarget() error {
-	valid := []string{
-		"control-plane",
-		"remote",
-	}
-	for i := range valid {
-		if o.Target == valid[i] {
-			return nil
-		}
-	}
-	return fmt.Errorf("target %s is invalid, allowed: %s", o.Target, valid)
-}
-
 func (o *Options) Validate() error {
 	if !o.WithModuleConfigFile() {
 		if err := o.ValidateVersion(); err != nil {
@@ -125,11 +111,7 @@ func (o *Options) Validate() error {
 		}
 	}
 
-	if err := o.ValidatePath(); err != nil {
-		return err
-	}
-
-	return o.ValidateTarget()
+	return o.ValidatePath()
 }
 
 func (o *Options) WithModuleConfigFile() bool {

--- a/cmd/kyma/alpha/create/module/opts.go
+++ b/cmd/kyma/alpha/create/module/opts.go
@@ -37,6 +37,7 @@ type Options struct {
 	RegistryCredSelector    string
 	SecurityScanConfig      string
 	PrivateKeyPath          string
+	ModuleConfigFile        string
 }
 
 const (
@@ -45,7 +46,11 @@ const (
 )
 
 var (
-	ErrChannelValidation = errors.New("channel validation failed")
+	ErrChannelValidation       = errors.New("channel validation failed")
+	ErrManifestPathValidation  = errors.New("YAML manifest path validation failed")
+	ErrDefaultCRPathValidation = errors.New("default CR path validation failed")
+	ErrNameValidation          = errors.New("name validation failed")
+	ErrVersionValidation       = errors.New("version validation failed")
 )
 
 // NewOptions creates options with default values
@@ -110,17 +115,23 @@ func (o *Options) ValidateTarget() error {
 }
 
 func (o *Options) Validate() error {
-	if err := o.ValidateVersion(); err != nil {
-		return err
+	if !o.WithModuleConfigFile() {
+		if err := o.ValidateVersion(); err != nil {
+			return err
+		}
+
+		if err := o.ValidateChannel(); err != nil {
+			return err
+		}
 	}
 
 	if err := o.ValidatePath(); err != nil {
 		return err
 	}
 
-	if err := o.ValidateChannel(); err != nil {
-		return err
-	}
-
 	return o.ValidateTarget()
+}
+
+func (o *Options) WithModuleConfigFile() bool {
+	return len(o.ModuleConfigFile) > 0
 }

--- a/docs/gen-docs/kyma_alpha_create.md
+++ b/docs/gen-docs/kyma_alpha_create.md
@@ -22,5 +22,5 @@ Use this command to create resources on the Kyma cluster.
 ## See also
 
 * [kyma alpha](kyma_alpha.md)	 - Experimental commands
-* [kyma alpha create module](kyma_alpha_create_module.md)	 - Creates a module bundled as an OCI image with the given OCI image name from the contents of the given path
+* [kyma alpha create module](kyma_alpha_create_module.md)	 - Creates a module bundled as an OCI artifact
 

--- a/docs/gen-docs/kyma_alpha_create_module.md
+++ b/docs/gen-docs/kyma_alpha_create_module.md
@@ -37,7 +37,7 @@ The module config file is a YAML file used to configure the following attributes
 - labels:       a map with string keys and values, optional, additional labels for the generated ModuleTemplate CR
 - annotations:  a map with string keys and values, optional, additional annotations for the generated ModuleTemplate CR
 
-The**manifes** and **defaultCR** paths are resolved against the module's directory, as configured with the "--path" flag.
+The **manifest** and **defaultCR** paths are resolved against the module's directory, as configured with the "--path" flag.
 The **manifest** file contains all the module's resources in a single, multi-document YAML file. These resources will be created in the Kyma cluster when the module is activated.
 The **defaultCR** file contains a default custom resource for the module that will be installed along with the module.
 The Default CR is additionally schema-validated against the Custom Resource Definition. The CRD used for the validation must exist in the set of the module's resources.

--- a/docs/gen-docs/kyma_alpha_create_module.md
+++ b/docs/gen-docs/kyma_alpha_create_module.md
@@ -10,44 +10,44 @@ Use this command to create a Kyma module, bundle it as an OCI artifact and optio
 
 ### Detailed description
 
-This command lets you to create a Kyma module as an OCI artifact and optionally push it to the OCI registry of you choice.
-For more information about what is a Kyma module see the [documentation](https://github.com/kyma-project/lifecycle-manager)
+This command allows you to create a Kyma module as an OCI artifact and optionally push it to the OCI registry of your choice.
+For more information about a Kyma module see the [documentation](https://github.com/kyma-project/lifecycle-manager).
 
-This command creates a module from an existing directory containing module's source files.
-The directory MUST be a valid git project that is publicly available.
-The command supports two directory layouts for the module:
+This command creates a module from an existing directory containing the module's source files.
+The directory must be a valid git project that is publicly available.
+The command supports two types of directory layouts for the module:
 - Simple: Just a directory with a valid git configuration. All the module's sources are defined in this directory.
-- Kubebuild projects (DEPRECATED): A directory with a valid Kubebuilder project. This is a convenience mode for the users who are creating the module operator(s) using the Kubebuilder toolset.
-Both modes require providing an explicit path to the module's project directory using "--path" flag or invoking the command from within the that directory.
+- Kubebuilder (DEPRECATED): A directory with a valid Kubebuilder project. Module operator(s) are created using the Kubebuilder toolset.
+Both simple and Kubebuilder projects require providing an explicit path to the module's project directory using the "--path" flag or invoking the command from within that directory.
 
 ### Simple mode configuration
 
-You configure the simple mode by providing the "--module-config-file" flag with a config file path.
+To configure the simple mode, provide the "--module-config-file" flag with a config file path.
 The module config file is a YAML file used to configure the following attributes for the module:
 
-- name:         a string, required, the name of the Module
-- version:      a string, required, the version of the Module
-- channel:      a string, required, channel that should be used in the ModuleTemplate
-- manifest:     a string, required, reference to the manifests, must be a relative file name.
-- defaultCR:    a string, optional, reference to a YAML file containing the default CR for the module, must be a relative file name.
-- resourceName: a string, optional, default={NAME}-{CHANNEL}, the name for the ModuleTemplate that will be created
+- name:         a string, required, the name of the module
+- version:      a string, required, the version of the module
+- channel:      a string, required, channel that should be used in the ModuleTemplate CR
+- manifest:     a string, required, reference to the manifest, must be a relative file name
+- defaultCR:    a string, optional, reference to a yaml file containing the default CR for the module, must be a relative file name
+- resourceName: a string, optional, default={NAME}-{CHANNEL}, the name for the ModuleTemplate CR that will be created
 - security:     a string, optional, name of the security scanners config file
-- internal:     a bool, optional, default=false, determines whether the ModuleTemplate should have the internal flag or not
-- beta:         a bool, optional, default=false, determines whether the ModuleTemplate should have the beta flag or not
-- labels:       a map with string keys and values, optional, additional labels for the generated ModuleTemplate
-- annotations:  a map with string keys and values, optional, additional annotations for the generated ModuleTemplate
+- internal:     a boolean, optional, default=false, determines whether the ModuleTemplate CR should have the internal flag or not
+- beta:         a boolean, optional, default=false, determines whether the ModuleTemplate CR should have the beta flag or not
+- labels:       a map with string keys and values, optional, additional labels for the generated ModuleTemplate CR
+- annotations:  a map with string keys and values, optional, additional annotations for the generated ModuleTemplate CR
 
-The "manifest" and "defaultCR" paths are resolved against the module's directory, as configured with "--path" flag.
-The "manifest" file contains all the module's resources in a single, multi-document YAML file. These resources will be created in the Kyma cluster when the module is activated.
-The "defaultCR" file contain a default Custom Resource for the module that will be installed along with the module.
-It is additionally schema-validated against the Custom Resource Definition for it's Group/Kind that must exists is the set of resources in the "manifest" file.
+The**manifes** and **defaultCR** paths are resolved against the module's directory, as configured with the "--path" flag.
+The **manifest** file contains all the module's resources in a single, multi-document yaml file. These resources will be created in the Kyma cluster when the module is activated.
+The **defaultCR** file contains a default custom resource for the module that will be installed along with the module.
+The Default CR is additionally schema-validated against the Custom Resource Definition. The CRD used for the validation must exist in the set of the module's resources.
 
 ### Kubebuilder mode configuration
 The Kubebuilder mode is DEPRECATED.
 The Kubebuilder mode is configured automatically if the "--module-config-file" flag is not provided.
 
-In this mode you have to explicitly provide the module name and version using "--name" and "--version" flags, respectively.
-Some defaults, like the module manifest file location and the default CR file location are then resolved automatically, but you can override these with available flags.
+In this mode, you have to explicitly provide the module name and version using the "--name" and "--version" flags, respectively.
+Some defaults, like the module manifest file location and the default CR file location, are then resolved automatically, but you can override these with the available flags.
 
 ### Modules as OCI artifacts
 Modules are built and distributed as OCI artifacts. 
@@ -55,11 +55,11 @@ This command creates a component descriptor in the configured descriptor path (.
 The internal structure of the artifact conforms to the [Open Component Model](https://ocm.software/) scheme version 3.
 
 If you configured the "--registry" flag, the created module is validated and pushed to the configured registry.
-During the validation the default CR resource, if defined, is validated against a corresponding CustomResourceDefinition.
-You can also trigger an on-demand default CR validation with "--validateCR=true", in case you don't push to the registry.
+During the validation the **defaultCR** resource, if defined, is validated against a corresponding CustomResourceDefinition.
+You can also trigger an on-demand **defaultCR** validation with "--validateCR=true", in case you don't push the module to the registry.
 
-#### Name Mapping Modes
-To push the artifact into some registries, for example, the central docker.io registry, you have to change the OCM Component Name Mapping with the following flag: "--name-mapping=sha256-digest". This is necessary because the registry does not accept artifact URLs with more than two path segments, and such URLs are generated with the default name mapping: "urlPath". In the case of the "sha256-digest" mapping, the artifact URL contains just a sha256 digest of the full Component Name and fits the path length restrictions. The downside of the "sha256-mapping" is that the module name is no longer visible in the artifact URL, as it contains the sha256 digest of the defined name.
+#### Name Mapping
+To push the artifact into some registries, for example, the central docker.io registry, you have to change the OCM Component Name Mapping with the following flag: "--name-mapping=sha256-digest". This is necessary because the registry does not accept artifact URLs with more than two path segments, and such URLs are generated with the default name mapping: **urlPath**. In the case of the "sha256-digest" mapping, the artifact URL contains just a sha256 digest of the full Component Name and fits the path length restrictions. The downside of the "sha256-mapping" is that the module name is no longer visible in the artifact URL, as it contains the sha256 digest of the defined name.
 
 
 

--- a/docs/gen-docs/kyma_alpha_create_module.md
+++ b/docs/gen-docs/kyma_alpha_create_module.md
@@ -29,7 +29,7 @@ The module config file is a YAML file used to configure the following attributes
 - version:      a string, required, the version of the module
 - channel:      a string, required, channel that should be used in the ModuleTemplate CR
 - manifest:     a string, required, reference to the manifest, must be a relative file name
-- defaultCR:    a string, optional, reference to a yaml file containing the default CR for the module, must be a relative file name
+- defaultCR:    a string, optional, reference to a YAML file containing the default CR for the module, must be a relative file name
 - resourceName: a string, optional, default={NAME}-{CHANNEL}, the name for the ModuleTemplate CR that will be created
 - security:     a string, optional, name of the security scanners config file
 - internal:     a boolean, optional, default=false, determines whether the ModuleTemplate CR should have the internal flag or not
@@ -38,7 +38,7 @@ The module config file is a YAML file used to configure the following attributes
 - annotations:  a map with string keys and values, optional, additional annotations for the generated ModuleTemplate CR
 
 The**manifes** and **defaultCR** paths are resolved against the module's directory, as configured with the "--path" flag.
-The **manifest** file contains all the module's resources in a single, multi-document yaml file. These resources will be created in the Kyma cluster when the module is activated.
+The **manifest** file contains all the module's resources in a single, multi-document YAML file. These resources will be created in the Kyma cluster when the module is activated.
 The **defaultCR** file contains a default custom resource for the module that will be installed along with the module.
 The Default CR is additionally schema-validated against the Custom Resource Definition. The CRD used for the validation must exist in the set of the module's resources.
 

--- a/pkg/module/build.go
+++ b/pkg/module/build.go
@@ -9,14 +9,11 @@ import (
 	"github.com/mandelsoft/vfs/pkg/vfs"
 	"github.com/open-component-model/ocm/pkg/common/accessobj"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/attrs/compatattr"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	ocm "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	v1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
 	compdescv2 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions/v2"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/comparch"
-
-	"gopkg.in/yaml.v3"
 )
 
 // CreateArchive creates a component archive with the given configuration.
@@ -27,14 +24,6 @@ func CreateArchive(fs vfs.FileSystem, path string, def *Definition) (*comparch.C
 		return nil, err
 	}
 	return createArchive(fs, path, def)
-}
-
-func DumpDescriptor(desc *compdesc.ComponentDescriptor) (string, error) {
-	output, err := yaml.Marshal(desc)
-	if err != nil {
-		return "", err
-	}
-	return string(output), err
 }
 
 func createArchive(fs vfs.FileSystem, path string, def *Definition) (*comparch.ComponentArchive, error) {

--- a/pkg/module/build.go
+++ b/pkg/module/build.go
@@ -23,10 +23,7 @@ func CreateArchive(fs vfs.FileSystem, path string, def *Definition) (*comparch.C
 	if err := def.validate(); err != nil {
 		return nil, err
 	}
-	return createArchive(fs, path, def)
-}
 
-func createArchive(fs vfs.FileSystem, path string, def *Definition) (*comparch.ComponentArchive, error) {
 	// build minimal archive
 
 	if err := fs.MkdirAll(path, os.ModePerm); err != nil {

--- a/pkg/module/build.go
+++ b/pkg/module/build.go
@@ -9,24 +9,35 @@ import (
 	"github.com/mandelsoft/vfs/pkg/vfs"
 	"github.com/open-component-model/ocm/pkg/common/accessobj"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/attrs/compatattr"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	ocm "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	v1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
 	compdescv2 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions/v2"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/comparch"
+
+	"gopkg.in/yaml.v3"
 )
 
-// Build creates a component archive with the given configuration.
+// CreateArchive creates a component archive with the given configuration.
 // An empty vfs.FileSystem causes a FileSystem to be created in
 // the temporary OS folder
-func Build(fs vfs.FileSystem, path string, def *Definition) (*comparch.ComponentArchive, error) {
+func CreateArchive(fs vfs.FileSystem, path string, def *Definition) (*comparch.ComponentArchive, error) {
 	if err := def.validate(); err != nil {
 		return nil, err
 	}
-	return build(fs, path, def)
+	return createArchive(fs, path, def)
 }
 
-func build(fs vfs.FileSystem, path string, def *Definition) (*comparch.ComponentArchive, error) {
+func DumpDescriptor(desc *compdesc.ComponentDescriptor) (string, error) {
+	output, err := yaml.Marshal(desc)
+	if err != nil {
+		return "", err
+	}
+	return string(output), err
+}
+
+func createArchive(fs vfs.FileSystem, path string, def *Definition) (*comparch.ComponentArchive, error) {
 	// build minimal archive
 
 	if err := fs.MkdirAll(path, os.ModePerm); err != nil {

--- a/pkg/module/def.go
+++ b/pkg/module/def.go
@@ -9,14 +9,15 @@ import (
 
 // Definition contains all infrmation and configuration that defines a module (e.g. component descriptor config, template config, layers, CRs...)
 type Definition struct {
-	SchemaVersion   string      // schema version for the ocm descriptor
-	Source          string      // path to the sources to create the module
-	Name            string      // Name of the module (mandatory)
-	NameMappingMode NameMapping // Component Name mapping as defined in OCM spec.
-	Version         string      // Version of the module (mandatory)
-	RegistryURL     string      // Registry URL to push the image to (optional)
-	DefaultCRPath   string      // path to the file containing the CR to include in the module template  (optional)
-	Override        bool        // If true, existing module is overwritten if the configuration differs.
+	SchemaVersion      string      // schema version for the ocm descriptor
+	Source             string      // path to the sources to create the module
+	Name               string      // Name of the module (mandatory)
+	NameMappingMode    NameMapping // Component Name mapping as defined in OCM spec.
+	Version            string      // Version of the module (mandatory)
+	RegistryURL        string      // Registry URL to push the image to (optional)
+	DefaultCRPath      string      // path to the file containing the CR to include in the module template  (optional)
+	SingleManifestPath string      // path to the file containing combined manifest for the module (optional)
+	Override           bool        // If true, existing module is overwritten if the configuration differs.
 
 	// these fields will be filled out when inspecting the module contents
 	Layers    []Layer

--- a/pkg/module/resources.go
+++ b/pkg/module/resources.go
@@ -91,13 +91,6 @@ func AddResources(
 func generateResources(log *zap.SugaredLogger, version string, credLabel []byte, defs ...Layer) ([]ResourceDescriptor, error) {
 	res := []ResourceDescriptor{}
 	for _, d := range defs {
-		//DEBUG
-		fmt.Println("-- Layer: ----------------------------->")
-		fmt.Println("name:", d.name)
-		fmt.Println("resourceType:", d.resourceType)
-		fmt.Println("path:", d.path)
-		fmt.Println("excludedFiles:", d.excludedFiles)
-		fmt.Println("<---------------------------------------")
 		r := ResourceDescriptor{Input: &blob.Input{}}
 
 		r.Name = d.Name()

--- a/pkg/module/template.go
+++ b/pkg/module/template.go
@@ -33,7 +33,9 @@ metadata:
 spec:
   channel: {{.Channel}}
   data:
-{{.Data | indent 4}}
+{{- with .Data}}
+{{. | indent 4}}
+{{- end}}
   descriptor:
 {{yaml .Descriptor | printf "%s" | indent 4}}
 `

--- a/pkg/module/template.go
+++ b/pkg/module/template.go
@@ -29,7 +29,7 @@ spec:
 `
 )
 
-func Template(remote ocm.ComponentVersionAccess, channel, target string, data []byte) ([]byte, error) {
+func Template(remote ocm.ComponentVersionAccess, channel string, data []byte) ([]byte, error) {
 	descriptor := remote.GetDescriptor()
 	ref, err := oci.ParseRef(descriptor.Name)
 	if err != nil {

--- a/pkg/module/template.go
+++ b/pkg/module/template.go
@@ -16,10 +16,20 @@ const (
 	modTemplate = `apiVersion: operator.kyma-project.io/v1beta2
 kind: ModuleTemplate
 metadata:
-  name: moduletemplate-{{ .ShortName }}
+  name: {{.ResourceName}}
   namespace: kcp-system
+{{- with .Labels}}
   labels:
-    "operator.kyma-project.io/module-name": "{{ .ShortName }}"
+    {{- range $key, $value := . }}
+    {{ printf "%q" $key }}: {{ printf "%q" $value }}
+    {{- end}}
+{{- end}} 
+{{- with .Annotations}}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ printf "%q" $key }}: {{ printf "%q" $value }}
+    {{- end}}
+{{- end}} 
 spec:
   channel: {{.Channel}}
   data:
@@ -29,7 +39,7 @@ spec:
 `
 )
 
-func Template(remote ocm.ComponentVersionAccess, channel string, data []byte) ([]byte, error) {
+func Template(remote ocm.ComponentVersionAccess, moduleTemplateName, channel string, data []byte, labels, annotations map[string]string) ([]byte, error) {
 	descriptor := remote.GetDescriptor()
 	ref, err := oci.ParseRef(descriptor.Name)
 	if err != nil {
@@ -41,16 +51,26 @@ func Template(remote ocm.ComponentVersionAccess, channel string, data []byte) ([
 		return nil, err
 	}
 
+	shortName := ref.ShortName()
+	labels["operator.kyma-project.io/module-name"] = shortName
+	resourceName := moduleTemplateName
+	if len(resourceName) == 0 {
+		resourceName = shortName + "-" + channel
+	}
 	td := struct { // Custom struct for the template
-		ShortName  string                              // Last part of the component descriptor name
-		Descriptor compdesc.ComponentDescriptorVersion // descriptor info for the template
-		Channel    string
-		Data       string // contents for the spec.data section of the template taken from the defaults.yaml file in the mod folder
+		ResourceName string                              // K8s resource name of the generated ModuleTemplate
+		Descriptor   compdesc.ComponentDescriptorVersion // descriptor info for the template
+		Channel      string
+		Data         string // contents for the spec.data section of the template taken from the defaults.yaml file in the mod folder
+		Labels       map[string]string
+		Annotations  map[string]string
 	}{
-		ShortName:  ref.ShortName(),
-		Descriptor: cva,
-		Channel:    channel,
-		Data:       string(data),
+		ResourceName: resourceName,
+		Descriptor:   cva,
+		Channel:      channel,
+		Data:         string(data),
+		Labels:       labels,
+		Annotations:  annotations,
 	}
 
 	t, err := template.New("modTemplate").Funcs(template.FuncMap{"yaml": yaml.Marshal, "indent": Indent}).Parse(modTemplate)

--- a/pkg/module/validation.go
+++ b/pkg/module/validation.go
@@ -84,9 +84,7 @@ func runTestEnv(ctx context.Context, log *zap.SugaredLogger, crdFilePath string,
 	}
 	defer func() {
 		if err := runner.Stop(); err != nil {
-			//TODO: This doesn't seem to print anything...
 			log.Error(fmt.Errorf("error stopping envTest: %w", err))
-			//THIS does: fmt.Println(fmt.Errorf("Error stopping envTest: %w", stopErr))
 		}
 	}()
 
@@ -402,7 +400,7 @@ func (v *SingleManifestFileCRValidator) Run(ctx context.Context, log *zap.Sugare
 		}
 	}()
 	tempCRDFile := filepath.Join(tempDir, "crd.yaml")
-	err = os.WriteFile(tempCRDFile, crdBytes, 0666)
+	err = os.WriteFile(tempCRDFile, crdBytes, 0600)
 	if err != nil {
 		return fmt.Errorf("error writing temporary CRD file %q file: %w", tempCRDFile, err)
 	}


### PR DESCRIPTION
**Description**
This PR delivers simplified syntax for `kyma alpha create module` for non-kubebuilder projects.
The syntax for kubebuilder projects stays the same for now.
See #1684 for details

Changes proposed in this pull request:

- Introduce a config file as described [here](https://github.com/kyma-project/cli/issues/1684

**Related issue(s)**
See also #1684 