### PR TITLE
Unify flags and commands descriptions

### DIFF
--- a/internal/cmd/alpha/alpha.go
+++ b/internal/cmd/alpha/alpha.go
@@ -19,8 +19,8 @@ import (
 func NewAlphaCMD() (*cobra.Command, clierror.Error) {
 	cmd := &cobra.Command{
 		Use:                   "alpha",
-		Short:                 "Groups command prototypes the API for which may still change.",
-		Long:                  `A set of alpha prototypes that may still change. Use in automations on your own risk.`,
+		Short:                 "Groups command prototypes the API for which may still change",
+		Long:                  `A set of alpha prototypes that may still change. Use in automations on your own risk`,
 		DisableFlagsInUseLine: true,
 	}
 

--- a/internal/cmd/alpha/app/app.go
+++ b/internal/cmd/alpha/app/app.go
@@ -8,8 +8,8 @@ import (
 func NewAppCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "app",
-		Short:                 "Manage applications on Kubernetes cluster.",
-		Long:                  `Use this command to manage applications on the Kubernetes cluster.`,
+		Short:                 "Manage applications on Kubernetes cluster",
+		Long:                  `Use this command to manage applications on the Kubernetes cluster`,
 		DisableFlagsInUseLine: true,
 	}
 

--- a/internal/cmd/alpha/app/push.go
+++ b/internal/cmd/alpha/app/push.go
@@ -40,8 +40,8 @@ func NewAppPushCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "push",
-		Short: "Push the application to the Kubernetes cluster.",
-		Long:  "Use this command to push the application to the Kubernetes cluster.",
+		Short: "Push the application to the Kubernetes cluster",
+		Long:  "Use this command to push the application to the Kubernetes cluster",
 
 		PreRun: func(_ *cobra.Command, args []string) {
 			clierror.Check(config.complete())

--- a/internal/cmd/alpha/hana/hana.go
+++ b/internal/cmd/alpha/hana/hana.go
@@ -8,8 +8,8 @@ import (
 func NewHanaCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                   "hana",
-		Short:                 "Manage a Hana instance on the Kyma platform.",
-		Long:                  `Use this command to manage a Hana instance on the SAP Kyma platform.`,
+		Short:                 "Manage a Hana instance on the Kyma platform",
+		Long:                  `Use this command to manage a Hana instance on the SAP Kyma platform`,
 		DisableFlagsInUseLine: true,
 	}
 

--- a/internal/cmd/alpha/hana/map.go
+++ b/internal/cmd/alpha/hana/map.go
@@ -27,15 +27,15 @@ func NewMapHanaCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "map",
-		Short: "Map the Hana instance to the Kyma cluster.",
-		Long:  "Use this command to map the Hana instance to the Kyma cluster.",
+		Short: "Map the Hana instance to the Kyma cluster",
+		Long:  "Use this command to map the Hana instance to the Kyma cluster",
 		Run: func(_ *cobra.Command, _ []string) {
 			clierror.Check(runHanaMap(&config))
 		},
 	}
 
-	cmd.Flags().StringVar(&config.credentialsPath, "credentials-path", "", "Path to the credentials json file.")
-	cmd.Flags().StringVar(&config.hanaID, "hana-id", "", "Hana instance ID.")
+	cmd.Flags().StringVar(&config.credentialsPath, "credentials-path", "", "Path to the credentials json file")
+	cmd.Flags().StringVar(&config.hanaID, "hana-id", "", "Hana instance ID")
 	_ = cmd.MarkFlagRequired("credentials-path")
 
 	return cmd

--- a/internal/cmd/alpha/module/add.go
+++ b/internal/cmd/alpha/module/add.go
@@ -25,8 +25,8 @@ func newAddCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "add <module>",
-		Short: "Add module.",
-		Long:  "Use this command to add module.",
+		Short: "Add module",
+		Long:  "Use this command to add module",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg.module = args[0]

--- a/internal/cmd/alpha/module/catalog.go
+++ b/internal/cmd/alpha/module/catalog.go
@@ -18,8 +18,8 @@ func newCatalogCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "catalog",
-		Short: "List modules catalog.",
-		Long:  `List available Kyma modules.`,
+		Short: "List modules catalog",
+		Long:  `List available Kyma modules`,
 		Run: func(_ *cobra.Command, _ []string) {
 			clierror.Check(catalogModules(&cfg))
 		},

--- a/internal/cmd/alpha/module/delete.go
+++ b/internal/cmd/alpha/module/delete.go
@@ -19,10 +19,11 @@ func newDeleteCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "delete <module>",
-		Short: "Delete module",
-		Long:  "Use this command to delete module",
-		Args:  cobra.ExactArgs(1),
+		Use:     "delete <module>",
+		Short:   "Delete module",
+		Aliases: []string{"del"},
+		Long:    "Use this command to delete module",
+		Args:    cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg.module = args[0]
 			clierror.Check(runDelete(&cfg))

--- a/internal/cmd/alpha/module/list.go
+++ b/internal/cmd/alpha/module/list.go
@@ -18,8 +18,8 @@ func newListCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "list",
-		Short: "List installed modules.",
-		Long:  `List installed Kyma modules.`,
+		Short: "List installed modules",
+		Long:  `List installed Kyma modules`,
 		Run: func(_ *cobra.Command, _ []string) {
 			clierror.Check(listModules(&cfg))
 		},

--- a/internal/cmd/alpha/module/manage.go
+++ b/internal/cmd/alpha/module/manage.go
@@ -2,6 +2,7 @@ package module
 
 import (
 	"fmt"
+
 	"github.com/kyma-project/cli.v3/internal/clierror"
 	"github.com/kyma-project/cli.v3/internal/cmdcommon"
 	"github.com/spf13/cobra"
@@ -21,8 +22,8 @@ func newManageCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "manage <module>",
-		Short: "Manage module.",
-		Long:  "Use this command to manage an existing module.",
+		Short: "Manage module",
+		Long:  "Use this command to manage an existing module",
 		Args:  cobra.ExactArgs(1),
 		PreRun: func(_ *cobra.Command, args []string) {
 			clierror.Check(cfg.validate())
@@ -33,7 +34,7 @@ func newManageCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&cfg.policy, "policy", "CreateAndDelete", "Set custom resource policy. (Possible values: CreateAndDelete, Ignore)")
+	cmd.Flags().StringVar(&cfg.policy, "policy", "CreateAndDelete", "Set custom resource policy (Possible values: CreateAndDelete, Ignore)")
 	return cmd
 }
 

--- a/internal/cmd/alpha/module/module.go
+++ b/internal/cmd/alpha/module/module.go
@@ -9,8 +9,8 @@ func NewModuleCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "module",
 		Aliases: []string{"modules"},
-		Short:   "Manage kyma modules.",
-		Long:    `Use this command to manage modules on a kyma cluster.`,
+		Short:   "Manage kyma modules",
+		Long:    `Use this command to manage modules on a kyma cluster`,
 	}
 
 	cmd.AddCommand(newListCMD(kymaConfig))

--- a/internal/cmd/alpha/module/unmanage.go
+++ b/internal/cmd/alpha/module/unmanage.go
@@ -2,6 +2,7 @@ package module
 
 import (
 	"fmt"
+
 	"github.com/kyma-project/cli.v3/internal/clierror"
 	"github.com/kyma-project/cli.v3/internal/cmdcommon"
 	"github.com/spf13/cobra"
@@ -20,8 +21,8 @@ func newUnmanageCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "unmanage <module>",
-		Short: "Unmanage module.",
-		Long:  "Use this command to unmanage an existing module.",
+		Short: "Unmanage module",
+		Long:  "Use this command to unmanage an existing module",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg.module = args[0]

--- a/internal/cmd/alpha/oidc/oidc.go
+++ b/internal/cmd/alpha/oidc/oidc.go
@@ -51,7 +51,7 @@ func NewOIDCCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&cfg.cisCredentialsPath, "credentials-path", "", "Path to the CIS credentials file.")
+	cmd.Flags().StringVar(&cfg.cisCredentialsPath, "credentials-path", "", "Path to the CIS credentials file")
 	cmd.Flags().StringVar(&cfg.output, "output", "", "Path to the output kubeconfig file")
 
 	cmd.Flags().StringVar(&cfg.token, "token", "", "Token used in the kubeconfig")

--- a/internal/cmd/alpha/provision/provision.go
+++ b/internal/cmd/alpha/provision/provision.go
@@ -27,22 +27,21 @@ func NewProvisionCMD() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "provision",
-		Short: "Provisions a Kyma cluster on the BTP.",
-		Long: `Use this command to provision a Kyma environment on the SAP BTP platform.
-`,
+		Short: "Provisions a Kyma cluster on the BTP",
+		Long:  `Use this command to provision a Kyma environment on the SAP BTP platform`,
 		Run: func(_ *cobra.Command, _ []string) {
 			clierror.Check(runProvision(&config))
 		},
 	}
 
