### PR TITLE
Updating the security scan labels according to the new fields in the security config files

### DIFF
--- a/.github/workflows/test-e2e-create-module.yml
+++ b/.github/workflows/test-e2e-create-module.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       K3D_VERSION: v5.4.7
-      MODULE_TEMPLATE_VERSION: v1.0.1
+      MODULE_TEMPLATE_VERSION: v1.0.0
       OCI_REPOSITORY_URL: http://k3d-oci.localhost:5001
     steps:
       - name: Checkout Kyma CLI
@@ -48,6 +48,7 @@ jobs:
       - name: Run create module with kubebuilder-project
         if: ${{ matrix.e2e-test == 'create_module_kubebuilder_project' }}
         run: |
+          vim ./template-operator/sec-scanners-config.yaml
           kyma alpha create module \
           --name kyma-project.io/module/template-operator \
           --path ./template-operator \
@@ -55,13 +56,13 @@ jobs:
           --insecure \
           --kubebuilder-project \
           --version $MODULE_TEMPLATE_VERSION -v \
-          --output /tmp/kubebuilder-template.yaml \
-          --module-archive-version-overwrite
+          --output /tmp/kubebuilder-template.yaml
           echo "MODULE_TEMPLATE_PATH=/tmp/kubebuilder-template.yaml" >> "$GITHUB_ENV"
       - name: Run create module with module-config
         if: ${{ matrix.e2e-test == 'create_module_module_config' }}
         run: |
           cd ./template-operator
+          vim sec-scanners-config.yaml
           make build-manifests
           kyma alpha create module \
           --name kyma-project.io/module/template-operator \
@@ -70,8 +71,7 @@ jobs:
           --insecure \
           --module-config-file ./module-config.yaml \
           --version $MODULE_TEMPLATE_VERSION -v \
-          --output /tmp/module-config-template.yaml \
-          --module-archive-version-overwrite
+          --output /tmp/module-config-template.yaml 
           echo "MODULE_TEMPLATE_PATH=/tmp/module-config-template.yaml" >> "$GITHUB_ENV"
       - name: Verify module template
         run: |

--- a/.github/workflows/test-e2e-create-module.yml
+++ b/.github/workflows/test-e2e-create-module.yml
@@ -39,7 +39,6 @@ jobs:
       - name: export template-operator URL
         run: |
           cd ./template-operator
-          vim ./sec-scanners-config.yaml
           echo "TEST_REPOSITORY_URL=$(git remote get-url origin)" >> "$GITHUB_ENV"
       - name: Set up k3d
         run: wget -qO - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=$K3D_VERSION bash
@@ -57,6 +56,7 @@ jobs:
           --kubebuilder-project \
           --version $MODULE_TEMPLATE_VERSION -v \
           --output /tmp/kubebuilder-template.yaml
+          --module-archive-version-overwrite
           echo "MODULE_TEMPLATE_PATH=/tmp/kubebuilder-template.yaml" >> "$GITHUB_ENV"
       - name: Run create module with module-config
         if: ${{ matrix.e2e-test == 'create_module_module_config' }}
@@ -71,6 +71,7 @@ jobs:
           --module-config-file ./module-config.yaml \
           --version $MODULE_TEMPLATE_VERSION -v \
           --output /tmp/module-config-template.yaml
+          --module-archive-version-overwrite
           echo "MODULE_TEMPLATE_PATH=/tmp/module-config-template.yaml" >> "$GITHUB_ENV"
       - name: Verify module template
         run: |

--- a/.github/workflows/test-e2e-create-module.yml
+++ b/.github/workflows/test-e2e-create-module.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       K3D_VERSION: v5.4.7
-      MODULE_TEMPLATE_VERSION: v1.0.0
+      MODULE_TEMPLATE_VERSION: v1.0.1
       OCI_REPOSITORY_URL: http://k3d-oci.localhost:5001
     steps:
       - name: Checkout Kyma CLI

--- a/.github/workflows/test-e2e-create-module.yml
+++ b/.github/workflows/test-e2e-create-module.yml
@@ -55,7 +55,8 @@ jobs:
           --insecure \
           --kubebuilder-project \
           --version $MODULE_TEMPLATE_VERSION -v \
