### PR TITLE
Init Legacy flags by default

### DIFF
--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -176,9 +176,7 @@ Build a Kubebuilder module my-domain/modC in version 3.2.1 and push it to a loca
 
 	cmd.Flags().BoolVar(&o.KubebuilderProject, "kubebuilder-project", false, "Specifies provided module is a Kubebuilder Project.")
 
-	if o.KubebuilderProject {
-		configureLegacyFlags(cmd, o)
-	}
+	configureLegacyFlags(cmd, o)
 
 	return cmd
 }

--- a/docs/gen-docs/kyma_alpha_create_module.md
+++ b/docs/gen-docs/kyma_alpha_create_module.md
@@ -84,7 +84,9 @@ Build a Kubebuilder module my-domain/modC in version 3.2.1 and push it to a loca
 ## Flags
 
 ```bash
+      --channel string                     Channel to use for the module template. (default "regular")
   -c, --credentials string                 Basic authentication credentials for the given registry in the user:password format
+      --default-cr string                  File containing the default custom resource of the module. If the module is a kubebuilder project, the default CR is automatically detected.
       --descriptor-version string          Schema version to use for the generated OCM descriptor. One of ocm.software/v3alpha1,v2 (default "v2")
       --insecure                           Uses an insecure connection to access the registry.
       --key string                         Specifies the path where a private key is used for signing.
@@ -93,13 +95,16 @@ Build a Kubebuilder module my-domain/modC in version 3.2.1 and push it to a loca
       --module-archive-persistence         Uses the host filesystem instead of in-memory archiving to build the module.
       --module-archive-version-overwrite   Overwrites existing component's versions of the module. If set to false, the push is a No-Op.
       --module-config-file string          Specifies the module configuration file
+  -n, --name string                        Override the module name of the kubebuilder project. If the module is not a kubebuilder project, this flag is mandatory.
       --name-mapping string                Overrides the OCM Component Name Mapping, Use: "urlPath" or "sha256-digest". (default "urlPath")
   -o, --output string                      File to write the module template if the module is uploaded to a registry. (default "template.yaml")
   -p, --path string                        Path to the module's contents. (default current directory)
       --registry string                    Context URL of the repository. The repository URL will be automatically added to the repository contexts in the module descriptor.
       --registry-cred-selector string      Label selector to identify an externally created Secret of type "kubernetes.io/dockerconfigjson". It allows the image to be accessed in private image registries. It can be used when you push your module to a registry with authenticated access. For example, "label1=value1,label2=value2".
+  -r, --resource stringArray               Add an extra resource in a new layer in the <NAME:TYPE@PATH> format. If you provide only a path, the name defaults to the last path element, and the type is set to 'helm-chart'.
       --sec-scanners-config string         Path to the file holding the security scan configuration. (default "sec-scanners-config.yaml")
   -t, --token string                       Authentication token for the given registry (alternative to basic authentication).
+      --version string                     Version of the module. This flag is mandatory.
 ```
 
 ## Flags inherited from parent commands


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Init legacy flags by default
- https://github.com/kyma-project/cli/pull/1739 introduced the bug
- I took over the same logic as before in https://github.com/kyma-project/cli/pull/1739 - but there the bug was already existing but never appeared since the if clause always was true and never false - thus this did not happen before. Unfortunately, it is not possible to add flags dynamically based on input flags.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
