### PR TITLE
OIDC: allow retrieving kubeconfig from BTP

### DIFF
--- a/internal/btp/cis/kubeconfig.go
+++ b/internal/btp/cis/kubeconfig.go
@@ -1,0 +1,81 @@
+package cis
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/kyma-project/cli.v3/internal/clierror"
+)
+
+const environmentsEndpoint = "provisioning/v1/environments"
+
+type Labels struct {
+	APIServerURL  string `json:"APIServerURL"`
+	KubeconfigURL string `json:"KubeconfigURL"`
+	Name          string `json:"Name"`
+}
+
+type environmentInstances struct {
+	EnvironmentInstances []ProvisionResponse `json:"environmentInstances"`
+}
+
+func (c *LocalClient) GetKymaKubeconfig() (string, clierror.Error) {
+	provisionURL := fmt.Sprintf("%s/%s", c.credentials.Endpoints.ProvisioningServiceURL, environmentsEndpoint)
+
+	response, err := c.cis.get(provisionURL, requestOptions{})
+	if err != nil {
+		// TODO: finish
+		return "", clierror.New(err.Error())
+	}
+
+	defer response.Body.Close()
+
+	return decodeKubeconfig(response)
+
+}
+
+func decodeKubeconfig(response *http.Response) (string, clierror.Error) {
+	envInstances := environmentInstances{}
+	err := json.NewDecoder(response.Body).Decode(&envInstances)
+	if err != nil {
+		return "", clierror.Wrap(err, clierror.New("failed to decode response"))
+	}
+
+	// we assume there can be only one Kyma environment in the BTP subaccount
+	for _, env := range envInstances.EnvironmentInstances {
+		if env.EnvironmentType == "kyma" {
+			// parse labels to get kubeconfig URL
+			labels := Labels{}
+			err := json.Unmarshal([]byte(env.Labels), &labels)
+			if err != nil {
+				return "", clierror.Wrap(err, clierror.New("failed to unmarshal labels"))
+			}
+
+			kubeconfig, err := getKubeconfig(labels.KubeconfigURL)
+			if err != nil {
+				return "", clierror.Wrap(err, clierror.New("failed to get kubeconfig"))
+			}
+			return kubeconfig, nil
+		}
+	}
+
+	return "", clierror.New("no Kyma environment found")
+}
+
+func getKubeconfig(url string) (string, error) {
+	response, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+
+	defer response.Body.Close()
+
+	kubeconfig, err := io.ReadAll(response.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(kubeconfig), nil
+}

--- a/internal/btp/cis/kubeconfig.go
+++ b/internal/btp/cis/kubeconfig.go
@@ -26,17 +26,17 @@ func (c *LocalClient) GetKymaKubeconfig() (string, clierror.Error) {
 
 	response, err := c.cis.get(provisionURL, requestOptions{})
 	if err != nil {
-		// TODO: finish
+		// TODO: finish - error codes?
 		return "", clierror.New(err.Error())
 	}
 
 	defer response.Body.Close()
 
-	return decodeKubeconfig(response)
+	return decodeResponse(response)
 
 }
 
-func decodeKubeconfig(response *http.Response) (string, clierror.Error) {
+func decodeResponse(response *http.Response) (string, clierror.Error) {
 	envInstances := environmentInstances{}
 	err := json.NewDecoder(response.Body).Decode(&envInstances)
 	if err != nil {
@@ -53,7 +53,7 @@ func decodeKubeconfig(response *http.Response) (string, clierror.Error) {
 				return "", clierror.Wrap(err, clierror.New("failed to unmarshal labels"))
 			}
 
-			kubeconfig, err := getKubeconfig(labels.KubeconfigURL)
+			kubeconfig, err := downloadKubeconfig(labels.KubeconfigURL)
 			if err != nil {
 				return "", clierror.Wrap(err, clierror.New("failed to get kubeconfig"))
 			}
@@ -64,12 +64,11 @@ func decodeKubeconfig(response *http.Response) (string, clierror.Error) {
 	return "", clierror.New("no Kyma environment found")
 }
 
-func getKubeconfig(url string) (string, error) {
+func downloadKubeconfig(url string) (string, error) {
 	response, err := http.Get(url)
 	if err != nil {
 		return "", err
 	}
-
 	defer response.Body.Close()
 
 	kubeconfig, err := io.ReadAll(response.Body)

--- a/internal/btp/cis/provision.go
+++ b/internal/btp/cis/provision.go
@@ -54,8 +54,6 @@ type ProvisionResponse struct {
 	StateMessage    string `json:"stateMessage"`
 	ServiceName     string `json:"serviceName"`
 	PlanName        string `json:"planName"`
-	CreatedBy       string `json:"createdBy,omitempty"`
-	ModifiedBy      string `json:"modifiedBy,omitempty"`
 }
 
 func (c *LocalClient) Provision(pe *ProvisionEnvironment) (*ProvisionResponse, clierror.Error) {

--- a/internal/btp/cis/provision.go
+++ b/internal/btp/cis/provision.go
@@ -54,6 +54,8 @@ type ProvisionResponse struct {
 	StateMessage    string `json:"stateMessage"`
 	ServiceName     string `json:"serviceName"`
 	PlanName        string `json:"planName"`
+	CreatedBy       string `json:"createdBy,omitempty"`
+	ModifiedBy      string `json:"modifiedBy,omitempty"`
 }
 
 func (c *LocalClient) Provision(pe *ProvisionEnvironment) (*ProvisionResponse, clierror.Error) {

--- a/internal/cmd/oidc/oidc.go
+++ b/internal/cmd/oidc/oidc.go
@@ -116,14 +116,15 @@ func runOIDC(cfg *oidcConfig) clierror.Error {
 			return clierror.WrapE(clierr, clierror.New("failed to get token"))
 		}
 	}
-	kubeconfig := &api.Config{}
+
+	var kubeconfig *api.Config
 
 	if cfg.cisCredentialsPath != "" {
 		kubeconfig, clierr = getKubeconfigFromCIS(cfg)
 		if clierr != nil {
 			return clierror.WrapE(clierr, clierror.New("failed to get kubeconfig from CIS"))
 		}
-	} else if cfg.KubeClientConfig.Kubeconfig != "" {
+	} else {
 		kubeconfig = cfg.KubeClient.ApiConfig()
 	}
 

--- a/internal/cmd/oidc/oidc.go
+++ b/internal/cmd/oidc/oidc.go
@@ -77,7 +77,7 @@ func (cfg *oidcConfig) complete() clierror.Error {
 	}
 	cfg.idTokenRequestToken = os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
 
-	if cfg.KubeClientConfig.Kubeconfig != "" {
+	if cfg.cisCredentialsPath == "" {
 		return cfg.KubeClientConfig.Complete()
 	}
 	return nil


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- OIDC: allow retrieving kubeconfig from BTP
- remove separate clusterServer & caCertificate flags to simplify the command by passing whole api.Config inside

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- #2093