-          --output /tmp/kubebuilder-template.yaml
+          --output /tmp/kubebuilder-template.yaml \
+          --sec-scanners-config ./template-operator/sec-scanners-config.yaml
           echo "MODULE_TEMPLATE_PATH=/tmp/kubebuilder-template.yaml" >> "$GITHUB_ENV"
       - name: Run create module with module-config
         if: ${{ matrix.e2e-test == 'create_module_module_config' }}

--- a/.github/workflows/test-e2e-create-module.yml
+++ b/.github/workflows/test-e2e-create-module.yml
@@ -55,7 +55,7 @@ jobs:
           --insecure \
           --kubebuilder-project \
           --version $MODULE_TEMPLATE_VERSION -v \
-          --output /tmp/kubebuilder-template.yaml
+          --output /tmp/kubebuilder-template.yaml \
           --module-archive-version-overwrite
           echo "MODULE_TEMPLATE_PATH=/tmp/kubebuilder-template.yaml" >> "$GITHUB_ENV"
       - name: Run create module with module-config
@@ -70,7 +70,7 @@ jobs:
           --insecure \
           --module-config-file ./module-config.yaml \
           --version $MODULE_TEMPLATE_VERSION -v \
-          --output /tmp/module-config-template.yaml
+          --output /tmp/module-config-template.yaml \
           --module-archive-version-overwrite
           echo "MODULE_TEMPLATE_PATH=/tmp/module-config-template.yaml" >> "$GITHUB_ENV"
       - name: Verify module template

--- a/.github/workflows/test-e2e-create-module.yml
+++ b/.github/workflows/test-e2e-create-module.yml
@@ -48,7 +48,6 @@ jobs:
       - name: Run create module with kubebuilder-project
         if: ${{ matrix.e2e-test == 'create_module_kubebuilder_project' }}
         run: |
-          vim ./template-operator/sec-scanners-config.yaml
           kyma alpha create module \
           --name kyma-project.io/module/template-operator \
           --path ./template-operator \
@@ -62,7 +61,6 @@ jobs:
         if: ${{ matrix.e2e-test == 'create_module_module_config' }}
         run: |
           cd ./template-operator
-          vim sec-scanners-config.yaml
           make build-manifests
           kyma alpha create module \
           --name kyma-project.io/module/template-operator \

--- a/.github/workflows/test-e2e-create-module.yml
+++ b/.github/workflows/test-e2e-create-module.yml
@@ -39,6 +39,7 @@ jobs:
       - name: export template-operator URL
         run: |
           cd ./template-operator
+          vim ./sec-scanners-config.yaml
           echo "TEST_REPOSITORY_URL=$(git remote get-url origin)" >> "$GITHUB_ENV"
       - name: Set up k3d
         run: wget -qO - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=$K3D_VERSION bash

