### PR TITLE
Implement `INSTALLED` and `MANAGED` headers for table view when listing modules

### DIFF
--- a/internal/kube/kyma/kyma.go
+++ b/internal/kube/kyma/kyma.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	defaultKymaName      = "default"
-	defaultKymaNamespace = "kyma-system"
+	DefaultKymaName      = "default"
+	DefaultKymaNamespace = "kyma-system"
 )
 
 type Interface interface {
@@ -35,31 +35,21 @@ func NewClient(dynamic dynamic.Interface) Interface {
 	}
 }
 
+// ListModuleReleaseMeta lists ModuleReleaseMeta resources from across the whole cluster
 func (c *client) ListModuleReleaseMeta(ctx context.Context) (*ModuleReleaseMetaList, error) {
 	return list[ModuleReleaseMetaList](ctx, c.dynamic, GVRModuleReleaseMeta)
 }
 
+// ListModuleTemplate lists ModuleTemplate resources from across the whole cluster
 func (c *client) ListModuleTemplate(ctx context.Context) (*ModuleTemplateList, error) {
 	return list[ModuleTemplateList](ctx, c.dynamic, GVRModuleTemplate)
-}
-
-func list[T any](ctx context.Context, client dynamic.Interface, gvr schema.GroupVersionResource) (*T, error) {
-	list, err := client.Resource(gvr).
-		List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	structuredList := new(T)
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(list.UnstructuredContent(), structuredList)
-	return structuredList, err
 }
 
 // GetDefaultKyma gets the default Kyma CR from the kyma-system namespace and cast it to the Kyma structure
 func (c *client) GetDefaultKyma(ctx context.Context) (*Kyma, error) {
 	u, err := c.dynamic.Resource(GVRKyma).
-		Namespace(defaultKymaNamespace).
-		Get(ctx, defaultKymaName, metav1.GetOptions{})
+		Namespace(DefaultKymaNamespace).
+		Get(ctx, DefaultKymaName, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +68,7 @@ func (c *client) UpdateDefaultKyma(ctx context.Context, obj *Kyma) error {
 	}
 
 	_, err = c.dynamic.Resource(GVRKyma).
-		Namespace(defaultKymaNamespace).
+		Namespace(DefaultKymaNamespace).
 		Update(ctx, &unstructured.Unstructured{Object: u}, metav1.UpdateOptions{})
 
 	return err
@@ -132,4 +122,16 @@ func disableModule(kymaCR *Kyma, moduleName string) *Kyma {
 	})
 
 	return kymaCR
+}
+
+func list[T any](ctx context.Context, client dynamic.Interface, gvr schema.GroupVersionResource) (*T, error) {
+	list, err := client.Resource(gvr).
+		List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	structuredList := new(T)
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(list.UnstructuredContent(), structuredList)
+	return structuredList, err
 }

--- a/internal/kube/kyma/types.go
+++ b/internal/kube/kyma/types.go
@@ -114,6 +114,7 @@ type Module struct {
 	ControllerName       string `json:"controller,omitempty"`
 	Channel              string `json:"channel,omitempty"`
 	CustomResourcePolicy string `json:"customResourcePolicy,omitempty"`
+	Managed              bool   `json:"managed,omitempty"`
 }
 
 // KymaStatus defines the observed state of Kyma
@@ -125,6 +126,7 @@ type ModuleStatus struct {
 	Name    string `json:"name"`
 	Channel string `json:"channel,omitempty"`
 	Version string `json:"version,omitempty"`
+	State   string `json:"state,omitempty"`
 }
 
 // ModuleFromInterface converts a map retrieved from the Unstructured kyma CR to a Module struct.