-	cmd.Flags().StringVar(&config.credentialsPath, "credentials-path", "", "Path to the CIS credentials file.")
+	cmd.Flags().StringVar(&config.credentialsPath, "credentials-path", "", "Path to the CIS credentials file")
 
-	cmd.Flags().StringVar(&config.plan, "plan", "trial", "Name of the Kyma environment plan, e.g trial, azure, aws, gcp.")
-	cmd.Flags().StringVar(&config.environmentName, "environment-name", "kyma", "Name of the environment in the BTP.")
-	cmd.Flags().StringVar(&config.clusterName, "cluster-name", "kyma", "Name of the Kyma cluster.")
-	cmd.Flags().StringVar(&config.region, "region", "", "Name of the region of the Kyma cluster.")
-	cmd.Flags().StringVar(&config.owner, "owner", "", "Email of the owner of the Kyma cluster.")
-	cmd.Flags().StringVar(&config.parametersPath, "parameters", "", "Path to the JSON file with Kyma configuration.")
+	cmd.Flags().StringVar(&config.plan, "plan", "trial", "Name of the Kyma environment plan, e.g trial, azure, aws, gcp")
+	cmd.Flags().StringVar(&config.environmentName, "environment-name", "kyma", "Name of the environment in the BTP")
+	cmd.Flags().StringVar(&config.clusterName, "cluster-name", "kyma", "Name of the Kyma cluster")
+	cmd.Flags().StringVar(&config.region, "region", "", "Name of the region of the Kyma cluster")
+	cmd.Flags().StringVar(&config.owner, "owner", "", "Email of the owner of the Kyma cluster")
+	cmd.Flags().StringVar(&config.parametersPath, "parameters", "", "Path to the JSON file with Kyma configuration")
 
 	_ = cmd.MarkFlagRequired("credentials-path")
 	_ = cmd.MarkFlagRequired("owner")

