### PR TITLE
Make the `--kubeconfig` frag persistent

### DIFF
--- a/internal/cmd/alpha/access/access.go
+++ b/internal/cmd/alpha/access/access.go
@@ -14,7 +14,6 @@ import (
 
 type accessConfig struct {
 	*cmdcommon.KymaConfig
-	cmdcommon.KubeClientConfig
 
 	name        string
 	clusterrole string
@@ -26,23 +25,17 @@ type accessConfig struct {
 
 func NewAccessCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	cfg := accessConfig{
-		KymaConfig:       kymaConfig,
-		KubeClientConfig: cmdcommon.KubeClientConfig{},
+		KymaConfig: kymaConfig,
 	}
 
 	cmd := &cobra.Command{
 		Use:   "access",
 		Short: "Produce a kubeconfig with Service Account based token and certificate",
 		Long:  "Produce a kubeconfig with Service Account based token and certificate that is valid for a specified time or indefinitely",
-		PreRun: func(_ *cobra.Command, _ []string) {
-			clierror.Check(cfg.KubeClientConfig.Complete())
-		},
 		Run: func(_ *cobra.Command, _ []string) {
 			clierror.Check(runAccess(&cfg))
 		},
 	}
-
-	cfg.KubeClientConfig.AddFlag(cmd)
 
 	cmd.Flags().StringVar(&cfg.name, "name", "", "Name of the Service Account to be created")
 	cmd.Flags().StringVar(&cfg.clusterrole, "clusterrole", "", "Name of the cluster role to bind the Service Account to")

--- a/internal/cmd/alpha/add/add.go
+++ b/internal/cmd/alpha/add/add.go
@@ -11,7 +11,6 @@ import (
 
 type addConfig struct {
 	*cmdcommon.KymaConfig
-	cmdcommon.KubeClientConfig
 
 	modules []string
 	crs     []string
@@ -19,8 +18,7 @@ type addConfig struct {
 
 func NewAddCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	cfg := addConfig{
-		KymaConfig:       kymaConfig,
-		KubeClientConfig: cmdcommon.KubeClientConfig{},
+		KymaConfig: kymaConfig,
 	}
 
 	cmd := &cobra.Command{
@@ -28,7 +26,6 @@ func NewAddCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 		Short: "Adds Kyma modules.",
 		Long:  `Use this command to add Kyma modules`,
 		PreRun: func(_ *cobra.Command, _ []string) {
-			clierror.Check(cfg.KubeClientConfig.Complete())
 		},
 		Run: func(_ *cobra.Command, _ []string) {
 			clierror.Check(runAdd(&cfg))
@@ -37,7 +34,6 @@ func NewAddCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 
 	cmd.AddCommand(managed.NewManagedCMD(kymaConfig))
 
-	cfg.KubeClientConfig.AddFlag(cmd)
 	cmd.Flags().StringSliceVar(&cfg.modules, "module", []string{}, "Name and version of the modules to add. Example: --module serverless,keda:1.1.1,etc...")
 	cmd.Flags().StringSliceVar(&cfg.crs, "cr", []string{}, "Path to the custom CR file")
 

--- a/internal/cmd/alpha/add/add.go
+++ b/internal/cmd/alpha/add/add.go
@@ -25,8 +25,6 @@ func NewAddCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 		Use:   "add",
 		Short: "Adds Kyma modules.",
 		Long:  `Use this command to add Kyma modules`,
-		PreRun: func(_ *cobra.Command, _ []string) {
-		},
 		Run: func(_ *cobra.Command, _ []string) {
 			clierror.Check(runAdd(&cfg))
 		},

--- a/internal/cmd/alpha/add/managed/managed.go
+++ b/internal/cmd/alpha/add/managed/managed.go
@@ -20,8 +20,6 @@ func NewManagedCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "managed",
 		Short: "Add managed Kyma module in a managed Kyma instance",
-		PreRun: func(_ *cobra.Command, _ []string) {
-		},
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runAddManaged(config)
 		},

--- a/internal/cmd/alpha/add/managed/managed.go
+++ b/internal/cmd/alpha/add/managed/managed.go
@@ -1,14 +1,12 @@
 package managed
 
 import (
-	"github.com/kyma-project/cli.v3/internal/clierror"
 	"github.com/kyma-project/cli.v3/internal/cmdcommon"
 	"github.com/spf13/cobra"
 )
 
 type managedConfig struct {
 	*cmdcommon.KymaConfig
-	cmdcommon.KubeClientConfig
 
 	module  string
 	channel string
@@ -16,22 +14,19 @@ type managedConfig struct {
 
 func NewManagedCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	config := &managedConfig{
-		KymaConfig:       kymaConfig,
-		KubeClientConfig: cmdcommon.KubeClientConfig{},
+		KymaConfig: kymaConfig,
 	}
 
 	cmd := &cobra.Command{
 		Use:   "managed",
 		Short: "Add managed Kyma module in a managed Kyma instance",
 		PreRun: func(_ *cobra.Command, _ []string) {
-			clierror.Check(config.KubeClientConfig.Complete())
 		},
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runAddManaged(config)
 		},
 	}
 
-	config.KubeClientConfig.AddFlag(cmd)
 	cmd.Flags().StringVar(&config.module, "module", "", "Name of the module to add")
 	cmd.Flags().StringVar(&config.channel, "channel", "", "Name of the Kyma channel to use for the module")
 

--- a/internal/cmd/alpha/alpha.go
+++ b/internal/cmd/alpha/alpha.go
@@ -1,9 +1,7 @@
 package alpha
 
 import (
-	"context"
-	"github.com/kyma-project/cli.v3/internal/cmd/alpha/registry"
-
+	"github.com/kyma-project/cli.v3/internal/clierror"
 	"github.com/kyma-project/cli.v3/internal/cmd/alpha/access"
 	"github.com/kyma-project/cli.v3/internal/cmd/alpha/add"
 	"github.com/kyma-project/cli.v3/internal/cmd/alpha/hana"
@@ -12,22 +10,22 @@ import (
 	"github.com/kyma-project/cli.v3/internal/cmd/alpha/oidc"
 	"github.com/kyma-project/cli.v3/internal/cmd/alpha/provision"
 	"github.com/kyma-project/cli.v3/internal/cmd/alpha/referenceinstance"
+	"github.com/kyma-project/cli.v3/internal/cmd/alpha/registry"
 	"github.com/kyma-project/cli.v3/internal/cmd/alpha/remove"
 	"github.com/kyma-project/cli.v3/internal/cmdcommon"
 	"github.com/spf13/cobra"
 )
 
-func NewAlphaCMD() *cobra.Command {
-
-	config := &cmdcommon.KymaConfig{
-		Ctx: context.Background(),
-	}
-
+func NewAlphaCMD() (*cobra.Command, clierror.Error) {
 	cmd := &cobra.Command{
 		Use:                   "alpha",
 		Short:                 "Groups command prototypes the API for which may still change.",
 		Long:                  `A set of alpha prototypes that may still change. Use in automations on your own risk.`,
 		DisableFlagsInUseLine: true,
+	}
+	config, err := cmdcommon.NewKymaConfig(cmd)
+	if err != nil {
+		return nil, err
 	}
 
 	cmd.AddCommand(hana.NewHanaCMD(config))
@@ -41,5 +39,5 @@ func NewAlphaCMD() *cobra.Command {
 	cmd.AddCommand(remove.NewRemoveCMD(config))
 	cmd.AddCommand(registry.NewRegistryCMD(config))
 
-	return cmd
+	return cmd, nil
 }

--- a/internal/cmd/alpha/hana/check.go
+++ b/internal/cmd/alpha/hana/check.go
@@ -15,7 +15,6 @@ import (
 
 type hanaCheckConfig struct {
 	*cmdcommon.KymaConfig
-	cmdcommon.KubeClientConfig
 
 	name      string
 	namespace string
@@ -27,25 +26,19 @@ type hanaCheckConfig struct {
 
 func NewHanaCheckCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	config := hanaCheckConfig{
-		KymaConfig:       kymaConfig,
-		KubeClientConfig: cmdcommon.KubeClientConfig{},
-		stdout:           os.Stdout,
-		checkCommands:    checkCommands,
+		KymaConfig:    kymaConfig,
+		stdout:        os.Stdout,
+		checkCommands: checkCommands,
 	}
 
 	cmd := &cobra.Command{
 		Use:   "check",
 		Short: "Check if the Hana instance is provisioned.",
 		Long:  "Use this command to check if the Hana instance is provisioned on the SAP Kyma platform.",
-		PreRun: func(_ *cobra.Command, _ []string) {
-			clierror.Check(config.KubeClientConfig.Complete())
-		},
 		Run: func(_ *cobra.Command, _ []string) {
 			clierror.Check(runCheck(&config))
 		},
 	}
-
-	config.KubeClientConfig.AddFlag(cmd)
 
 	cmd.Flags().StringVar(&config.name, "name", "", "Name of Hana instance.")
 	cmd.Flags().StringVar(&config.namespace, "namespace", "default", "Namespace for Hana instance.")

--- a/internal/cmd/alpha/hana/check_test.go
+++ b/internal/cmd/alpha/hana/check_test.go
@@ -167,11 +167,13 @@ func fixCheckConfig(objects ...runtime.Object) hanaCheckConfig {
 	scheme.AddKnownTypes(btp.GVRServiceInstance.GroupVersion())
 	dynamic := dynamic_fake.NewSimpleDynamicClient(scheme, objects...)
 	config := hanaCheckConfig{
-		stdout:     io.Discard,
-		KymaConfig: &cmdcommon.KymaConfig{Ctx: context.Background()},
-		KubeClientConfig: cmdcommon.KubeClientConfig{
-			KubeClient: &kube_fake.FakeKubeClient{
-				TestBtpInterface: btp.NewClient(dynamic),
+		stdout: io.Discard,
+		KymaConfig: &cmdcommon.KymaConfig{
+			Ctx: context.Background(),
+			KubeClientConfig: &cmdcommon.KubeClientConfig{
+				KubeClient: &kube_fake.FakeKubeClient{
+					TestBtpInterface: btp.NewClient(dynamic),
+				},
 			},
 		},
 		name:      testName,

--- a/internal/cmd/alpha/hana/credentials.go
+++ b/internal/cmd/alpha/hana/credentials.go
@@ -11,7 +11,6 @@ import (
 
 type hanaCredentialsConfig struct {
 	*cmdcommon.KymaConfig
-	cmdcommon.KubeClientConfig
 
 	name      string
 	namespace string
@@ -26,23 +25,17 @@ type credentials struct {
 
 func NewHanaCredentialsCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	config := hanaCredentialsConfig{
-		KymaConfig:       kymaConfig,
-		KubeClientConfig: cmdcommon.KubeClientConfig{},
+		KymaConfig: kymaConfig,
 	}
 
 	cmd := &cobra.Command{
 		Use:   "credentials",
 		Short: "Print credentials of the Hana instance.",
 		Long:  "Use this command to print credentials of the Hana instance on the SAP Kyma platform.",
-		PreRun: func(_ *cobra.Command, _ []string) {
-			clierror.Check(config.KubeClientConfig.Complete())
-		},
 		Run: func(_ *cobra.Command, _ []string) {
 			clierror.Check(runCredentials(&config))
 		},
 	}
-
-	config.KubeClientConfig.AddFlag(cmd)
 
 	cmd.Flags().StringVar(&config.name, "name", "", "Name of Hana instance.")
 	cmd.Flags().StringVar(&config.namespace, "namespace", "default", "Namespace for Hana instance.")

--- a/internal/cmd/alpha/hana/delete.go
+++ b/internal/cmd/alpha/hana/delete.go
@@ -13,7 +13,6 @@ import (
 
 type hanaDeleteConfig struct {
 	*cmdcommon.KymaConfig
-	cmdcommon.KubeClientConfig
 
 	name      string
 	namespace string
@@ -21,23 +20,17 @@ type hanaDeleteConfig struct {
 
 func NewHanaDeleteCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	config := hanaDeleteConfig{
-		KymaConfig:       kymaConfig,
-		KubeClientConfig: cmdcommon.KubeClientConfig{},
+		KymaConfig: kymaConfig,
 	}
 
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete a Hana instance on the Kyma.",
 		Long:  "Use this command to delete a Hana instance on the SAP Kyma platform.",
-		PreRun: func(_ *cobra.Command, _ []string) {
-			clierror.Check(config.KubeClientConfig.Complete())
-		},
 		Run: func(_ *cobra.Command, _ []string) {
 			clierror.Check(runDelete(&config))
 		},
 	}
-
-	config.KubeClientConfig.AddFlag(cmd)
 
 	cmd.Flags().StringVar(&config.name, "name", "", "Name of Hana instance.")
 	cmd.Flags().StringVar(&config.namespace, "namespace", "default", "Namespace for Hana instance.")

--- a/internal/cmd/alpha/hana/map.go
+++ b/internal/cmd/alpha/hana/map.go
@@ -19,23 +19,17 @@ import (
 // this command uses the same config as check command
 func NewMapHanaCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	config := hanaCheckConfig{
-		KymaConfig:       kymaConfig,
-		KubeClientConfig: cmdcommon.KubeClientConfig{},
+		KymaConfig: kymaConfig,
 	}
 
 	cmd := &cobra.Command{
 		Use:   "map",
 		Short: "Map the Hana instance to the Kyma cluster.",
 		Long:  "Use this command to map the Hana instance to the Kyma cluster.",
-		PreRun: func(_ *cobra.Command, _ []string) {
-			clierror.Check(config.KubeClientConfig.Complete())
-		},
 		Run: func(_ *cobra.Command, _ []string) {
 			clierror.Check(runMap(&config))
 		},
 	}
-
-	config.KubeClientConfig.AddFlag(cmd)
 
 	cmd.Flags().StringVar(&config.name, "name", "", "Name of Hana instance.")
 	cmd.Flags().StringVar(&config.namespace, "namespace", "default", "Namespace for Hana instance.")

--- a/internal/cmd/alpha/hana/provision.go
+++ b/internal/cmd/alpha/hana/provision.go
@@ -12,7 +12,6 @@ import (
 
 type hanaProvisionConfig struct {
 	*cmdcommon.KymaConfig
-	cmdcommon.KubeClientConfig
 
 	name        string
 	namespace   string
@@ -24,23 +23,17 @@ type hanaProvisionConfig struct {
 
 func NewHanaProvisionCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	config := hanaProvisionConfig{
-		KymaConfig:       kymaConfig,
-		KubeClientConfig: cmdcommon.KubeClientConfig{},
+		KymaConfig: kymaConfig,
 	}
 
 	cmd := &cobra.Command{
 		Use:   "provision",
 		Short: "Provisions a Hana instance on the Kyma.",
 		Long:  "Use this command to provision a Hana instance on the SAP Kyma platform.",
-		PreRun: func(_ *cobra.Command, _ []string) {
-			clierror.Check(config.KubeClientConfig.Complete())
-		},
 		Run: func(_ *cobra.Command, _ []string) {
 			clierror.Check(runProvision(&config))
 		},
 	}
-
-	config.KubeClientConfig.AddFlag(cmd)
 
 	cmd.Flags().StringVar(&config.name, "name", "", "Name of Hana instance.")
 	cmd.Flags().StringVar(&config.namespace, "namespace", "default", "Namespace for Hana instance.")

--- a/internal/cmd/alpha/imageimport/imageimport.go
+++ b/internal/cmd/alpha/imageimport/imageimport.go
@@ -12,15 +12,13 @@ import (
 
 type provisionConfig struct {
 	*cmdcommon.KymaConfig
-	cmdcommon.KubeClientConfig
 
 	image string
 }
 
 func NewImportCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	config := provisionConfig{
-		KymaConfig:       kymaConfig,
-		KubeClientConfig: cmdcommon.KubeClientConfig{},
+		KymaConfig: kymaConfig,
 	}
 
 	cmd := &cobra.Command{
@@ -30,15 +28,13 @@ func NewImportCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 
 		PreRun: func(_ *cobra.Command, args []string) {
-			clierror.Check(config.complete(args))
+			config.complete(args)
 			clierror.Check(config.validate())
 		},
 		Run: func(_ *cobra.Command, _ []string) {
 			clierror.Check(runImageImport(&config))
 		},
 	}
-
-	config.KubeClientConfig.AddFlag(cmd)
 
 	return cmd
 }
@@ -52,10 +48,8 @@ func (pc *provisionConfig) validate() clierror.Error {
 	return nil
 }
 
-func (pc *provisionConfig) complete(args []string) clierror.Error {
+func (pc *provisionConfig) complete(args []string) {
 	pc.image = args[0]
-
-	return pc.KubeClientConfig.Complete()
 }
 
 func runImageImport(config *provisionConfig) clierror.Error {

--- a/internal/cmd/alpha/modules/modules.go
+++ b/internal/cmd/alpha/modules/modules.go
@@ -9,7 +9,6 @@ import (
 
 type modulesConfig struct {
 	*cmdcommon.KymaConfig
-	cmdcommon.KubeClientConfig
 
 	catalog   bool
 	managed   bool
@@ -19,22 +18,17 @@ type modulesConfig struct {
 
 func NewModulesCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	cfg := modulesConfig{
-		KymaConfig:       kymaConfig,
-		KubeClientConfig: cmdcommon.KubeClientConfig{},
+		KymaConfig: kymaConfig,
 	}
 
 	cmd := &cobra.Command{
 		Use:   "modules",
 		Short: "List modules.",
 		Long:  `List either installed, managed or available Kyma modules.`,
-		PreRun: func(_ *cobra.Command, _ []string) {
-			clierror.Check(cfg.KubeClientConfig.Complete())
-		},
 		Run: func(_ *cobra.Command, _ []string) {
 			clierror.Check(listModules(&cfg))
 		},
 	}
-	cfg.KubeClientConfig.AddFlag(cmd)
 
 	cmd.Flags().BoolVar(&cfg.catalog, "catalog", false, "List of al available Kyma modules.")
 	cmd.Flags().BoolVar(&cfg.managed, "managed", false, "List of all Kyma modules managed by central control-plane.")
@@ -88,11 +82,11 @@ func collectiveView(cfg *modulesConfig) clierror.Error {
 	if err != nil {
 		return clierror.WrapE(err, clierror.New("failed to get all Kyma catalog"))
 	}
-	installedWith, err := communitymodules.InstalledModules(cfg.KubeClientConfig, *cfg.KymaConfig)
+	installedWith, err := communitymodules.InstalledModules(cfg.Ctx, cfg.KubeClient)
 	if err != nil {
 		return clierror.WrapE(err, clierror.New("failed to get installed Kyma modules"))
 	}
-	managedWith, err := communitymodules.ManagedModules(cfg.KubeClientConfig, *cfg.KymaConfig)
+	managedWith, err := communitymodules.ManagedModules(cfg.Ctx, cfg.KubeClient)
 	if err != nil {
 		return clierror.WrapE(err, clierror.New("failed to get managed Kyma modules"))
 	}
@@ -105,7 +99,7 @@ func collectiveView(cfg *modulesConfig) clierror.Error {
 
 // listInstalledModules lists all installed modules
 func listInstalledModules(cfg *modulesConfig) clierror.Error {
-	installed, err := communitymodules.InstalledModules(cfg.KubeClientConfig, *cfg.KymaConfig)
+	installed, err := communitymodules.InstalledModules(cfg.Ctx, cfg.KubeClient)
 	if err != nil {
 		return clierror.WrapE(err, clierror.New("failed to get installed Kyma modules"))
 	}
@@ -116,7 +110,7 @@ func listInstalledModules(cfg *modulesConfig) clierror.Error {
 
 // listManagedModules lists all managed modules
 func listManagedModules(cfg *modulesConfig) clierror.Error {
-	managed, err := communitymodules.ManagedModules(cfg.KubeClientConfig, *cfg.KymaConfig)
+	managed, err := communitymodules.ManagedModules(cfg.Ctx, cfg.KubeClient)
 	if err != nil {
 		return clierror.WrapE(err, clierror.New("failed to get managed Kyma modules"))
 	}

--- a/internal/cmd/alpha/referenceinstance/referenceinstance.go
+++ b/internal/cmd/alpha/referenceinstance/referenceinstance.go
@@ -1,7 +1,6 @@
 package referenceinstance
 
 import (
-	"github.com/kyma-project/cli.v3/internal/clierror"
 	"github.com/kyma-project/cli.v3/internal/cmdcommon"
 	"github.com/kyma-project/cli.v3/internal/kube/btp"
 	"github.com/spf13/cobra"
@@ -10,7 +9,6 @@ import (
 
 type referenceInstanceConfig struct {
 	*cmdcommon.KymaConfig
-	cmdcommon.KubeClientConfig
 
 	namespace     string
 	offeringName  string
@@ -24,8 +22,7 @@ type referenceInstanceConfig struct {
 
 func NewReferenceInstanceCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	config := referenceInstanceConfig{
-		KymaConfig:       kymaConfig,
-		KubeClientConfig: cmdcommon.KubeClientConfig{},
+		KymaConfig: kymaConfig,
 	}
 
 	cmd := &cobra.Command{
@@ -33,15 +30,10 @@ func NewReferenceInstanceCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 		Short: "Add an instance reference to a shared service instance.",
 		Long: `Use this command to add an instance reference to a shared service instance on the SAP Kyma platform.
 `,
-		PreRun: func(_ *cobra.Command, _ []string) {
-			clierror.Check(config.KubeClientConfig.Complete())
-		},
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runReferenceInstance(config)
 		},
 	}
-
-	config.KubeClientConfig.AddFlag(cmd)
 
 	cmd.Flags().StringVar(&config.namespace, "namespace", "default", "Namespace of the reference instance.")
 	cmd.Flags().StringVar(&config.offeringName, "offering-name", "", "Offering name.")

--- a/internal/cmd/alpha/registry/config/config.go
+++ b/internal/cmd/alpha/registry/config/config.go
@@ -2,16 +2,16 @@ package config
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/kyma-project/cli.v3/internal/clierror"
 	"github.com/kyma-project/cli.v3/internal/cmdcommon"
 	"github.com/kyma-project/cli.v3/internal/registry"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 type cfgConfig struct {
 	*cmdcommon.KymaConfig
-	cmdcommon.KubeClientConfig
 
 	externalurl bool
 	output      string
@@ -19,23 +19,18 @@ type cfgConfig struct {
 
 func NewConfigCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	cfg := cfgConfig{
-		KymaConfig:       kymaConfig,
-		KubeClientConfig: cmdcommon.KubeClientConfig{},
+		KymaConfig: kymaConfig,
 	}
 
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Saves Kyma registry dockerconfig to a file",
 		Long:  "Use this command to save Kyma registry dockerconfig to a file",
-		PreRun: func(_ *cobra.Command, _ []string) {
-			clierror.Check(cfg.KubeClientConfig.Complete())
-		},
 		Run: func(_ *cobra.Command, _ []string) {
 			clierror.Check(runConfig(&cfg))
 		},
 	}
 
-	cfg.KubeClientConfig.AddFlag(cmd)
 	cmd.Flags().BoolVar(&cfg.externalurl, "externalurl", false, "External URL for the Kyma registry.")
 	cmd.Flags().StringVar(&cfg.output, "output", "", "Path where the output file should be saved to. NOTE: docker expects the file to be named `config.json`.")
 

--- a/internal/cmd/alpha/remove/managed/managed.go
+++ b/internal/cmd/alpha/remove/managed/managed.go
@@ -1,36 +1,29 @@
 package managed
 
 import (
-	"github.com/kyma-project/cli.v3/internal/clierror"
 	"github.com/kyma-project/cli.v3/internal/cmdcommon"
 	"github.com/spf13/cobra"
 )
 
 type managedConfig struct {
 	*cmdcommon.KymaConfig
-	cmdcommon.KubeClientConfig
 
 	module string
 }
 
 func NewManagedCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	config := &managedConfig{
-		KymaConfig:       kymaConfig,
-		KubeClientConfig: cmdcommon.KubeClientConfig{},
+		KymaConfig: kymaConfig,
 	}
 
 	cmd := &cobra.Command{
 		Use:   "managed",
 		Short: "Remove Kyma module on a managed Kyma instance",
-		PreRun: func(_ *cobra.Command, _ []string) {
-			clierror.Check(config.KubeClientConfig.Complete())
-		},
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runRemoveManaged(config)
 		},
 	}
 
-	config.KubeClientConfig.AddFlag(cmd)
 	cmd.Flags().StringVar(&config.module, "module", "", "Name of the module to remove")
 
 	_ = cmd.MarkFlagRequired("module")

--- a/internal/cmd/alpha/remove/remove.go
+++ b/internal/cmd/alpha/remove/remove.go
@@ -10,24 +10,19 @@ import (
 
 type removeConfig struct {
 	*cmdcommon.KymaConfig
-	cmdcommon.KubeClientConfig
 
 	modules []string
 }
 
 func NewRemoveCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	cfg := removeConfig{
-		KymaConfig:       kymaConfig,
-		KubeClientConfig: cmdcommon.KubeClientConfig{},
+		KymaConfig: kymaConfig,
 	}
 
 	cmd := &cobra.Command{
 		Use:   "remove",
 		Short: "Remove Kyma modules.",
 		Long:  `Use this command to remove Kyma modules`,
-		PreRun: func(_ *cobra.Command, _ []string) {
-			clierror.Check(cfg.KubeClientConfig.Complete())
-		},
 		Run: func(_ *cobra.Command, _ []string) {
 			clierror.Check(runRemove(&cfg))
 		},

--- a/internal/cmd/kyma.go
+++ b/internal/cmd/kyma.go
@@ -1,12 +1,12 @@
 package cmd
 
 import (
+	"github.com/kyma-project/cli.v3/internal/clierror"
 	"github.com/kyma-project/cli.v3/internal/cmd/alpha"
 	"github.com/spf13/cobra"
 )
 
-func NewKymaCMD() *cobra.Command {
-
+func NewKymaCMD() (*cobra.Command, clierror.Error) {
 	cmd := &cobra.Command{
 		Use: "kyma",
 
@@ -20,6 +20,12 @@ func NewKymaCMD() *cobra.Command {
 			}
 		},
 	}
-	cmd.AddCommand(alpha.NewAlphaCMD())
-	return cmd
+
+	alpha, err := alpha.NewAlphaCMD()
+	if err != nil {
+		return nil, err
+	}
+	cmd.AddCommand(alpha)
+
+	return cmd, nil
 }

--- a/internal/cmdcommon/kubeconfig.go
+++ b/internal/cmdcommon/kubeconfig.go
@@ -1,6 +1,8 @@
 package cmdcommon
 
 import (
+	"os"
+
 	"github.com/kyma-project/cli.v3/internal/clierror"
 	"github.com/kyma-project/cli.v3/internal/kube"
 	"github.com/spf13/cobra"
@@ -8,17 +10,38 @@ import (
 
 // KubeClientConfig allows to setup kubeconfig flag and use it to create kube.Client
 type KubeClientConfig struct {
-	Kubeconfig string
 	KubeClient kube.Client
 }
 
-func (kcc *KubeClientConfig) AddFlag(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&kcc.Kubeconfig, "kubeconfig", "", "Path to the Kyma kubeconfig file.")
+func newKubeClientConfig(cmd *cobra.Command) (*KubeClientConfig, clierror.Error) {
+	cfg := &KubeClientConfig{}
+	cfg.addFlag(cmd)
+
+	return cfg, cfg.complete()
 }
 
-func (kcc *KubeClientConfig) Complete() clierror.Error {
+func (kcc *KubeClientConfig) addFlag(cmd *cobra.Command) {
+	// this flag is not operational. it's only to print help description and help cobra with validation
+	_ = cmd.PersistentFlags().String("kubeconfig", "", "Path to the Kyma kubeconfig file.")
+}
+
+func (kcc *KubeClientConfig) complete() clierror.Error {
+	kubeconfigPath := getKubeconfigPath()
+
 	var err clierror.Error
-	kcc.KubeClient, err = kube.NewClient(kcc.Kubeconfig)
+	kcc.KubeClient, err = kube.NewClient(kubeconfigPath)
 
 	return err
+}
+
+// search os.Args manually to find if user pass --kubeconfig path and return its value
+func getKubeconfigPath() string {
+	path := ""
+	for i, arg := range os.Args {
+		if arg == "--kubeconfig" && len(os.Args) > i+1 {
+			path = os.Args[i+1]
+		}
+	}
+
+	return path
 }

--- a/internal/cmdcommon/kymaconfig.go
+++ b/internal/cmdcommon/kymaconfig.go
@@ -1,8 +1,27 @@
 package cmdcommon
 
-import "context"
+import (
+	"context"
+
+	"github.com/kyma-project/cli.v3/internal/clierror"
+	"github.com/spf13/cobra"
+)
 
 // KymaConfig contains data common for all subcommands
 type KymaConfig struct {
+	*KubeClientConfig
+
 	Ctx context.Context
+}
+
+func NewKymaConfig(cmd *cobra.Command) (*KymaConfig, clierror.Error) {
+	kubeClient, err := newKubeClientConfig(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	return &KymaConfig{
+		Ctx:              context.Background(),
+		KubeClientConfig: kubeClient,
+	}, nil
 }

--- a/internal/communitymodules/modules_test.go
+++ b/internal/communitymodules/modules_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/kyma-project/cli.v3/internal/cmdcommon"
 	kube_fake "github.com/kyma-project/cli.v3/internal/kube/fake"
 	"github.com/kyma-project/cli.v3/internal/kube/kyma"
 	"github.com/stretchr/testify/assert"
@@ -124,14 +123,7 @@ func Test_ManagedModules(t *testing.T) {
 			TestKymaInterface:       kyma.NewClient(dynamic),
 		}
 
-		kymaConfig := cmdcommon.KymaConfig{
-			Ctx: context.Background(),
-		}
-
-		modules, err := ManagedModules(cmdcommon.KubeClientConfig{
-			Kubeconfig: "",
-			KubeClient: kubeClient,
-		}, kymaConfig)
+		modules, err := ManagedModules(context.Background(), kubeClient)
 
 		assert.Equal(t, expectedResult, modules)
 		assert.Nil(t, err)
@@ -148,14 +140,7 @@ func Test_ManagedModules(t *testing.T) {
 			TestKymaInterface:       kyma.NewClient(dynamic),
 		}
 
-		kymaConfig := cmdcommon.KymaConfig{
-			Ctx: context.Background(),
-		}
-
-		modules, err := ManagedModules(cmdcommon.KubeClientConfig{
-			Kubeconfig: "",
-			KubeClient: kubeClient,
-		}, kymaConfig)
+		modules, err := ManagedModules(context.Background(), kubeClient)
 
 		assert.Equal(t, expectedResult, modules)
 		assert.Nil(t, err)
@@ -188,16 +173,7 @@ func Test_installedModules(t *testing.T) {
 			TestDynamicInterface:    nil,
 		}
 
-		kymaConfig := cmdcommon.KymaConfig{
-			Ctx: context.Background(),
-		}
-
-		modules, err := installedModules(
-			httpServer.URL,
-			cmdcommon.KubeClientConfig{
-				Kubeconfig: "",
-				KubeClient: kubeClient,
-			}, kymaConfig)
+		modules, err := installedModules(context.Background(), httpServer.URL, kubeClient)
 
 		assert.Equal(t, expectedResult, modules)
 		assert.Nil(t, err)
@@ -222,16 +198,7 @@ func Test_installedModules(t *testing.T) {
 			TestDynamicInterface:    nil,
 		}
 
-		kymaConfig := cmdcommon.KymaConfig{
-			Ctx: context.Background(),
-		}
-
-		modules, err := installedModules(
-			httpServer.URL,
-			cmdcommon.KubeClientConfig{
-				Kubeconfig: "",
-				KubeClient: kubeClient,
-			}, kymaConfig)
+		modules, err := installedModules(context.Background(), httpServer.URL, kubeClient)
 
 		assert.Equal(t, expectedResult, modules)
 		assert.Nil(t, err)

--- a/main.go
+++ b/main.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/kyma-project/cli.v3/internal/clierror"
 	"github.com/kyma-project/cli.v3/internal/cmd"
 )
 
 func main() {
-	cmd := cmd.NewKymaCMD()
+	cmd, err := cmd.NewKymaCMD()
+	clierror.Check(err)
 
 	if err := cmd.Execute(); err != nil {
 		fmt.Println(err.Error())


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- make `--kubeconfig` flag persistent for the whole alpha group
- prepare code for a new configmap fetching mechanism described in the ticket below

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/cli/issues/2228