### PR TITLE
Make code about kubeconfig more generic

### DIFF
--- a/internal/cmd/hana/check.go
+++ b/internal/cmd/hana/check.go
@@ -47,7 +47,6 @@ func NewHanaCheckCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	cmd.Flags().StringVar(&config.name, "name", "", "Name of Hana instance.")
 	cmd.Flags().StringVar(&config.namespace, "namespace", "default", "Namespace for Hana instance.")
 
-	_ = cmd.MarkFlagRequired("kubeconfig")
 	_ = cmd.MarkFlagRequired("name")
 
 	return cmd

--- a/internal/cmd/hana/credentials.go
+++ b/internal/cmd/hana/credentials.go
@@ -50,7 +50,6 @@ func NewHanaCredentialsCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	cmd.Flags().BoolVar(&config.user, "user", false, "Print only user name")
 	cmd.Flags().BoolVar(&config.password, "password", false, "Print only password")
 
-	_ = cmd.MarkFlagRequired("kubeconfig")
 	_ = cmd.MarkFlagRequired("name")
 	cmd.MarkFlagsMutuallyExclusive("user", "password")
 

--- a/internal/cmd/hana/delete.go
+++ b/internal/cmd/hana/delete.go
@@ -42,7 +42,6 @@ func NewHanaDeleteCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	cmd.Flags().StringVar(&config.name, "name", "", "Name of Hana instance.")
 	cmd.Flags().StringVar(&config.namespace, "namespace", "default", "Namespace for Hana instance.")
 
-	_ = cmd.MarkFlagRequired("kubeconfig")
 	_ = cmd.MarkFlagRequired("name")
 
 	return cmd

