### PR TITLE
Upgrade default k8s version for k3d provisioning

### DIFF
--- a/cmd/kyma/provision/cmd.go
+++ b/cmd/kyma/provision/cmd.go
@@ -4,9 +4,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const DefaultK8sShortVersion = "1.25"                       //default Kubernetes version for provisioning clusters on hyperscalers
+const DefaultK8sShortVersion = "1.26"                       //default Kubernetes version for provisioning clusters on hyperscalers
 const DefaultK8sFullVersion = DefaultK8sShortVersion + ".6" //default Kubernetes version with the "patch" component (mainly for K3d/K3s)
-const DefaultGardenLinuxVersion = "934.6.0"                 //default Garden Linux version
+const DefaultGardenLinuxVersion = "934.9"                   //default Garden Linux version
 
 // NewCmd creates a new provision command
 func NewCmd() *cobra.Command {

--- a/docs/gen-docs/kyma_provision_gardener_aws.md
+++ b/docs/gen-docs/kyma_provision_gardener_aws.md
@@ -23,11 +23,11 @@ kyma provision gardener aws [flags]
       --disk-size int                 Disk size (in GB) of the cluster. (default 50)
       --disk-type string              Type of disk to use on AWS. (default "gp2")
   -e, --extra NAME=VALUE              One or more arguments provided as the NAME=VALUE key-value pairs to configure additional cluster settings. You can use this flag multiple times or enter the key-value pairs as a comma-separated list.
-  -g, --gardenlinux-version string    Garden Linux version of the cluster. (default "934.6.0")
+  -g, --gardenlinux-version string    Garden Linux version of the cluster. (default "934.9")
       --hibernation-end string        Cron expression to configure when the cluster should stop hibernating
       --hibernation-location string   Timezone in which the hibernation schedule should be applied. (default "Europe/Berlin")
       --hibernation-start string      Cron expression to configure when the cluster should start hibernating (default "00 18 * * 1,2,3,4,5")
-  -k, --kube-version string           Kubernetes version of the cluster. (default "1.25")
+  -k, --kube-version string           Kubernetes version of the cluster. (default "1.26")
   -n, --name string                   Name of the cluster to provision. (required)
   -p, --project string                Name of the Gardener project where you provision the cluster. (required)
   -r, --region string                 Region of the cluster. (default "eu-west-3")

--- a/docs/gen-docs/kyma_provision_gardener_az.md
+++ b/docs/gen-docs/kyma_provision_gardener_az.md
@@ -22,11 +22,11 @@ kyma provision gardener az [flags]
       --disk-size int                 Disk size (in GB) of the cluster. (default 50)
       --disk-type string              Type of disk to use on Azure. (default "Standard_LRS")
   -e, --extra NAME=VALUE              One or more arguments provided as the NAME=VALUE key-value pairs to configure additional cluster settings. You can use this flag multiple times or enter the key-value pairs as a comma-separated list.
-  -g, --gardenlinux-version string    Garden Linux version of the cluster. (default "934.6.0")
+  -g, --gardenlinux-version string    Garden Linux version of the cluster. (default "934.9")
       --hibernation-end string        Cron expression to configure when the cluster should stop hibernating
       --hibernation-location string   Timezone in which the hibernation schedule should be applied. (default "Europe/Berlin")
       --hibernation-start string      Cron expression to configure when the cluster should start hibernating (default "00 18 * * 1,2,3,4,5")
-  -k, --kube-version string           Kubernetes version of the cluster. (default "1.25")
+  -k, --kube-version string           Kubernetes version of the cluster. (default "1.26")
   -n, --name string                   Name of the cluster to provision. (required)
   -p, --project string                Name of the Gardener project where you provision the cluster. (required)
   -r, --region string                 Region of the cluster. (default "westeurope")

--- a/docs/gen-docs/kyma_provision_gardener_gcp.md
+++ b/docs/gen-docs/kyma_provision_gardener_gcp.md
@@ -23,11 +23,11 @@ kyma provision gardener gcp [flags]
       --disk-size int                 Disk size (in GB) of the cluster. (default 50)
       --disk-type string              Type of disk to use on GCP. (default "pd-standard")
   -e, --extra NAME=VALUE              One or more arguments provided as the NAME=VALUE key-value pairs to configure additional cluster settings. You can use this flag multiple times or enter the key-value pairs as a comma-separated list.
-  -g, --gardenlinux-version string    Garden Linux version of the cluster. (default "934.6.0")
+  -g, --gardenlinux-version string    Garden Linux version of the cluster. (default "934.9")
       --hibernation-end string        Cron expression to configure when the cluster should stop hibernating
       --hibernation-location string   Timezone in which the hibernation schedule should be applied. (default "Europe/Berlin")
       --hibernation-start string      Cron expression to configure when the cluster should start hibernating (default "00 18 * * 1,2,3,4,5")
-  -k, --kube-version string           Kubernetes version of the cluster. (default "1.25")
+  -k, --kube-version string           Kubernetes version of the cluster. (default "1.26")
   -n, --name string                   Name of the cluster to provision. (required)
   -p, --project string                Name of the Gardener project where you provision the cluster. (required)
   -r, --region string                 Region of the cluster. (default "europe-west3")

--- a/docs/gen-docs/kyma_provision_k3d.md
+++ b/docs/gen-docs/kyma_provision_k3d.md
@@ -18,7 +18,7 @@ kyma provision k3d [flags]
       --k3d-arg strings            One or more arguments passed to the k3d provisioning command (e.g. --k3d-arg='--no-rollback')
       --k3d-registry-arg strings   One or more arguments passed to the k3d registry create command (e.g. --k3d-registry-arg='--default-network podman')
   -s, --k3s-arg strings            One or more arguments passed from k3d to the k3s command (format: ARG@NODEFILTER[;@NODEFILTER])
-  -k, --kube-version string        Kubernetes version of the cluster (default "1.25.6")
+  -k, --kube-version string        Kubernetes version of the cluster (default "1.26.6")
       --name string                Name of the Kyma cluster (default "kyma")
   -p, --port strings               Map ports 80 and 443 of K3D loadbalancer (e.g. -p 80:80@loadbalancer -p 443:443@loadbalancer) (default [80:80@loadbalancer,443:443@loadbalancer])
       --registry-port string       Specify the port on which the k3d registry will be exposed (default "5001")


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Bump k8s default version along with latest gardner linux version.

**Related issue(s)**
#1689 