--- a/internal/cmd/alpha/referenceinstance/referenceinstance.go
+++ b/internal/cmd/alpha/referenceinstance/referenceinstance.go
@@ -27,21 +27,20 @@ func NewReferenceInstanceCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "reference-instance",
-		Short: "Add an instance reference to a shared service instance.",
-		Long: `Use this command to add an instance reference to a shared service instance on the SAP Kyma platform.
-`,
+		Short: "Add an instance reference to a shared service instance",
+		Long:  `Use this command to add an instance reference to a shared service instance on the SAP Kyma platform`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			return runReferenceInstance(config)
 		},
 	}
 
-	cmd.Flags().StringVar(&config.namespace, "namespace", "default", "Namespace of the reference instance.")
-	cmd.Flags().StringVar(&config.offeringName, "offering-name", "", "Offering name.")
-	cmd.Flags().StringVar(&config.referenceName, "reference-name", "", "Name of the reference.")
-	cmd.Flags().StringVar(&config.instanceID, "instance-id", "", "ID of the instance.")
-	cmd.Flags().StringSliceVar(&config.labelSelector, "label-selector", nil, "Label selector for filtering instances.")
-	cmd.Flags().StringVar(&config.nameSelector, "name-selector", "", "Instance name selector for filtering instances.")
-	cmd.Flags().StringVar(&config.planSelector, "plan-selector", "", "Plan name selector for filtering instances.")
+	cmd.Flags().StringVar(&config.namespace, "namespace", "default", "Namespace of the reference instance")
+	cmd.Flags().StringVar(&config.offeringName, "offering-name", "", "Offering name")
+	cmd.Flags().StringVar(&config.referenceName, "reference-name", "", "Name of the reference")
+	cmd.Flags().StringVar(&config.instanceID, "instance-id", "", "ID of the instance")
+	cmd.Flags().StringSliceVar(&config.labelSelector, "label-selector", nil, "Label selector for filtering instances")
+	cmd.Flags().StringVar(&config.nameSelector, "name-selector", "", "Instance name selector for filtering instances")
+	cmd.Flags().StringVar(&config.planSelector, "plan-selector", "", "Plan name selector for filtering instances")
 	cmd.Flags().StringVar(&config.btpSecretName, "btp-secret-name", "", "name of the BTP secret containing credentials to another subaccount Service Manager:\nhttps://github.com/SAP/sap-btp-service-operator/blob/main/README.md#working-with-multiple-subaccounts")
 
 	// either instance id or selectors can be used