--- a/pkg/module/security_scan.go
+++ b/pkg/module/security_scan.go
@@ -16,12 +16,12 @@ import (
 var ErrFailedToParseImageURL = errors.New("error parsing protecode image URL")
 
 const (
-	secScanLabelKey = "scan.security.kyma-project.io"
+	SecScanLabelKey = "scan.security.kyma-project.io"
 	secLabelKey     = "security.kyma-project.io"
 	secScanEnabled  = "enabled"
 )
 
-var labelTemplate = secScanLabelKey + "/%s"
+var labelTemplate = SecScanLabelKey + "/%s"
 var globalLabelTemplate = secLabelKey + "/%s"
 
 func AddSecurityScanningMetadata(descriptor *ocm.ComponentDescriptor, securityConfigPath string) error {

--- a/pkg/module/security_scan.go
+++ b/pkg/module/security_scan.go
@@ -37,17 +37,26 @@ func AddSecurityScanningMetadata(descriptor *ocm.ComponentDescriptor, securityCo
 	if err != nil {
 		return err
 	}
+
 	if len(descriptor.Sources) == 0 {
 		return errors.New("found no sources in component descriptor")
 	}
 	//add whitesource sec scan labels
 	for srcIdx := range descriptor.Sources {
 		src := &descriptor.Sources[srcIdx]
-		err := appendLabelToAccessor(src, "language", config.WhiteSource.Language, labelTemplate)
+		// add dev branch label
+		err = appendLabelToAccessor(src, "dev-branch", config.DevBranch, labelTemplate)
 		if err != nil {
 			return err
 		}
-		err = appendLabelToAccessor(src, "subprojects", config.WhiteSource.SubProjects, labelTemplate)
+
+		// add rc tag label
+		err = appendLabelToAccessor(src, "rc-tag", config.RcTag, labelTemplate)
+		if err != nil {
+			return err
+		}
+
+		err := appendLabelToAccessor(src, "language", config.WhiteSource.Language, labelTemplate)
 		if err != nil {
 			return err
 		}
@@ -117,11 +126,12 @@ type SecurityScanCfg struct {
 	ModuleName  string            `json:"module-name"`
 	Protecode   []string          `json:"protecode"`
 	WhiteSource WhiteSourceSecCfg `json:"whitesource"`
+	DevBranch   string            `json:"dev-branch"`
+	RcTag       string            `json:"rc-tag"`
 }
 type WhiteSourceSecCfg struct {
-	Language    string   `json:"language"`
-	SubProjects string   `json:"subprojects"`
-	Exclude     []string `json:"exclude"`
+	Language string   `json:"language"`
+	Exclude  []string `json:"exclude"`
 }
 
 func parseSecurityScanConfig(securityConfigPath string) (*SecurityScanCfg, error) {

--- a/tests/e2e/kyma_create_module_test.go
+++ b/tests/e2e/kyma_create_module_test.go
@@ -73,6 +73,12 @@ func Test_ModuleTemplate(t *testing.T) {
 	// test security scan labels
 	secScanLabels := descriptor.Sources[0].Labels
 
+	fmt.Println(descriptor.Sources[0].Labels[0].Value)
+	fmt.Println(descriptor.Sources[0].Labels[1].Value)
+	fmt.Println(descriptor.Sources[0].Labels[2].Value)
+	fmt.Println(descriptor.Sources[0].Labels[3].Value)
+	fmt.Println(descriptor.Sources[0].Labels[4].Value)
+
 	var devBranchJson string
 	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "dev-branch"), &devBranchJson)
 	devBranch, err := yaml.Marshal(devBranchJson)
@@ -92,5 +98,5 @@ func Test_ModuleTemplate(t *testing.T) {
 	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "exclude"), &excludeJson)
 	exclude, err := yaml.Marshal(excludeJson)
 	assert.Nil(t, err)
-	assert.Equal(t, "**/test/**,**/*_test.go", string(exclude))
+	assert.Equal(t, "'**/test/**,**/*_test.go'", string(exclude))
 }

--- a/tests/e2e/kyma_create_module_test.go
+++ b/tests/e2e/kyma_create_module_test.go
@@ -71,12 +71,16 @@ func Test_ModuleTemplate(t *testing.T) {
 
 	// test security scan labels
 	assert.Equal(t, len(descriptor.Labels), 5)
-	devBranch := descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "dev-branch"))
+	var devBranch string
+	devBranch := descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "dev-branch"), &devBranch)
 	assert.Equal(t, devBranch, "main")
-	rcTag := descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "rc-tag"))
+	var rcTag string
+	descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "rc-tag"), &rcTag)
 	assert.Equal(t, rcTag, "0.5.0")
-	language := descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "language"))
+	var language string
+	descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "language"), &language)
 	assert.Equal(t, language, "golang-mod")
-	exclude := descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "exclude"))
+	var exclude string
+	descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "exclude"), &exclude)
 	assert.Equal(t, exclude, "**/test/**,**/*_test.go")
 }

--- a/tests/e2e/kyma_create_module_test.go
+++ b/tests/e2e/kyma_create_module_test.go
@@ -3,6 +3,7 @@
 package e2e_test
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -67,4 +68,15 @@ func Test_ModuleTemplate(t *testing.T) {
 	githubAccessSpec, ok := sourceAccessSpec.(*github.AccessSpec)
 	assert.Equal(t, githubAccessSpec.Type, github.Type)
 	assert.Contains(t, testRepoURL, githubAccessSpec.RepoURL)
+
+	// test security scan labels
+	assert.Equal(t, len(descriptor.Labels), 5)
+	devBranch := descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "dev-branch"))
+	assert.Equal(t, devBranch, "main")
+	rcTag := descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "rc-tag"))
+	assert.Equal(t, rcTag, "0.5.0")
+	language := descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "language"))
+	assert.Equal(t, language, "golang-mod")
+	exclude := descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "exclude"))
+	assert.Equal(t, exclude, "**/test/**,**/*_test.go")
 }