--- a/internal/cmd/hana/delete.go
+++ b/internal/cmd/hana/delete.go
@@ -6,7 +6,6 @@ import (
 	"github.com/kyma-project/cli.v3/internal/btp/operator"
 	"github.com/kyma-project/cli.v3/internal/clierror"
 	"github.com/kyma-project/cli.v3/internal/cmdcommon"
-	"github.com/kyma-project/cli.v3/internal/kube"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,16 +13,16 @@ import (
 
 type hanaDeleteConfig struct {
 	*cmdcommon.KymaConfig
-	kubeClient kube.Client
+	cmdcommon.KubeClientConfig
 
-	kubeconfig string
-	name       string
-	namespace  string
+	name      string
+	namespace string
 }
 
 func NewHanaDeleteCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	config := hanaDeleteConfig{
-		KymaConfig: kymaConfig,
+		KymaConfig:       kymaConfig,
+		KubeClientConfig: cmdcommon.KubeClientConfig{},
 	}
 
 	cmd := &cobra.Command{
@@ -31,14 +30,14 @@ func NewHanaDeleteCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 		Short: "Delete a Hana instance on the Kyma.",
 		Long:  "Use this command to delete a Hana instance on the SAP Kyma platform.",
 		PreRunE: func(_ *cobra.Command, args []string) error {
-			return config.complete()
+			return config.KubeClientConfig.Complete()
 		},
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runDelete(&config)
 		},
 	}
 
-	cmd.Flags().StringVar(&config.kubeconfig, "kubeconfig", "", "Path to the Kyma kubecongig file.")
+	config.KubeClientConfig.AddFlag(cmd)
 
 	cmd.Flags().StringVar(&config.name, "name", "", "Name of Hana instance.")
 	cmd.Flags().StringVar(&config.namespace, "namespace", "default", "Namespace for Hana instance.")
@@ -47,13 +46,6 @@ func NewHanaDeleteCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	_ = cmd.MarkFlagRequired("name")
 
 	return cmd
-}
-
-func (pc *hanaDeleteConfig) complete() error {
-	var err error
-	pc.kubeClient, err = kube.NewClient(pc.kubeconfig)
-
-	return err
 }
 
 var (
@@ -78,14 +70,14 @@ func runDelete(config *hanaDeleteConfig) error {
 }
 
 func deleteHanaInstance(config *hanaDeleteConfig) error {
-	err := config.kubeClient.Dynamic().Resource(operator.GVRServiceInstance).
+	err := config.KubeClient.Dynamic().Resource(operator.GVRServiceInstance).
 		Namespace(config.namespace).
 		Delete(config.Ctx, config.name, metav1.DeleteOptions{})
 	return handleDeleteResponse(err, "Hana instance", config.namespace, config.name)
 }
 
 func deleteHanaBinding(config *hanaDeleteConfig) error {
-	err := config.kubeClient.Dynamic().Resource(operator.GVRServiceBinding).
+	err := config.KubeClient.Dynamic().Resource(operator.GVRServiceBinding).
 		Namespace(config.namespace).
 		Delete(config.Ctx, config.name, metav1.DeleteOptions{})
 	return handleDeleteResponse(err, "Hana binding", config.namespace, config.name)
@@ -93,7 +85,7 @@ func deleteHanaBinding(config *hanaDeleteConfig) error {
 
 func deleteHanaBindingUrl(config *hanaDeleteConfig) error {
 	urlName := hanaBindingUrlName(config.name)
-	err := config.kubeClient.Dynamic().Resource(operator.GVRServiceBinding).
+	err := config.KubeClient.Dynamic().Resource(operator.GVRServiceBinding).
 		Namespace(config.namespace).
 		Delete(config.Ctx, urlName, metav1.DeleteOptions{})
 	return handleDeleteResponse(err, "Hana URL binding", config.namespace, urlName)

--- a/internal/cmd/hana/map.go
+++ b/internal/cmd/hana/map.go
@@ -45,7 +45,6 @@ func NewMapHanaCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	cmd.Flags().StringVar(&config.namespace, "namespace", "default", "Namespace for Hana instance.")
 	cmd.Flags().DurationVar(&config.timeout, "timeout", 7*time.Minute, "Timeout for the command")
 
-	_ = cmd.MarkFlagRequired("kubeconfig")
 	_ = cmd.MarkFlagRequired("name")
 
 	return cmd

--- a/internal/cmd/hana/provision.go
+++ b/internal/cmd/hana/provision.go
@@ -50,7 +50,6 @@ func NewHanaProvisionCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	cmd.Flags().IntVar(&config.cpu, "cpu", 2, "Number of CPUs for Hana.")                                            //TODO: fulfill proper usage
 	cmd.Flags().StringSliceVar(&config.whitelistIP, "whitelist-ip", []string{"0.0.0.0/0"}, "IP whitelist for Hana.") //TODO: fulfill proper usage
 
-	_ = cmd.MarkFlagRequired("kubeconfig")
 	_ = cmd.MarkFlagRequired("name")
 
 	return cmd

--- a/internal/cmd/hana/provision.go
+++ b/internal/cmd/hana/provision.go
@@ -6,7 +6,6 @@ import (
 	"github.com/kyma-project/cli.v3/internal/btp/operator"
 	"github.com/kyma-project/cli.v3/internal/clierror"
 	"github.com/kyma-project/cli.v3/internal/cmdcommon"
-	"github.com/kyma-project/cli.v3/internal/kube"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -14,9 +13,8 @@ import (
 
 type hanaProvisionConfig struct {
 	*cmdcommon.KymaConfig
-	kubeClient kube.Client
+	cmdcommon.KubeClientConfig
 
-	kubeconfig  string
 	name        string
 	namespace   string
 	planName    string
@@ -27,7 +25,8 @@ type hanaProvisionConfig struct {
 
 func NewHanaProvisionCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	config := hanaProvisionConfig{
-		KymaConfig: kymaConfig,
+		KymaConfig:       kymaConfig,
+		KubeClientConfig: cmdcommon.KubeClientConfig{},
 	}
 
 	cmd := &cobra.Command{
@@ -35,14 +34,14 @@ func NewHanaProvisionCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 		Short: "Provisions a Hana instance on the Kyma.",
 		Long:  "Use this command to provision a Hana instance on the SAP Kyma platform.",
 		PreRunE: func(_ *cobra.Command, args []string) error {
-			return config.complete()
+			return config.KubeClientConfig.Complete()
 		},
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runProvision(&config)
 		},
 	}
 
-	cmd.Flags().StringVar(&config.kubeconfig, "kubeconfig", "", "Path to the Kyma kubecongig file.")
+	config.KubeClientConfig.AddFlag(cmd)
 
 	cmd.Flags().StringVar(&config.name, "name", "", "Name of Hana instance.")
 	cmd.Flags().StringVar(&config.namespace, "namespace", "default", "Namespace for Hana instance.")
@@ -55,13 +54,6 @@ func NewHanaProvisionCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	_ = cmd.MarkFlagRequired("name")
 
 	return cmd
-}
-
-func (pc *hanaProvisionConfig) complete() error {
-	var err error
-	pc.kubeClient, err = kube.NewClient(pc.kubeconfig)
-
-	return err
 }
 
 var (
@@ -86,21 +78,21 @@ func runProvision(config *hanaProvisionConfig) error {
 }
 
 func createHanaInstance(config *hanaProvisionConfig) error {
-	_, err := config.kubeClient.Dynamic().Resource(operator.GVRServiceInstance).
+	_, err := config.KubeClient.Dynamic().Resource(operator.GVRServiceInstance).
 		Namespace(config.namespace).
 		Create(config.Ctx, hanaInstance(config), metav1.CreateOptions{})
 	return handleProvisionResponse(err, "Hana instance", config.namespace, config.name)
 }
 
 func createHanaBinding(config *hanaProvisionConfig) error {
-	_, err := config.kubeClient.Dynamic().Resource(operator.GVRServiceBinding).
+	_, err := config.KubeClient.Dynamic().Resource(operator.GVRServiceBinding).
 		Namespace(config.namespace).
 		Create(config.Ctx, hanaBinding(config), metav1.CreateOptions{})
 	return handleProvisionResponse(err, "Hana binding", config.namespace, config.name)
 }
 
 func createHanaBindingUrl(config *hanaProvisionConfig) error {
-	_, err := config.kubeClient.Dynamic().Resource(operator.GVRServiceBinding).
+	_, err := config.KubeClient.Dynamic().Resource(operator.GVRServiceBinding).
 		Namespace(config.namespace).
 		Create(config.Ctx, hanaBindingUrl(config), metav1.CreateOptions{})
 	return handleProvisionResponse(err, "Hana URL binding", config.namespace, hanaBindingUrlName(config.name))

--- a/internal/cmd/kyma.go
+++ b/internal/cmd/kyma.go
@@ -3,11 +3,11 @@ package cmd
 import (
 	"context"
 
-	"github.com/kyma-project/cli.v3/internal/cmdcommon"
 	"github.com/kyma-project/cli.v3/internal/cmd/hana"
 	"github.com/kyma-project/cli.v3/internal/cmd/imageimport"
 	"github.com/kyma-project/cli.v3/internal/cmd/provision"
 	"github.com/kyma-project/cli.v3/internal/cmd/referenceinstance"
+	"github.com/kyma-project/cli.v3/internal/cmdcommon"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cmd/referenceinstance/referenceinstance.go
+++ b/internal/cmd/referenceinstance/referenceinstance.go
@@ -54,7 +54,6 @@ func NewReferenceInstanceCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	cmd.MarkFlagsMutuallyExclusive("instance-id", "name-selector")
 	cmd.MarkFlagsMutuallyExclusive("instance-id", "plan-selector")
 
-	_ = cmd.MarkFlagRequired("kubeconfig")
 	_ = cmd.MarkFlagRequired("offering-name")
 	_ = cmd.MarkFlagRequired("reference-name")
 

--- a/internal/cmdcommon/kubeconfig.go
+++ b/internal/cmdcommon/kubeconfig.go
@@ -1,0 +1,23 @@
+package cmdcommon
+
+import (
+	"github.com/kyma-project/cli.v3/internal/kube"
+	"github.com/spf13/cobra"
+)
+
+// KubeClientConfig allows to setup kubeconfig flag and use it to create kube.Client
+type KubeClientConfig struct {
+	Kubeconfig string
+	KubeClient kube.Client
+}
+
+func (kcc *KubeClientConfig) AddFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&kcc.Kubeconfig, "kubeconfig", "", "Path to the Kyma kubecongig file.")
+}
+
+func (kcc *KubeClientConfig) Complete() error {
+	var err error
+	kcc.KubeClient, err = kube.NewClient(kcc.Kubeconfig)
+
+	return err
+}

--- a/internal/cmdcommon/kubeconfig.go
+++ b/internal/cmdcommon/kubeconfig.go
@@ -13,6 +13,8 @@ type KubeClientConfig struct {
 
 func (kcc *KubeClientConfig) AddFlag(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&kcc.Kubeconfig, "kubeconfig", "", "Path to the Kyma kubecongig file.")
+
+	_ = cmd.MarkFlagRequired("kubeconfig")
 }
 
 func (kcc *KubeClientConfig) Complete() error {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- create the kubeconfig flag and its usage in one place
- move flag creation to the cmdcommon pkg
- move kube.Client creation to the cmdcommon pkg

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/cli/issues/2033#issue-2225406939