### PR TITLE
Increase Retries and Delay for Manifest applying

### DIFF
--- a/internal/deploy/apply.go
+++ b/internal/deploy/apply.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	defaultRetries        = 3
-	defaultInitialBackoff = 3 * time.Second
+	defaultRetries        = 5
+	defaultInitialBackoff = 10 * time.Second
 )
 
 type applyOpts struct {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Since in some scenarios, like `control-plane` kustomize incl. Watcher enables, the kustomize need at least second try with already the KLM up and running, since the Watcher CRs need to have a ready `klm-webhook-service` available to be created. Thus time should be increased. Right now it is 9 seconds in total, which is in general a bit less in my opinion.


Changes proposed in this pull request:

- Increased `defaultRetries` to 5
- Increased `defaultInitialBackoff` to 10 seconds

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