--- a/tests/e2e/kyma_create_module_test.go
+++ b/tests/e2e/kyma_create_module_test.go
@@ -3,7 +3,6 @@
 package e2e_test
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
@@ -19,6 +18,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/genericocireg"
 	ocmOCIReg "github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/ocireg"
+	"gopkg.in/yaml.v3"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -75,22 +75,22 @@ func Test_ModuleTemplate(t *testing.T) {
 
 	var devBranchJson string
 	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "dev-branch"), &devBranchJson)
-	devBranch, err := json.Marshal(&devBranchJson)
+	devBranch, err := yaml.Marshal(devBranchJson)
 	assert.Nil(t, err)
 	assert.Equal(t, "main", string(devBranch))
 	var rcTagJson string
 	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "rc-tag"), &rcTagJson)
-	rcTag, err := json.Marshal(&rcTagJson)
+	rcTag, err := yaml.Marshal(rcTagJson)
 	assert.Nil(t, err)
 	assert.Equal(t, "0.5.0", string(rcTag))
 	var languageJson string
 	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "language"), &languageJson)
-	language, err := json.Marshal(&languageJson)
+	language, err := yaml.Marshal(languageJson)
 	assert.Nil(t, err)
 	assert.Equal(t, "golang-mod", string(language))
 	var excludeJson string
 	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "exclude"), &excludeJson)
-	exclude, err := json.Marshal(&excludeJson)
+	exclude, err := yaml.Marshal(excludeJson)
 	assert.Nil(t, err)
 	assert.Equal(t, "**/test/**,**/*_test.go", string(exclude))
 }

--- a/tests/e2e/kyma_create_module_test.go
+++ b/tests/e2e/kyma_create_module_test.go
@@ -86,5 +86,5 @@ func Test_ModuleTemplate(t *testing.T) {
 
 	var exclude string
 	yaml.Unmarshal(secScanLabels[4].Value, &exclude)
-	assert.Equal(t, "'**/test/**,**/*_test.go'", exclude)
+	assert.Equal(t, "**/test/**,**/*_test.go", exclude)
 }

--- a/tests/e2e/kyma_create_module_test.go
+++ b/tests/e2e/kyma_create_module_test.go
@@ -72,7 +72,7 @@ func Test_ModuleTemplate(t *testing.T) {
 	// test security scan labels
 	assert.Equal(t, len(descriptor.Labels), 5)
 	var devBranch string
-	devBranch := descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "dev-branch"), &devBranch)
+	descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "dev-branch"), &devBranch)
 	assert.Equal(t, devBranch, "main")
 	var rcTag string
 	descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "rc-tag"), &rcTag)

--- a/tests/e2e/kyma_create_module_test.go
+++ b/tests/e2e/kyma_create_module_test.go
@@ -77,20 +77,20 @@ func Test_ModuleTemplate(t *testing.T) {
 	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "dev-branch"), &devBranchJson)
 	devBranch, err := json.Marshal(&devBranchJson)
 	assert.Nil(t, err)
-	assert.Equal(t, "main", devBranch)
+	assert.Equal(t, "main", string(devBranch))
 	var rcTagJson string
 	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "rc-tag"), &rcTagJson)
 	rcTag, err := json.Marshal(&rcTagJson)
 	assert.Nil(t, err)
-	assert.Equal(t, "0.5.0", rcTag)
+	assert.Equal(t, "0.5.0", string(rcTag))
 	var languageJson string
 	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "language"), &languageJson)
 	language, err := json.Marshal(&languageJson)
 	assert.Nil(t, err)
-	assert.Equal(t, "golang-mod", language)
+	assert.Equal(t, "golang-mod", string(language))
 	var excludeJson string
 	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "exclude"), &excludeJson)
 	exclude, err := json.Marshal(&excludeJson)
 	assert.Nil(t, err)
-	assert.Equal(t, "**/test/**,**/*_test.go", exclude)
+	assert.Equal(t, "**/test/**,**/*_test.go", string(exclude))
 }

--- a/tests/e2e/kyma_create_module_test.go
+++ b/tests/e2e/kyma_create_module_test.go
@@ -85,6 +85,6 @@ func Test_ModuleTemplate(t *testing.T) {
 	assert.Equal(t, "golang-mod", language)
 
 	var exclude string
-	yaml.Unmarshal(secScanLabels[3].Value, &exclude)
+	yaml.Unmarshal(secScanLabels[4].Value, &exclude)
 	assert.Equal(t, "'**/test/**,**/*_test.go'", exclude)
 }

