### PR TITLE
add backoff to retry transport layer

### DIFF
--- a/internal/registry/portforward/retry.go
+++ b/internal/registry/portforward/retry.go
@@ -6,6 +6,17 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
+)
+
+var (
+	backoffSchedule = []time.Duration{
+		time.Millisecond,
+		time.Millisecond * 10,
+		time.Millisecond * 100,
+		time.Millisecond * 1000,
+		time.Millisecond * 2000,
+	}
 )
 
 // onErrorRetryTransport is a RoundTripper that retries requests on error
@@ -34,6 +45,7 @@ func (t *onErrorRetryTransport) RoundTrip(req *http.Request) (*http.Response, er
 		}
 
 		errList = append(errList, err)
+		time.Sleep(backoffSchedule[i])
 	}
 
 	return nil, errors.Join(errList...)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- add backoff to the `onErrorRetryTransport` to avoid situations when the API server is overloaded and can't handle a huge bundle of request

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/docker-registry/issues/25