### PR TITLE
Add transport layer that retries requests on error

### DIFF
--- a/internal/registry/image.go
+++ b/internal/registry/image.go
@@ -58,7 +58,7 @@ func importImage(ctx context.Context, imageName string, opts ImportOptions, util
 	defer conn.Close()
 
 	localTr := portforward.NewPortforwardTransport(conn, opts.RegistryPodPort)
-	transport := portforward.NewRetryTransport(localTr)
+	transport := portforward.NewOnErrRetryTransport(localTr)
 
 	pushedImage, err := imageToInClusterRegistry(ctx, localImage, transport, opts.RegistryAuth, opts.RegistryPullHost, imageName, utils)
 	if err != nil {

--- a/internal/registry/portforward/retry.go
+++ b/internal/registry/portforward/retry.go
@@ -1,0 +1,61 @@
+package portforward
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// onErrorRetryTransport is a RoundTripper that retries requests on error
+type onErrorRetryTransport struct {
+	inner http.RoundTripper
+}
+
+// NewOnErrRetryTransport creates a new onErrorRetryTransport
+func NewOnErrRetryTransport(inner http.RoundTripper) http.RoundTripper {
+	return &onErrorRetryTransport{
+		inner: inner,
+	}
+}
+
+func (t *onErrorRetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	var errList []error
+	for i := 0; i < 5; i++ {
+		copyReq, err := copyRequest(req)
+		if err != nil {
+			return nil, fmt.Errorf("error copying request: %v", err)
+		}
+
+		resp, err := t.inner.RoundTrip(copyReq)
+		if err == nil {
+			return resp, nil
+		}
+
+		errList = append(errList, err)
+	}
+
+	return nil, errors.Join(errList...)
+}
+
+// copyRequest copies the request to avoid closing the original request body
+func copyRequest(req *http.Request) (*http.Request, error) {
+	copy := req.Clone(req.Context())
+
+	if req.Body == nil {
+		// stop if body is empty
+		return copy, nil
+	}
+
+	commonBodyData, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	copy.Body = io.NopCloser(bytes.NewReader(commonBodyData))
+	req.Body = io.NopCloser(bytes.NewReader(commonBodyData))
+
+	return copy, nil
+
+}

--- a/internal/registry/portforward/retry_test.go
+++ b/internal/registry/portforward/retry_test.go
@@ -1,0 +1,231 @@
+package portforward
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_onErrorRetryTransport_RoundTrip(t *testing.T) {
+	testReqBody := "test"
+
+	type fields struct {
+		inner http.RoundTripper
+	}
+	type args struct {
+		req *http.Request
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *http.Response
+		wantErr error
+	}{
+		{
+			name: "should return response",
+			fields: fields{
+				inner: &fakeTransport{
+					responses: []fakeResponse{
+						{
+							response: &http.Response{},
+							err:      nil,
+						},
+					},
+				},
+			},
+
+			args: args{
+				req: &http.Request{
+					Body: io.NopCloser(bytes.NewReader([]byte(testReqBody))),
+				},
+			},
+
+			want:    &http.Response{},
+			wantErr: nil,
+		},
+		{
+			name: "should return response after 5 retries",
+			fields: fields{
+				inner: &fakeTransport{
+					responses: []fakeResponse{
+						{
+							response: nil,
+							err:      errors.New("test error"),
+						},
+						{
+							response: nil,
+							err:      errors.New("test error"),
+						},
+						{
+							response: nil,
+							err:      errors.New("test error"),
+						},
+						{
+							response: nil,
+							err:      errors.New("test error"),
+						},
+						{
+							response: &http.Response{
+								StatusCode: 123,
+							},
+							err: nil,
+						},
+					},
+				},
+			},
+
+			args: args{
+				req: &http.Request{
+					Body: io.NopCloser(bytes.NewReader([]byte(testReqBody))),
+				},
+			},
+
+			want: &http.Response{
+				StatusCode: 123,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "should return error",
+			fields: fields{
+				inner: &fakeTransport{
+					responses: []fakeResponse{
+						{
+							response: nil,
+							err:      errors.New("test error"),
+						},
+						{
+							response: nil,
+							err:      errors.New("test error"),
+						},
+						{
+							response: nil,
+							err:      errors.New("test error"),
+						},
+						{
+							response: nil,
+							err:      errors.New("test error"),
+						},
+						{
+							response: nil,
+							err:      errors.New("test error"),
+						},
+					},
+				},
+			},
+
+			args: args{
+				req: &http.Request{
+					Body: io.NopCloser(bytes.NewReader([]byte(testReqBody))),
+				},
+			},
+
+			want: nil,
+			wantErr: errors.Join(
+				errors.New("test error"),
+				errors.New("test error"),
+				errors.New("test error"),
+				errors.New("test error"),
+				errors.New("test error"),
+			),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := &onErrorRetryTransport{
+				inner: tt.fields.inner,
+			}
+
+			got, err := tr.RoundTrip(tt.args.req)
+
+			require.Equal(t, tt.wantErr, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_copyRequest(t *testing.T) {
+	testReqBody := "test"
+
+	type args struct {
+		req *http.Request
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *http.Request
+		wantErr error
+	}{
+		{
+			name: "should return copied request",
+			args: args{
+				req: (&http.Request{
+					Method: "POST",
+					URL: &url.URL{
+						Host: "http://test.com",
+					},
+				}).WithContext(context.Background()),
+			},
+			want: (&http.Request{
+				Method: "POST",
+				URL: &url.URL{
+					Host: "http://test.com",
+				},
+			}).WithContext(context.Background()),
+			wantErr: nil,
+		},
+		{
+			name: "should return copied request with body",
+			args: args{
+				req: (&http.Request{
+					Method: "POST",
+					URL: &url.URL{
+						Host: "http://test.com",
+					},
+					Body: io.NopCloser(bytes.NewReader([]byte(testReqBody))),
+				}).WithContext(context.Background()),
+			},
+			want: (&http.Request{
+				Method: "POST",
+				URL: &url.URL{
+					Host: "http://test.com",
+				},
+				Body: io.NopCloser(bytes.NewReader([]byte(testReqBody))),
+			}).WithContext(context.Background()),
+			wantErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := copyRequest(tt.args.req)
+
+			require.Equal(t, tt.wantErr, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+type fakeResponse struct {
+	response *http.Response
+	err      error
+}
+
+// fakeTransport is a fake http.RoundTripper that returns responses in order
+type fakeTransport struct {
+	iter      int
+	responses []fakeResponse
+}
+
+func (t *fakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	res := t.responses[t.iter]
+	t.iter++
+
+	return res.response, res.err
+}

--- a/internal/registry/portforward/transport.go
+++ b/internal/registry/portforward/transport.go
@@ -9,13 +9,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/httpstream"
-)
-
-var (
-	NewRetryTransport = transport.NewRetry
 )
 
 // portforwardTransport forwards requests sent by the client to the port-forwarded pod from the cluster


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- as in the title
- cover cases when a request could not reach the server or when a response could not go to the client because of any error 

**Issue:**
- https://github.com/kyma-project/docker-registry/issues/25