--- a/tests/e2e/kyma_create_module_test.go
+++ b/tests/e2e/kyma_create_module_test.go
@@ -3,6 +3,7 @@
 package e2e_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
@@ -71,18 +72,17 @@ func Test_ModuleTemplate(t *testing.T) {
 
 	// test security scan labels
 	secScanLabels := descriptor.Sources[0].Labels
-	fmt.Println(secScanLabels[0].Value)
 
 	var devBranch string
 	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "dev-branch"), &devBranch)
-	assert.Equal(t, "main", devBranch)
+	assert.Equal(t, "main", json.Marshal(&devBranch))
 	var rcTag string
 	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "rc-tag"), &rcTag)
-	assert.Equal(t, "0.5.0", rcTag)
+	assert.Equal(t, "0.5.0", json.Marshal(&rcTag))
 	var language string
 	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "language"), &language)
-	assert.Equal(t, "golang-mod", language)
+	assert.Equal(t, "golang-mod", json.Marshal(&language))
 	var exclude string
 	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "exclude"), &exclude)
-	assert.Equal(t, "**/test/**,**/*_test.go", exclude)
+	assert.Equal(t, "**/test/**,**/*_test.go", json.Marshal(&exclude))
 }

--- a/tests/e2e/kyma_create_module_test.go
+++ b/tests/e2e/kyma_create_module_test.go
@@ -70,19 +70,18 @@ func Test_ModuleTemplate(t *testing.T) {
 	assert.Contains(t, testRepoURL, githubAccessSpec.RepoURL)
 
 	// test security scan labels
-	fmt.Println(descriptor.Labels[0].Name)
-	fmt.Println(descriptor.Labels[0].Value)
+	secScanLabels := descriptor.Sources[0].Labels
 
 	var devBranch string
-	descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "dev-branch"), &devBranch)
+	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "dev-branch"), &devBranch)
 	assert.Equal(t, "main", devBranch)
 	var rcTag string
-	descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "rc-tag"), &rcTag)
+	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "rc-tag"), &rcTag)
 	assert.Equal(t, "0.5.0", rcTag)
 	var language string
-	descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "language"), &language)
+	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "language"), &language)
 	assert.Equal(t, "golang-mod", language)
 	var exclude string
-	descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "exclude"), &exclude)
+	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "exclude"), &exclude)
 	assert.Equal(t, "**/test/**,**/*_test.go", exclude)
 }

--- a/tests/e2e/kyma_create_module_test.go
+++ b/tests/e2e/kyma_create_module_test.go
@@ -73,11 +73,9 @@ func Test_ModuleTemplate(t *testing.T) {
 	// test security scan labels
 	secScanLabels := descriptor.Sources[0].Labels
 
-	fmt.Println(yaml.Marshal(descriptor.Sources[0].Labels[0].Value))
-	fmt.Println(yaml.Marshal(descriptor.Sources[0].Labels[1].Value))
-	fmt.Println(yaml.Marshal(descriptor.Sources[0].Labels[2].Value))
-	fmt.Println(yaml.Marshal(descriptor.Sources[0].Labels[3].Value))
-	fmt.Println(yaml.Marshal(descriptor.Sources[0].Labels[4].Value))
+	var test string
+	yaml.Unmarshal(descriptor.Sources[0].Labels[0].Value, &test)
+	fmt.Println(test)
 
 	var devBranchJson string
 	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "dev-branch"), &devBranchJson)

--- a/tests/e2e/kyma_create_module_test.go
+++ b/tests/e2e/kyma_create_module_test.go
@@ -71,7 +71,7 @@ func Test_ModuleTemplate(t *testing.T) {
 
 	// test security scan labels
 	secScanLabels := descriptor.Sources[0].Labels
-	fmt.Println(secScanLabels)
+	fmt.Println(secScanLabels[0].Value)
 
 	var devBranch string
 	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "dev-branch"), &devBranch)

