### PR TITLE
feat: Add dry-run flag to prevent pushing module template to registry

### DIFF
--- a/cmd/kyma/alpha/create/module/module.go
+++ b/cmd/kyma/alpha/create/module/module.go
@@ -197,6 +197,8 @@ Build a Kubebuilder module my-domain/modC in version 3.2.1 and push it to a loca
 	cmd.Flags().BoolVar(&o.KubebuilderProject, "kubebuilder-project", false,
 		"Specifies provided module is a Kubebuilder Project.")
 
+	cmd.Flags().BoolVar(&o.DryRun, "dry-run", false, "Prevents pushing the module to the registry, signing and generating the module template.")
+
 	configureLegacyFlags(cmd, o)
 
 	return cmd
@@ -387,6 +389,11 @@ func (cmd *command) Run(cobraCmd *cobra.Command) error {
 	if err != nil {
 		cmd.CurrentStep.Failure()
 		return err
+	}
+
+	if cmd.opts.DryRun {
+		cmd.CurrentStep.Successf("Image not pushed to %q due to the dry-run flag", cmd.opts.RegistryURL)
+		return nil
 	}
 
 	if shouldPushArchive {

--- a/cmd/kyma/alpha/create/module/opts.go
+++ b/cmd/kyma/alpha/create/module/opts.go
@@ -41,6 +41,7 @@ type Options struct {
 	ModuleConfigFile        string
 	KubebuilderProject      bool
 	Namespace               string
+	DryRun                  bool
 }
 
 const (

--- a/docs/gen-docs/kyma_alpha_create_module.md
+++ b/docs/gen-docs/kyma_alpha_create_module.md
@@ -91,6 +91,7 @@ Build a Kubebuilder module my-domain/modC in version 3.2.1 and push it to a loca
   -c, --credentials string                 Basic authentication credentials for the given registry in the user:password format
       --default-cr string                  File containing the default custom resource of the module. If the module is a kubebuilder project, the default CR is automatically detected.
       --descriptor-version string          Schema version to use for the generated OCM descriptor. One of ocm.software/v3alpha1,v2 (default "v2")
+      --dry-run                            Prevents pushing the module to the registry, signing and generating the module template.
       --git-remote string                  Specifies the remote name of the wanted GitHub repository. For Example "origin" or "upstream" (default "origin")
       --insecure                           Uses an insecure connection to access the registry.
       --key string                         Specifies the path where a private key is used for signing.

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -33,7 +33,7 @@ func Test_GetFile(t *testing.T) {
 		assert.Equal(t, currFile, file, "Local files should not be copied to the dst-folder")
 	})
 	t.Run("Retrieve remote file", func(t *testing.T) {
-		file, err := File("https://raw.githubusercontent.com/kyma-project/cli/main/LICENCE", testDir)
+		file, err := File("https://raw.githubusercontent.com/kyma-project/cli/release-2.20/LICENCE", testDir)
 		assert.NoError(t, err)
 		assert.Equal(t, filepath.Join(testDir, "LICENCE"), file, "Remote files should be copied to the dst-folder")
 	})

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -33,7 +33,7 @@ func Test_GetFile(t *testing.T) {
 		assert.Equal(t, currFile, file, "Local files should not be copied to the dst-folder")
 	})
 	t.Run("Retrieve remote file", func(t *testing.T) {
-		file, err := File("https://raw.githubusercontent.com/kyma-project/cli/release-2.20/LICENCE", testDir)
+		file, err := File("https://raw.githubusercontent.com/kyma-project/cli/main/LICENSE", testDir)
 		assert.NoError(t, err)
 		assert.Equal(t, filepath.Join(testDir, "LICENCE"), file, "Remote files should be copied to the dst-folder")
 	})


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

In neighbors team, we need to validate only the possibility to push module template to registry.
It's required to write correct check for submission pipeline. See: https://github.tools.sap/kyma/test-infra/issues/469

Changes proposed in this pull request:

- Add `dry-run` flag to `kyma alpha create module` to preventing push of module template

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See: https://github.tools.sap/kyma/test-infra/issues/469