### PR TITLE
fix: don't fail getting state on not installed modules

### DIFF
--- a/internal/modules/list.go
+++ b/internal/modules/list.go
@@ -76,7 +76,7 @@ func List(ctx context.Context, client kube.Client) (ModulesList, error) {
 			),
 		}
 
-		moduleInstalled := getModuleInstalledState(defaultKyma, moduleName)
+		moduleInstalled := isModuleInstalled(defaultKyma, moduleName)
 
 		state := ""
 		if moduleInstalled {
@@ -249,7 +249,7 @@ func getStateFromConditions(conditions []interface{}) string {
 	return ""
 }
 
-func getModuleInstalledState(kyma *kyma.Kyma, moduleName string) bool {
+func isModuleInstalled(kyma *kyma.Kyma, moduleName string) bool {
 	if kyma != nil {
 		for _, module := range kyma.Status.Modules {
 			if module.Name == moduleName {

--- a/internal/modules/list.go
+++ b/internal/modules/list.go
@@ -76,11 +76,16 @@ func List(ctx context.Context, client kube.Client) (ModulesList, error) {
 			),
 		}
 
-		state, err := getModuleState(ctx, client, moduleTemplate, defaultKyma)
-		if err != nil {
-			return nil, err
-		}
+		moduleInstalled := getModuleInstalledState(defaultKyma, moduleName)
 
+		state := ""
+		if moduleInstalled {
+			// only get state of installed modules
+			state, err = getModuleState(ctx, client, moduleTemplate, defaultKyma)
+			if err != nil {
+				return nil, err
+			}
+		}
 		if i := getModuleIndex(modulesList, moduleName); i != -1 {
 			// append version if module with same name is in the list
 			modulesList[i].Versions = append(modulesList[i].Versions, version)
@@ -168,7 +173,6 @@ func getResourceState(ctx context.Context, client kube.Client, manager *kyma.Man
 	apiVersion := fmt.Sprintf("%s/%s", manager.Group, manager.Version)
 
 	unstruct := generateUnstruct(apiVersion, manager.Kind, manager.Name, namespace)
-
 	result, err := client.RootlessDynamic().Get(ctx, &unstruct)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -243,6 +247,19 @@ func getStateFromConditions(conditions []interface{}) string {
 		}
 	}
 	return ""
+}
+
+func getModuleInstalledState(kyma *kyma.Kyma, moduleName string) bool {
+	if kyma != nil {
+		for _, module := range kyma.Status.Modules {
+			if module.Name == moduleName {
+				return true
+			}
+		}
+	}
+
+	// module is not installed
+	return false
 }
 
 func getInstallDetails(kyma *kyma.Kyma, releaseMetas kyma.ModuleReleaseMetaList, moduleName, state string) ModuleInstallDetails {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- don't try to get module state if the module is not installed

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- #2264