--- a/tests/e2e/kyma_create_module_test.go
+++ b/tests/e2e/kyma_create_module_test.go
@@ -73,16 +73,24 @@ func Test_ModuleTemplate(t *testing.T) {
 	// test security scan labels
 	secScanLabels := descriptor.Sources[0].Labels
 
-	var devBranch string
-	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "dev-branch"), &devBranch)
-	assert.Equal(t, "main", json.Marshal(&devBranch))
-	var rcTag string
-	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "rc-tag"), &rcTag)
-	assert.Equal(t, "0.5.0", json.Marshal(&rcTag))
-	var language string
-	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "language"), &language)
-	assert.Equal(t, "golang-mod", json.Marshal(&language))
-	var exclude string
-	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "exclude"), &exclude)
-	assert.Equal(t, "**/test/**,**/*_test.go", json.Marshal(&exclude))
+	var devBranchJson string
+	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "dev-branch"), &devBranchJson)
+	devBranch, err := json.Marshal(&devBranchJson)
+	assert.Nil(t, err)
+	assert.Equal(t, "main", devBranch)
+	var rcTagJson string
+	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "rc-tag"), &rcTagJson)
+	rcTag, err := json.Marshal(&rcTagJson)
+	assert.Nil(t, err)
+	assert.Equal(t, "0.5.0", rcTag)
+	var languageJson string
+	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "language"), &languageJson)
+	language, err := json.Marshal(&languageJson)
+	assert.Nil(t, err)
+	assert.Equal(t, "golang-mod", language)
+	var excludeJson string
+	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "exclude"), &excludeJson)
+	exclude, err := json.Marshal(&excludeJson)
+	assert.Nil(t, err)
+	assert.Equal(t, "**/test/**,**/*_test.go", exclude)
 }

--- a/tests/e2e/kyma_create_module_test.go
+++ b/tests/e2e/kyma_create_module_test.go
@@ -3,7 +3,6 @@
 package e2e_test
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -73,34 +72,19 @@ func Test_ModuleTemplate(t *testing.T) {
 	// test security scan labels
 	secScanLabels := descriptor.Sources[0].Labels
 
-	var test string
-	yaml.Unmarshal(descriptor.Sources[0].Labels[1].Value, &test)
-	fmt.Println(test)
-	yaml.Unmarshal(descriptor.Sources[0].Labels[2].Value, &test)
-	fmt.Println(test)
-	yaml.Unmarshal(descriptor.Sources[0].Labels[3].Value, &test)
-	fmt.Println(test)
-	yaml.Unmarshal(descriptor.Sources[0].Labels[4].Value, &test)
-	fmt.Println(test)
+	var devBranch string
+	yaml.Unmarshal(secScanLabels[1].Value, &devBranch)
+	assert.Equal(t, "main", devBranch)
 
-	var devBranchJson string
-	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "dev-branch"), &devBranchJson)
-	devBranch, err := yaml.Marshal(devBranchJson)
-	assert.Nil(t, err)
-	assert.Equal(t, "main", string(devBranch))
-	var rcTagJson string
-	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "rc-tag"), &rcTagJson)
-	rcTag, err := yaml.Marshal(rcTagJson)
-	assert.Nil(t, err)
-	assert.Equal(t, "0.5.0", string(rcTag))
-	var languageJson string
-	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "language"), &languageJson)
-	language, err := yaml.Marshal(languageJson)
-	assert.Nil(t, err)
-	assert.Equal(t, "golang-mod", string(language))
-	var excludeJson string
-	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "exclude"), &excludeJson)
-	exclude, err := yaml.Marshal(excludeJson)
-	assert.Nil(t, err)
-	assert.Equal(t, "'**/test/**,**/*_test.go'", string(exclude))
+	var rcTag string
+	yaml.Unmarshal(secScanLabels[2].Value, &rcTag)
+	assert.Equal(t, "0.5.0", rcTag)
+
+	var language string
+	yaml.Unmarshal(secScanLabels[3].Value, &language)
+	assert.Equal(t, "golang-mod", language)
+
+	var exclude string
+	yaml.Unmarshal(secScanLabels[3].Value, &exclude)
+	assert.Equal(t, "'**/test/**,**/*_test.go'", exclude)
 }

