### PR TITLE
Fix typo in kubeconfig flag help

### DIFF
--- a/internal/cmdcommon/kubeconfig.go
+++ b/internal/cmdcommon/kubeconfig.go
@@ -13,7 +13,7 @@ type KubeClientConfig struct {
 }
 
 func (kcc *KubeClientConfig) AddFlag(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&kcc.Kubeconfig, "kubeconfig", "", "Path to the Kyma kubecongig file.")
+	cmd.Flags().StringVar(&kcc.Kubeconfig, "kubeconfig", "", "Path to the Kyma kubeconfig file.")
 }
 
 func (kcc *KubeClientConfig) Complete() clierror.Error {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Fix typo in kubeconfig flag help

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