--- a/internal/modules/modules.go
+++ b/internal/modules/modules.go
@@ -4,11 +4,26 @@ import (
 	"context"
 
 	"github.com/kyma-project/cli.v3/internal/kube/kyma"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 type Module struct {
-	Name     string
-	Versions []ModuleVersion
+	Name           string
+	Versions       []ModuleVersion
+	InstallDetails ModuleInstallDetails
+}
+
+type Managed string
+
+const (
+	ManagedTrue  Managed = "true"
+	ManagedFalse Managed = "false"
+)
+
+type ModuleInstallDetails struct {
+	Version string
+	Channel string
+	Managed Managed
 }
 
 type ModuleVersion struct {
@@ -30,25 +45,38 @@ func List(ctx context.Context, client kyma.Interface) (ModulesList, error) {
 		return nil, err
 	}
 
+	defaultKyma, err := client.GetDefaultKyma(ctx)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	// assign spec to another value to operate on nil-free value
+	defaultKymaSpec := kyma.KymaSpec{}
+	if defaultKyma != nil {
+		defaultKymaSpec = defaultKyma.Spec
+	}
+
 	modulesList := ModulesList{}
 	for _, moduleTemplate := range moduleTemplates.Items {
+		moduleName := moduleTemplate.Spec.ModuleName
 		version := ModuleVersion{
 			Version:    moduleTemplate.Spec.Version,
 			Repository: moduleTemplate.Spec.Info.Repository,
 			Channel: getAssignedChannel(
 				*modulereleasemetas,
-				moduleTemplate.Spec.ModuleName,
+				moduleName,
 				moduleTemplate.Spec.Version,
 			),
 		}
 
-		if i := getModuleIndex(modulesList, moduleTemplate.Spec.ModuleName); i != -1 {
+		if i := getModuleIndex(modulesList, moduleName); i != -1 {
 			// append version if module with same name is in the list
 			modulesList[i].Versions = append(modulesList[i].Versions, version)
 		} else {
 			// otherwise create anew record in the list
 			modulesList = append(modulesList, Module{
-				Name: moduleTemplate.Spec.ModuleName,
+				Name:           moduleName,
+				InstallDetails: getInstallDetails(defaultKymaSpec, *modulereleasemetas, moduleName),
 				Versions: []ModuleVersion{
 					version,
 				},
@@ -57,6 +85,28 @@ func List(ctx context.Context, client kyma.Interface) (ModulesList, error) {
 	}
 
 	return modulesList, nil
+}
+
+func getInstallDetails(kymaSpec kyma.KymaSpec, releaseMetas kyma.ModuleReleaseMetaList, moduleName string) ModuleInstallDetails {
+	for _, module := range kymaSpec.Modules {
+		if module.Name == moduleName {
+			moduleChannel := kymaSpec.Channel
+			if module.Channel != "" {
+				moduleChannel = module.Channel
+			}
+
+			return ModuleInstallDetails{
+				Channel: moduleChannel,
+				Version: getAssignedVersion(releaseMetas, module.Name, moduleChannel),
+				Managed: ManagedTrue,
+			}
+		}
+	}
+
+	// TODO: support community modules
+
+	// return empty struct because module is not installed
+	return ModuleInstallDetails{}
 }
 
 // look for channel assigned to version with specified moduleName
@@ -69,10 +119,30 @@ func getAssignedChannel(releaseMetas kyma.ModuleReleaseMetaList, moduleName, ver
 	return ""
 }
 
+// look for version assigned to channel with specified moduleName
+func getAssignedVersion(releaseMetas kyma.ModuleReleaseMetaList, moduleName, channel string) string {
+	for _, releaseMeta := range releaseMetas.Items {
+		if releaseMeta.Spec.ModuleName == moduleName {
+			return getVersionFromAssignments(releaseMeta.Spec.Channels, channel)
+		}
+	}
+	return ""
+}
+
 func getChannelFromAssignments(assignments []kyma.ChannelVersionAssignment, version string) string {
 	for _, assignment := range assignments {
 		if assignment.Version == version {
 			return assignment.Channel
+		}
+	}
+
+	return ""
+}
+
+func getVersionFromAssignments(assignments []kyma.ChannelVersionAssignment, channel string) string {
+	for _, assignment := range assignments {
+		if assignment.Channel == channel {
+			return assignment.Version
 		}
 	}
 

--- a/internal/modules/modules_test.go
+++ b/internal/modules/modules_test.go
@@ -138,11 +138,23 @@ var (
 				"modules": []interface{}{
 					map[string]interface{}{
 						"name":    "serverless",
-						"channel": "regular",
+						"managed": false,
 					},
 					map[string]interface{}{
 						"name":    "keda",
-						"channel": "fast",
+						"managed": true,
+					},
+				},
+			},
+			"status": map[string]interface{}{
+				"modules": []interface{}{
+					map[string]interface{}{
+						"name":    "serverless",
+						"version": "0.0.1",
+					},
+					map[string]interface{}{
+						"name":    "keda",
+						"version": "0.2",
 					},
 				},
 			},
@@ -172,9 +184,9 @@ var (
 		{
 			Name: "serverless",
 			InstallDetails: ModuleInstallDetails{
-				Managed: ManagedTrue,
-				Channel: "regular",
-				Version: "0.0.2",
+				Managed: ManagedFalse,
+				Channel: "fast",
+				Version: "0.0.1",
 			},
 			Versions: []ModuleVersion{
 				{

--- a/internal/modules/render_test.go
+++ b/internal/modules/render_test.go
@@ -9,17 +9,28 @@ import (
 )
 
 const (
-	testModulesTableView = "NAME      \tREPOSITORY  \tVERSIONS                  \nkeda      \turl-3       \t0.1 (regular), 0.2 (fast)\t\nserverless\turl-1, url-2\t0.0.1 (fast), 0.0.2      \t\n"
+	testModulesTableView        = "NAME      \tREPOSITORY  \tVERSIONS                 \tINSTALLED\tMANAGED \n   keda   \t   url-3    \t0.1 (regular), 0.2 (fast)\t  false  \t false \t\nserverless\turl-1, url-2\t   0.0.1 (fast), 0.0.2   \t  false  \t false \t\n"
+	testManagedModulesTableView = "NAME      \tREPOSITORY  \tVERSIONS                 \tINSTALLED\tMANAGED \n   keda   \t   url-3    \t0.1 (regular), 0.2 (fast)\t  true   \t true  \t\nserverless\turl-1, url-2\t   0.0.1 (fast), 0.0.2   \t  true   \t true  \t\n"
 )
 
 func TestRender(t *testing.T) {
 	t.Run("render table from modules", func(t *testing.T) {
 		buffer := bytes.NewBuffer([]byte{})
 
-		render(buffer, fixModuleList(), ModulesTableInfo)
+		render(buffer, testModuleList, ModulesTableInfo)
 
 		tableViewBytes, err := io.ReadAll(buffer)
 		require.NoError(t, err)
 		require.Equal(t, testModulesTableView, string(tableViewBytes))
+	})
+
+	t.Run("render table from managed modules", func(t *testing.T) {
+		buffer := bytes.NewBuffer([]byte{})
+
+		render(buffer, testManagedModuleList, ModulesTableInfo)
+
+		tableViewBytes, err := io.ReadAll(buffer)
+		require.NoError(t, err)
+		require.Equal(t, testManagedModulesTableView, string(tableViewBytes))
 	})
 }

--- a/internal/modules/render_test.go
+++ b/internal/modules/render_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	testModulesTableView        = "NAME      \tREPOSITORY  \tVERSIONS                 \tINSTALLED\tMANAGED \n   keda   \t   url-3    \t0.1 (regular), 0.2 (fast)\t  false  \t false \t\nserverless\turl-1, url-2\t   0.0.1 (fast), 0.0.2   \t  false  \t false \t\n"
-	testManagedModulesTableView = "NAME      \tREPOSITORY  \tVERSIONS                 \tINSTALLED\tMANAGED \n   keda   \t   url-3    \t0.1 (regular), 0.2 (fast)\t  true   \t true  \t\nserverless\turl-1, url-2\t   0.0.1 (fast), 0.0.2   \t  true   \t true  \t\n"
+	testModulesTableView        = "NAME      \tVERSIONS               \tINSTALLED\tMANAGED \nkeda      \t0.1(regular), 0.2(fast)\t         \t       \t\nserverless\t0.0.1(fast), 0.0.2     \t         \t       \t\n"
+	testManagedModulesTableView = "NAME      \tVERSIONS               \tINSTALLED  \tMANAGED \nkeda      \t0.1(regular), 0.2(fast)\t0.2(fast)  \ttrue   \t\nserverless\t0.0.1(fast), 0.0.2     \t0.0.1(fast)\tfalse  \t\n"
 )
 
 func TestRender(t *testing.T) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- implement new headers (`INSTALLED` and `MANAGED`)
- the `INSTALLED` contains installed version with channel
- the `MANAGED` is a boolean value that informs if a module is installed via the KymaCR and has the `.managed` field set to true

The xample `module list` output:

```bash
NAME                    VERSIONS                        INSTALLED                       MANAGED
docker-registry         0.3.0, 0.4.0
keda                    1.2.0, 1.3.0(regular),
                        1.4.0(fast),
                        1.5.0(experimental)
serverless              1.5.0(regular), 1.5.1,
                        1.6.0(fast)
template-operator       0.0.1-catalog-meta(regular),    0.0.2-catalog-meta(fast)        true
                        0.0.2-catalog-meta(fast)
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/cli/issues/2253