### PR TITLE
Add option to define owner of cluster during provisioning

### DIFF
--- a/internal/cmd/provision/provision.go
+++ b/internal/cmd/provision/provision.go
@@ -14,6 +14,7 @@ type provisionConfig struct {
 	environmentName string
 	clusterName     string
 	region          string
+	owner           string
 }
 
 func NewProvisionCMD() *cobra.Command {
@@ -36,8 +37,10 @@ func NewProvisionCMD() *cobra.Command {
 	cmd.Flags().StringVar(&config.environmentName, "environment-name", "kyma", "Name of the environment in the BTP.")
 	cmd.Flags().StringVar(&config.clusterName, "cluster-name", "kyma", "Name of the Kyma cluster.")
 	cmd.Flags().StringVar(&config.region, "region", "", "Name of the region of the Kyma cluster.")
+	cmd.Flags().StringVar(&config.owner, "owner", "", "Email of the owner of the Kyma cluster.")
 
 	_ = cmd.MarkFlagRequired("credentials-path")
+	_ = cmd.MarkFlagRequired("owner")
 
 	return cmd
 }
@@ -66,7 +69,7 @@ func runProvision(config *provisionConfig) error {
 		EnvironmentType: "kyma",
 		PlanName:        config.plan,
 		Name:            config.environmentName,
-		User:            "kyma-cli",
+		User:            config.owner,
 		Parameters: cis.KymaParameters{
 			Name:   config.clusterName,
 			Region: config.region,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add option to define owner of cluster during provisioning

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- #2024