--- a/internal/cmd/alpha/registry/config/config.go
+++ b/internal/cmd/alpha/registry/config/config.go
@@ -31,8 +31,8 @@ func NewConfigCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&cfg.externalurl, "externalurl", false, "External URL for the Kyma registry.")
-	cmd.Flags().StringVar(&cfg.output, "output", "", "Path where the output file should be saved to. NOTE: docker expects the file to be named `config.json`.")
+	cmd.Flags().BoolVar(&cfg.externalurl, "externalurl", false, "External URL for the Kyma registry")
+	cmd.Flags().StringVar(&cfg.output, "output", "", "Path where the output file should be saved to. NOTE: docker expects the file to be named `config.json`")
 
 	return cmd
 }

--- a/internal/cmd/alpha/registry/imageimport/imageimport.go
+++ b/internal/cmd/alpha/registry/imageimport/imageimport.go
@@ -22,9 +22,9 @@ func NewImportCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "image-import",
-		Short: "Import image to in-cluster registry.",
-		Long:  `Import image from daemon to in-cluster registry.`,
+		Use:   "image-import <image>",
+		Short: "Import image to in-cluster registry",
+		Long:  `Import image from daemon to in-cluster registry`,
 		Args:  cobra.ExactArgs(1),
 
 		PreRun: func(_ *cobra.Command, args []string) {

--- a/internal/cmd/alpha/templates/create.go
+++ b/internal/cmd/alpha/templates/create.go
@@ -33,7 +33,7 @@ func BuildCreateCommand(clientGetter KubeClientGetter, options *CreateOptions) *
 func buildCreateCommand(out io.Writer, clientGetter KubeClientGetter, options *CreateOptions) *cobra.Command {
 	extraValues := []parameters.Value{}
 	cmd := &cobra.Command{
-		Use:     "create",
+		Use:     "create <resource_name>",
 		Short:   options.Description,
 		Long:    options.DescriptionLong,
 		Example: buildCreateExample(options),

--- a/internal/cmd/alpha/templates/create_test.go
+++ b/internal/cmd/alpha/templates/create_test.go
@@ -21,7 +21,7 @@ func Test_create(t *testing.T) {
 	t.Run("build proper command", func(t *testing.T) {
 		cmd := fixCreateCommand(bytes.NewBuffer([]byte{}), &mockGetter{})
 
-		require.Equal(t, "create", cmd.Use)
+		require.Equal(t, "create <resource_name>", cmd.Use)
 		require.Equal(t, "create test deploy", cmd.Short)
 		require.Equal(t, "use this to create test deploy", cmd.Long)
 

--- a/internal/cmd/alpha/templates/delete.go
+++ b/internal/cmd/alpha/templates/delete.go
@@ -28,7 +28,7 @@ func BuildDeleteCommand(clientGetter KubeClientGetter, options *DeleteOptions) *
 func buildDeleteCommand(out io.Writer, clientGetter KubeClientGetter, options *DeleteOptions) *cobra.Command {
 	extraValues := []parameters.Value{}
 	cmd := &cobra.Command{
-		Use:     "delete",
+		Use:     "delete <resource_name>",
 		Short:   options.Description,
 		Long:    options.DescriptionLong,
 		Example: buildDeleteExample(options),

--- a/internal/cmd/alpha/templates/delete_test.go
+++ b/internal/cmd/alpha/templates/delete_test.go
@@ -19,7 +19,7 @@ func Test_remove(t *testing.T) {
 	t.Run("build proper command", func(t *testing.T) {
 		cmd := fixDeleteCommand(bytes.NewBuffer([]byte{}), &mockGetter{})
 
-		require.Equal(t, "delete", cmd.Use)
+		require.Equal(t, "delete <resource_name>", cmd.Use)
 		require.Equal(t, "delete test deploy", cmd.Short)
 		require.Equal(t, "use this to delete test deploy", cmd.Long)
 

--- a/internal/cmd/alpha/templates/get.go
+++ b/internal/cmd/alpha/templates/get.go
@@ -32,7 +32,7 @@ func BuildGetCommand(clientGetter KubeClientGetter, options *GetOptions) *cobra.
 func buildGetCommand(out io.Writer, clientGetter KubeClientGetter, options *GetOptions) *cobra.Command {
 	flags := flags{}
 	cmd := &cobra.Command{
-		Use:     "get",
+		Use:     "get [<resource_name>]",
 		Example: buildGetExample(options),
 		Short:   options.Description,
 		Long:    options.DescriptionLong,
@@ -61,7 +61,7 @@ func buildGetExample(options *GetOptions) string {
 		"  kyma alpha ROOT_COMMAND get\n" +
 		"\n" +
 		"  # get resource with a specific name\n" +
-		"  kyma alpha ROOT_COMMAND get resource_name"
+		"  kyma alpha ROOT_COMMAND get <resource_name>"
 
 	if options.ResourceInfo.Scope == types.NamespaceScope {
 		template += "\n\n" +

--- a/internal/cmd/alpha/templates/get_test.go
+++ b/internal/cmd/alpha/templates/get_test.go
@@ -25,7 +25,7 @@ func Test_get(t *testing.T) {
 			},
 		})
 
-		require.Equal(t, "get", cmd.Use)
+		require.Equal(t, "get [<resource_name>]", cmd.Use)
 		require.Equal(t, "get test deploy", cmd.Short)
 		require.Equal(t, "use this to get test deploy", cmd.Long)
 

--- a/internal/cmd/kyma.go
+++ b/internal/cmd/kyma.go
@@ -8,8 +8,8 @@ import (
 
 func NewKymaCMD() (*cobra.Command, clierror.Error) {
 	cmd := &cobra.Command{
-		Use: "kyma",
-
+		Use:   "kyma",
+		Short: "Simple set of commands to manage a Kyma cluster",
 		// Affects children as well
 		// by default Cobra adds `Error:` to the front of the error message, we want to suppress it
 		SilenceErrors: true,
@@ -20,6 +20,7 @@ func NewKymaCMD() (*cobra.Command, clierror.Error) {
 			}
 		},
 	}
+	cmd.PersistentFlags().BoolP("help", "h", false, "Help for the command")
 
 	alpha, err := alpha.NewAlphaCMD()
 	if err != nil {

--- a/internal/cmdcommon/extension.go
+++ b/internal/cmdcommon/extension.go
@@ -41,7 +41,7 @@ func newExtensionsConfig(config *KymaConfig, cmd *cobra.Command) *KymaExtensions
 
 func (kec *KymaExtensionsConfig) addFlag(cmd *cobra.Command) {
 	// this flag is not operational. it's only to print help description and help cobra with validation
-	_ = cmd.PersistentFlags().Bool("show-extensions-error", false, "Print possible error when fetching extensions failed.")
+	_ = cmd.PersistentFlags().Bool("show-extensions-error", false, "Print possible error when fetching extensions failed")
 }
 
 func (kec *KymaExtensionsConfig) GetRawExtensions() ExtensionList {

--- a/internal/cmdcommon/kubeconfig.go
+++ b/internal/cmdcommon/kubeconfig.go
@@ -39,7 +39,7 @@ func (kcc *KubeClientConfig) GetKubeClientWithClierr() (kube.Client, clierror.Er
 
 func (kcc *KubeClientConfig) addFlag(cmd *cobra.Command) {
 	// this flag is not operational. it's only to print help description and help cobra with validation
-	_ = cmd.PersistentFlags().String("kubeconfig", "", "Path to the Kyma kubeconfig file.")
+	_ = cmd.PersistentFlags().String("kubeconfig", "", "Path to the Kyma kubeconfig file")
 }
 
 func (kcc *KubeClientConfig) complete() {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- unify commands and flags descriptions (capital first letter, ended without dot)
- add alias for the `alpha module delete` cmd - `alpha module del`
- add the `-h|--help` persistent flag with improved description

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/cli/issues/2352