--- a/tests/e2e/kyma_create_module_test.go
+++ b/tests/e2e/kyma_create_module_test.go
@@ -73,11 +73,11 @@ func Test_ModuleTemplate(t *testing.T) {
 	// test security scan labels
 	secScanLabels := descriptor.Sources[0].Labels
 
-	fmt.Println(descriptor.Sources[0].Labels[0].Value)
-	fmt.Println(descriptor.Sources[0].Labels[1].Value)
-	fmt.Println(descriptor.Sources[0].Labels[2].Value)
-	fmt.Println(descriptor.Sources[0].Labels[3].Value)
-	fmt.Println(descriptor.Sources[0].Labels[4].Value)
+	fmt.Println(yaml.Marshal(descriptor.Sources[0].Labels[0].Value))
+	fmt.Println(yaml.Marshal(descriptor.Sources[0].Labels[1].Value))
+	fmt.Println(yaml.Marshal(descriptor.Sources[0].Labels[2].Value))
+	fmt.Println(yaml.Marshal(descriptor.Sources[0].Labels[3].Value))
+	fmt.Println(yaml.Marshal(descriptor.Sources[0].Labels[4].Value))
 
 	var devBranchJson string
 	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "dev-branch"), &devBranchJson)

--- a/tests/e2e/kyma_create_module_test.go
+++ b/tests/e2e/kyma_create_module_test.go
@@ -70,8 +70,9 @@ func Test_ModuleTemplate(t *testing.T) {
 	assert.Contains(t, testRepoURL, githubAccessSpec.RepoURL)
 
 	// test security scan labels
-	fmt.Println(descriptor.Labels)
-	assert.Equal(t, 5, len(descriptor.Labels))
+	fmt.Println(descriptor.Labels[0].Name)
+	fmt.Println(descriptor.Labels[0].Value)
+
 	var devBranch string
 	descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "dev-branch"), &devBranch)
 	assert.Equal(t, "main", devBranch)

--- a/tests/e2e/kyma_create_module_test.go
+++ b/tests/e2e/kyma_create_module_test.go
@@ -70,17 +70,18 @@ func Test_ModuleTemplate(t *testing.T) {
 	assert.Contains(t, testRepoURL, githubAccessSpec.RepoURL)
 
 	// test security scan labels
-	assert.Equal(t, len(descriptor.Labels), 5)
+	fmt.Println(descriptor.Labels)
+	assert.Equal(t, 5, len(descriptor.Labels))
 	var devBranch string
 	descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "dev-branch"), &devBranch)
-	assert.Equal(t, devBranch, "main")
+	assert.Equal(t, "main", devBranch)
 	var rcTag string
 	descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "rc-tag"), &rcTag)
-	assert.Equal(t, rcTag, "0.5.0")
+	assert.Equal(t, "0.5.0", rcTag)
 	var language string
 	descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "language"), &language)
-	assert.Equal(t, language, "golang-mod")
+	assert.Equal(t, "golang-mod", language)
 	var exclude string
 	descriptor.Labels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "exclude"), &exclude)
-	assert.Equal(t, exclude, "**/test/**,**/*_test.go")
+	assert.Equal(t, "**/test/**,**/*_test.go", exclude)
 }

--- a/tests/e2e/kyma_create_module_test.go
+++ b/tests/e2e/kyma_create_module_test.go
@@ -74,7 +74,13 @@ func Test_ModuleTemplate(t *testing.T) {
 	secScanLabels := descriptor.Sources[0].Labels
 
 	var test string
-	yaml.Unmarshal(descriptor.Sources[0].Labels[0].Value, &test)
+	yaml.Unmarshal(descriptor.Sources[0].Labels[1].Value, &test)
+	fmt.Println(test)
+	yaml.Unmarshal(descriptor.Sources[0].Labels[2].Value, &test)
+	fmt.Println(test)
+	yaml.Unmarshal(descriptor.Sources[0].Labels[3].Value, &test)
+	fmt.Println(test)
+	yaml.Unmarshal(descriptor.Sources[0].Labels[4].Value, &test)
 	fmt.Println(test)
 
 	var devBranchJson string

--- a/tests/e2e/kyma_create_module_test.go
+++ b/tests/e2e/kyma_create_module_test.go
@@ -71,6 +71,7 @@ func Test_ModuleTemplate(t *testing.T) {
 
 	// test security scan labels
 	secScanLabels := descriptor.Sources[0].Labels
+	fmt.Println(secScanLabels)
 
 	var devBranch string
 	secScanLabels.GetValue(fmt.Sprintf("%s/%s", module.SecScanLabelKey, "dev-branch"), &devBranch)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Reflect the fields changes in the security config files when generating ModuleTemplate using create module command
- Remove `/whitsource/subprojects` field 
- Add `rc-tag` and `dev-branch` fields

**Related issue(s)**
Resolves #1755 
