### PR TITLE
fix: Fix e2e tests for the ModuleTemplate creation after the template operator upgrade

### DIFF
--- a/.github/workflows/test-e2e-create-module.yml
+++ b/.github/workflows/test-e2e-create-module.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       K3D_VERSION: v5.4.7
-      MODULE_TEMPLATE_VERSION: 0.1.0
+      MODULE_TEMPLATE_VERSION: 0.1.2
       OCI_REPOSITORY_URL: http://k3d-oci.localhost:5001
     steps:
       - name: Checkout Kyma CLI

--- a/tests/e2e/create_module/kyma_create_module_test.go
+++ b/tests/e2e/create_module/kyma_create_module_test.go
@@ -69,7 +69,7 @@ func Test_ModuleTemplate(t *testing.T) {
 		ociArtifactAccessSpec, ok := resourceAccessSpec.(*ociartifact.AccessSpec)
 		assert.True(t, ok)
 		assert.Equal(t, ociartifact.Type, ociArtifactAccessSpec.GetType())
-		assert.Equal(t, "europe-docker.pkg.dev/kyma-project/prod/template-operator:0.1.0",
+		assert.Equal(t, "europe-docker.pkg.dev/kyma-project/prod/template-operator:0.1.2",
 			ociArtifactAccessSpec.ImageReference)
 	})
 
@@ -102,7 +102,7 @@ func Test_ModuleTemplate(t *testing.T) {
 		flattened := e2e.Flatten(secScanLabels)
 		assert.Equal(t, map[string]string{
 			"git.kyma-project.io/ref":                   "refs/heads/main",
-			"scan.security.kyma-project.io/rc-tag":      "0.1.0",
+			"scan.security.kyma-project.io/rc-tag":      "0.1.2",
 			"scan.security.kyma-project.io/language":    "golang-mod",
 			"scan.security.kyma-project.io/dev-branch":  "main",
 			"scan.security.kyma-project.io/subprojects": "false",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix e2e tests for the moduletemplate creation after the template operator upgrade

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
