### PR TITLE
fix: Fix controller runtime logs for the create module command

### DIFF
--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/klog/v2"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // NewLogger returns the logger used for CLI log output (used in Hydroform deployments)
@@ -25,6 +26,7 @@ func NewLogger(printLogs bool) *zap.Logger {
 		logger = zap.NewNop()
 	}
 	logr := zapr.NewLoggerWithOptions(logger)
+	ctrllog.SetLogger(zapr.NewLoggerWithOptions(zap.NewNop()))
 	klog.SetLogger(logr)
 	ocm.DefaultContext().LoggingContext().SetBaseLogger(logr)
 	ocm.DefaultContext().LoggingContext().SetDefaultLevel(9)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Use SetLogger for the controller runtime to avoid printing the `[controller-runtime] log.SetLogger(...) was never called, logs will not be displayed:`

Note: In order to reproduce the issue before that fix, you need to **debug** the create module command. Running the command from the terminal does not print the above log.

**Related issue(s)**
Resolves #1763 
