### PR TITLE
Stop failing when cluster is down

### DIFF
--- a/internal/cmd/alpha/hana/check.go
+++ b/internal/cmd/alpha/hana/check.go
@@ -71,7 +71,12 @@ func runCheck(config *hanaCheckConfig) clierror.Error {
 }
 
 func checkHanaInstance(config *hanaCheckConfig) clierror.Error {
-	instance, err := config.KubeClient.Btp().GetServiceInstance(config.Ctx, config.namespace, config.name)
+	client, clientErr := config.GetKubeClientWithClierr()
+	if clientErr != nil {
+		return clientErr
+	}
+
+	instance, err := client.Btp().GetServiceInstance(config.Ctx, config.namespace, config.name)
 	if err != nil {
 		return clierror.New(err.Error())
 	}
@@ -80,7 +85,12 @@ func checkHanaInstance(config *hanaCheckConfig) clierror.Error {
 }
 
 func checkHanaBinding(config *hanaCheckConfig) clierror.Error {
-	binding, err := config.KubeClient.Btp().GetServiceBinding(config.Ctx, config.namespace, config.name)
+	client, clientErr := config.GetKubeClientWithClierr()
+	if clientErr != nil {
+		return clientErr
+	}
+
+	binding, err := client.Btp().GetServiceBinding(config.Ctx, config.namespace, config.name)
 	if err != nil {
 		return clierror.New(err.Error())
 	}
@@ -89,8 +99,13 @@ func checkHanaBinding(config *hanaCheckConfig) clierror.Error {
 }
 
 func checkHanaBindingURL(config *hanaCheckConfig) clierror.Error {
+	client, clientErr := config.GetKubeClientWithClierr()
+	if clientErr != nil {
+		return clientErr
+	}
+
 	urlName := hanaBindingURLName(config.name)
-	binding, err := config.KubeClient.Btp().GetServiceBinding(config.Ctx, config.namespace, urlName)
+	binding, err := client.Btp().GetServiceBinding(config.Ctx, config.namespace, urlName)
 	if err != nil {
 		return clierror.New(err.Error())
 	}

--- a/internal/cmd/alpha/hana/credentials.go
+++ b/internal/cmd/alpha/hana/credentials.go
@@ -71,7 +71,12 @@ func printCredentials(config *hanaCredentialsConfig, credentials credentials) {
 }
 
 func getHanaCredentials(config *hanaCredentialsConfig) (credentials, clierror.Error) {
-	secret, err := config.KubeClient.Static().CoreV1().Secrets(config.namespace).Get(config.Ctx, config.name, metav1.GetOptions{})
+	client, clientErr := config.GetKubeClientWithClierr()
+	if clientErr != nil {
+		return credentials{}, clientErr
+	}
+
+	secret, err := client.Static().CoreV1().Secrets(config.namespace).Get(config.Ctx, config.name, metav1.GetOptions{})
 	if err != nil {
 		return handleGetHanaCredentialsError(err)
 	}

--- a/internal/cmd/alpha/hana/delete.go
+++ b/internal/cmd/alpha/hana/delete.go
@@ -62,22 +62,37 @@ func runDelete(config *hanaDeleteConfig) clierror.Error {
 }
 
 func deleteHanaInstance(config *hanaDeleteConfig) clierror.Error {
-	err := config.KubeClient.Dynamic().Resource(btp.GVRServiceInstance).
+	client, clientErr := config.GetKubeClientWithClierr()
+	if clientErr != nil {
+		return clientErr
+	}
+
+	err := client.Dynamic().Resource(btp.GVRServiceInstance).
 		Namespace(config.namespace).
 		Delete(config.Ctx, config.name, metav1.DeleteOptions{})
 	return handleDeleteResponse(err, "Hana instance", config.namespace, config.name)
 }
 
 func deleteHanaBinding(config *hanaDeleteConfig) clierror.Error {
-	err := config.KubeClient.Dynamic().Resource(btp.GVRServiceBinding).
+	client, clientErr := config.GetKubeClientWithClierr()
+	if clientErr != nil {
+		return clientErr
+	}
+
+	err := client.Dynamic().Resource(btp.GVRServiceBinding).
 		Namespace(config.namespace).
 		Delete(config.Ctx, config.name, metav1.DeleteOptions{})
 	return handleDeleteResponse(err, "Hana binding", config.namespace, config.name)
 }
 
 func deleteHanaBindingURL(config *hanaDeleteConfig) clierror.Error {
+	client, clientErr := config.GetKubeClientWithClierr()
+	if clientErr != nil {
+		return clientErr
+	}
+
 	urlName := hanaBindingURLName(config.name)
-	err := config.KubeClient.Dynamic().Resource(btp.GVRServiceBinding).
+	err := client.Dynamic().Resource(btp.GVRServiceBinding).
 		Namespace(config.namespace).
 		Delete(config.Ctx, urlName, metav1.DeleteOptions{})
 	return handleDeleteResponse(err, "Hana URL binding", config.namespace, urlName)

--- a/internal/cmd/alpha/hana/provision.go
+++ b/internal/cmd/alpha/hana/provision.go
@@ -72,21 +72,36 @@ func runProvision(config *hanaProvisionConfig) clierror.Error {
 func createHanaInstance(config *hanaProvisionConfig) clierror.Error {
 	instance := hanaInstance(config)
 
-	err := config.KubeClient.Btp().CreateServiceInstance(config.Ctx, instance)
+	client, clientErr := config.GetKubeClientWithClierr()
+	if clientErr != nil {
+		return clientErr
+	}
+
+	err := client.Btp().CreateServiceInstance(config.Ctx, instance)
 	return handleProvisionResponse(err, "Hana instance", config.namespace, config.name)
 }
 
 func createHanaBinding(config *hanaProvisionConfig) clierror.Error {
 	binding := hanaBinding(config)
 
-	err := config.KubeClient.Btp().CreateServiceBinding(config.Ctx, binding)
+	client, clientErr := config.GetKubeClientWithClierr()
+	if clientErr != nil {
+		return clientErr
+	}
+
+	err := client.Btp().CreateServiceBinding(config.Ctx, binding)
 	return handleProvisionResponse(err, "Hana binding", config.namespace, config.name)
 }
 
 func createHanaBindingURL(config *hanaProvisionConfig) clierror.Error {
 	bindingURL := hanaBindingURL(config)
 
-	err := config.KubeClient.Btp().CreateServiceBinding(config.Ctx, bindingURL)
+	client, clientErr := config.GetKubeClientWithClierr()
+	if clientErr != nil {
+		return clientErr
+	}
+
+	err := client.Btp().CreateServiceBinding(config.Ctx, bindingURL)
 	return handleProvisionResponse(err, "Hana URL binding", config.namespace, hanaBindingURLName(config.name))
 }
 

--- a/internal/cmd/alpha/modules/modules.go
+++ b/internal/cmd/alpha/modules/modules.go
@@ -82,11 +82,18 @@ func collectiveView(cfg *modulesConfig) clierror.Error {
 	if err != nil {
 		return clierror.WrapE(err, clierror.New("failed to get all Kyma catalog"))
 	}
-	installedWith, err := communitymodules.InstalledModules(cfg.Ctx, cfg.KubeClient)
+
+	client, err := cfg.GetKubeClientWithClierr()
+	if err != nil {
+		return err
+	}
+
+	installedWith, err := communitymodules.InstalledModules(cfg.Ctx, client)
 	if err != nil {
 		return clierror.WrapE(err, clierror.New("failed to get installed Kyma modules"))
 	}
-	managedWith, err := communitymodules.ManagedModules(cfg.Ctx, cfg.KubeClient)
+
+	managedWith, err := communitymodules.ManagedModules(cfg.Ctx, client)
 	if err != nil {
 		return clierror.WrapE(err, clierror.New("failed to get managed Kyma modules"))
 	}
@@ -99,7 +106,12 @@ func collectiveView(cfg *modulesConfig) clierror.Error {
 
 // listInstalledModules lists all installed modules
 func listInstalledModules(cfg *modulesConfig) clierror.Error {
-	installed, err := communitymodules.InstalledModules(cfg.Ctx, cfg.KubeClient)
+	client, err := cfg.GetKubeClientWithClierr()
+	if err != nil {
+		return err
+	}
+
+	installed, err := communitymodules.InstalledModules(cfg.Ctx, client)
 	if err != nil {
 		return clierror.WrapE(err, clierror.New("failed to get installed Kyma modules"))
 	}
@@ -110,7 +122,12 @@ func listInstalledModules(cfg *modulesConfig) clierror.Error {
 
 // listManagedModules lists all managed modules
 func listManagedModules(cfg *modulesConfig) clierror.Error {
-	managed, err := communitymodules.ManagedModules(cfg.Ctx, cfg.KubeClient)
+	client, err := cfg.GetKubeClientWithClierr()
+	if err != nil {
+		return err
+	}
+
+	managed, err := communitymodules.ManagedModules(cfg.Ctx, client)
 	if err != nil {
 		return clierror.WrapE(err, clierror.New("failed to get managed Kyma modules"))
 	}

--- a/internal/cmd/alpha/oidc/oidc.go
+++ b/internal/cmd/alpha/oidc/oidc.go
@@ -117,7 +117,12 @@ func runOIDC(cfg *oidcConfig) clierror.Error {
 			return clierror.WrapE(clierr, clierror.New("failed to get kubeconfig from CIS"))
 		}
 	} else {
-		kubeconfig = cfg.KubeClient.APIConfig()
+		client, err := cfg.GetKubeClientWithClierr()
+		if err != nil {
+			return err
+		}
+
+		kubeconfig = client.APIConfig()
 	}
 
 	enrichedKubeconfig := createKubeconfig(kubeconfig, token)

--- a/internal/cmd/alpha/referenceinstance/referenceinstance.go
+++ b/internal/cmd/alpha/referenceinstance/referenceinstance.go
@@ -59,7 +59,12 @@ func NewReferenceInstanceCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 func runReferenceInstance(config referenceInstanceConfig) error {
 	requestData := fillRequestData(config)
 
-	return config.KubeClient.Btp().CreateServiceInstance(config.Ctx, &requestData)
+	client, err := config.GetKubeClient()
+	if err != nil {
+		return err
+	}
+
+	return client.Btp().CreateServiceInstance(config.Ctx, &requestData)
 }
 
 func fillRequestData(config referenceInstanceConfig) btp.ServiceInstance {

--- a/internal/cmd/alpha/registry/config/config.go
+++ b/internal/cmd/alpha/registry/config/config.go
@@ -38,7 +38,12 @@ func NewConfigCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 }
 
 func runConfig(cfg *cfgConfig) clierror.Error {
-	registryConfig, err := registry.GetExternalConfig(cfg.Ctx, cfg.KubeClient)
+	client, err := cfg.GetKubeClientWithClierr()
+	if err != nil {
+		return err
+	}
+
+	registryConfig, err := registry.GetExternalConfig(cfg.Ctx, client)
 	if err != nil {
 		return clierror.WrapE(err, clierror.New("failed to load in-cluster registry configuration"))
 	}

--- a/internal/cmd/alpha/registry/imageimport/imageimport.go
+++ b/internal/cmd/alpha/registry/imageimport/imageimport.go
@@ -53,8 +53,13 @@ func (pc *provisionConfig) complete(args []string) {
 }
 
 func runImageImport(config *provisionConfig) clierror.Error {
+	client, err := config.GetKubeClientWithClierr()
+	if err != nil {
+		return err
+	}
+
 	// TODO: Add "serverless is not installed" error message
-	registryConfig, err := registry.GetInternalConfig(config.Ctx, config.KubeClient)
+	registryConfig, err := registry.GetInternalConfig(config.Ctx, client)
 	if err != nil {
 		return clierror.WrapE(err, clierror.New("failed to load in-cluster registry configuration"))
 	}
@@ -65,7 +70,7 @@ func runImageImport(config *provisionConfig) clierror.Error {
 		config.Ctx,
 		config.image,
 		registry.ImportOptions{
-			ClusterAPIRestConfig: config.KubeClient.RestConfig(),
+			ClusterAPIRestConfig: client.RestConfig(),
 			RegistryAuth:         registry.NewBasicAuth(registryConfig.SecretData.Username, registryConfig.SecretData.Password),
 			RegistryPullHost:     registryConfig.SecretData.PullRegAddr,
 			RegistryPodName:      registryConfig.PodMeta.Name,

--- a/internal/cmd/alpha/remove/managed/managed.go
+++ b/internal/cmd/alpha/remove/managed/managed.go
@@ -32,5 +32,10 @@ func NewManagedCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 }
 
 func runRemoveManaged(config *managedConfig) error {
-	return config.KubeClient.Kyma().DisableModule(config.Ctx, config.module)
+	client, err := config.GetKubeClient()
+	if err != nil {
+		return err
+	}
+
+	return client.Kyma().DisableModule(config.Ctx, config.module)
 }

--- a/internal/cmd/alpha/remove/remove.go
+++ b/internal/cmd/alpha/remove/remove.go
@@ -38,5 +38,10 @@ func NewRemoveCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 
 func runRemove(cfg *removeConfig) clierror.Error {
 	modules := cluster.ParseModules(cfg.modules)
-	return cluster.RemoveSpecifiedModules(cfg.Ctx, cfg.KubeClient.RootlessDynamic(), modules)
+	client, err := cfg.GetKubeClientWithClierr()
+	if err != nil {
+		return err
+	}
+
+	return cluster.RemoveSpecifiedModules(cfg.Ctx, client.RootlessDynamic(), modules)
 }

--- a/internal/cmdcommon/kymaconfig.go
+++ b/internal/cmdcommon/kymaconfig.go
@@ -19,12 +19,9 @@ type KymaConfig struct {
 func NewKymaConfig(cmd *cobra.Command) (*KymaConfig, clierror.Error) {
 	ctx := context.Background()
 
-	kubeClient, kubeClientErr := newKubeClientConfig(cmd)
-	if kubeClientErr != nil {
-		return nil, kubeClientErr
-	}
+	kubeClient := newKubeClientConfig(cmd)
 
-	extensions, err := ListExtensions(ctx, kubeClient.KubeClient.Static())
+	extensions, err := listExtensions(ctx, kubeClient)
 	if err != nil {
 		fmt.Printf("DEBUG ERROR: %s\n", err.Error())
 		// TODO: think about handling error later

--- a/internal/kube/client.go
+++ b/internal/kube/client.go
@@ -1,10 +1,10 @@
 package kube
 
 import (
-	"github.com/kyma-project/cli.v3/internal/clierror"
 	"github.com/kyma-project/cli.v3/internal/kube/btp"
 	"github.com/kyma-project/cli.v3/internal/kube/kyma"
 	"github.com/kyma-project/cli.v3/internal/kube/rootlessdynamic"
+	"github.com/pkg/errors"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
@@ -35,12 +35,10 @@ type client struct {
 	restClient     *rest.RESTClient
 }
 
-func NewClient(kubeconfig string) (Client, clierror.Error) {
+func NewClient(kubeconfig string) (Client, error) {
 	client, err := newClient(kubeconfig)
 	if err != nil {
-		return nil, clierror.Wrap(err,
-			clierror.New("failed to initialise kubernetes client", "Make sure that kubeconfig is proper."),
-		)
+		return nil, errors.Wrap(err, "failed to initialise kubernetes client")
 	}
 	return client, nil
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- fix issue with failing cli commands that are not connecting to the cluster (for example `kyma help`) when kubeconfig is pointing to the cluster that does not exist or is down

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/cli/issues/2228