### PR TITLE
Better User-Feedback: Fail the sec scan info step if error appears

### DIFF
--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -299,7 +299,7 @@ func (cmd *command) Run(ctx context.Context) error {
 			}
 			cmd.CurrentStep.Successf("Security scanning configured")
 		} else {
-			l.Errorf("Security scanning configuration was skipped: %s", err.Error())
+			l.Warnf("Security scanning configuration was skipped: %s", err.Error())
 			cmd.CurrentStep.Failure()
 		}
 	}

--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -287,8 +287,8 @@ func (cmd *command) Run(ctx context.Context) error {
 	cmd.CurrentStep.Success()
 
 	if cmd.opts.SecurityScanConfig != "" {
+		cmd.NewStep("Configuring security scanning...")
 		if _, err := osFS.Stat(cmd.opts.SecurityScanConfig); err == nil {
-			cmd.NewStep("Configuring security scanning...")
 			err = module.AddSecurityScanningMetadata(archive.GetDescriptor(), cmd.opts.SecurityScanConfig)
 			if err != nil {
 				cmd.CurrentStep.Failure()
@@ -299,7 +299,8 @@ func (cmd *command) Run(ctx context.Context) error {
 			}
 			cmd.CurrentStep.Successf("Security scanning configured")
 		} else {
-			l.Warnf("Security scanning configuration was skipped: %s", err.Error())
+			l.Errorf("Security scanning configuration was skipped: %s", err.Error())
+			cmd.CurrentStep.Failure()
 		}
 	}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- If the security config file cannot be found, everything was skipped and no feedback was given to the user, thus quite confusing why this whole process was "skipped"
- Now, the step `Configuring security scanning...` is starting before the security file is fetched, thus when the file is not found, the user will get the feedback that it failed -> Better Userfeedback

Before this change:
![Screenshot 2023-08-24 at 15 19 57](https://github.com/kyma-project/cli/assets/48282931/fa8232a7-18b6-4951-bf45-69effe8ce15e)

After this change:
![Screenshot 2023-08-24 at 15 14 44](https://github.com/kyma-project/cli/assets/48282931/0b4f4589-eb90-4cd0-9874-790b4eff07a2)
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
