### PR TITLE
Improve missing in-cluster registry hint suffix

### DIFF
--- a/internal/cmd/alpha/module/add.go
+++ b/internal/cmd/alpha/module/add.go
@@ -34,7 +34,7 @@ func newAddCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&cfg.channel, "channel", "", "Name of the Kyma channel to use for the module")
+	cmd.Flags().StringVarP(&cfg.channel, "channel", "c", "", "Name of the Kyma channel to use for the module")
 	cmd.Flags().StringVar(&cfg.crPath, "cr-path", "", "Path to the custom resource file")
 	cmd.Flags().BoolVar(&cfg.defaultCR, "default-cr", false, "Use this flag to deploy module with default cr")
 

--- a/internal/registry/config.go
+++ b/internal/registry/config.go
@@ -32,7 +32,7 @@ func GetExternalConfig(ctx context.Context, client kube.Client) (*ExternalRegist
 		return nil, clierror.Wrap(err,
 			clierror.New("failed to get external registry configuration",
 				"make sure cluster is available and properly configured",
-				"enable docker registry module by calling `kyma alpha module enable docker-registry -c experimental`",
+				"enable docker registry module by calling `kyma alpha module enable docker-registry -c experimental --default-cr`",
 			),
 		)
 	}
@@ -46,7 +46,7 @@ func GetInternalConfig(ctx context.Context, client kube.Client) (*InternalRegist
 		return nil, clierror.Wrap(err,
 			clierror.New("failed to load in-cluster registry configuration",
 				"make sure cluster is available and properly configured",
-				"enable docker registry module by calling `kyma alpha module enable docker-registry -c experimental`",
+				"enable docker registry module by calling `kyma alpha module enable docker-registry -c experimental --default-cr`",
 			),
 		)
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- add `--default-cr` flag to the missing registry error hint

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/cli/issues/2280