### PR TITLE
Minor fixes for docs generator

### DIFF
--- a/gen-docs/main.go
+++ b/gen-docs/main.go
@@ -20,6 +20,7 @@ func main() {
 	clierror.Check(clierr)
 
 	docsTargetDir := "./docs/user/gen-docs"
+	command.InitDefaultCompletionCmd()
 	err := genMarkdownTree(command, docsTargetDir)
 	if err != nil {
 		fmt.Println("unable to generate docs", err.Error())
@@ -59,7 +60,6 @@ func genMarkdownTree(cmd *cobra.Command, dir string) error {
 func genMarkdown(cmd *cobra.Command, w io.Writer) error {
 	cmd.InitDefaultHelpCmd()
 	cmd.InitDefaultHelpFlag()
-	cmd.InitDefaultCompletionCmd()
 
 	buf := new(bytes.Buffer)
 

--- a/gen-docs/main.go
+++ b/gen-docs/main.go
@@ -34,6 +34,16 @@ func main() {
 // but in the kyma-project.io format
 // most of the code is copied the package
 func genMarkdownTree(cmd *cobra.Command, dir string) error {
+	// gen file for the root command
+	basename := getNewMarkdownPrefix() + strings.Replace(cmd.CommandPath(), " ", "_", -1) + ".md"
+	filename := filepath.Join(dir, basename)
+	f, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// gen files for all sub-commands
 	for _, c := range cmd.Commands() {
 		if !c.IsAvailableCommand() || c.IsAdditionalHelpTopicCommand() {
 			continue
@@ -43,17 +53,6 @@ func genMarkdownTree(cmd *cobra.Command, dir string) error {
 		}
 	}
 
-	basename := strings.Replace(cmd.CommandPath(), " ", "_", -1) + ".md"
-	filename := filepath.Join(dir, basename)
-	f, err := os.Create(filename)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	if _, err := io.WriteString(f, filePrepender(cmd)); err != nil {
-		return err
-	}
 	return genMarkdown(cmd, f)
 }
 
@@ -70,6 +69,8 @@ func genMarkdown(cmd *cobra.Command, w io.Writer) error {
 		buf.WriteString(fmt.Sprintf("```bash\n%s\n```\n\n", cmd.UseLine()))
 	}
 
+	printAvailableCommands(buf, cmd)
+
 	if len(cmd.Example) > 0 {
 		buf.WriteString("## Examples\n\n")
 		buf.WriteString(fmt.Sprintf("```bash\n%s\n```\n\n", cmd.Example))
@@ -85,8 +86,20 @@ func genMarkdown(cmd *cobra.Command, w io.Writer) error {
 	return err
 }
 
+var (
+	fileOrderNumber = 1
+)
+
+func getNewMarkdownPrefix() string {
+	prefix := fmt.Sprintf("01-%d0-", fileOrderNumber)
+	fileOrderNumber++
+	return prefix
+}
+
 func printShort(buf *bytes.Buffer, cmd *cobra.Command) {
 	short := cmd.Short
+
+	buf.WriteString("# " + cmd.CommandPath() + "\n\n")
 	if short != "" {
 		buf.WriteString(short + "\n\n")
 	}
@@ -103,6 +116,35 @@ func printSynopsis(buf *bytes.Buffer, cmd *cobra.Command) {
 	if long != "" {
 		buf.WriteString(long + "\n\n")
 	}
+}
+
+func printAvailableCommands(buf *bytes.Buffer, cmd *cobra.Command) {
+	subCommands := cmd.Commands()
+	if len(subCommands) == 0 {
+		return
+	}
+
+	elems := []printElem{}
+	maxNameLen := 0
+	for i := range subCommands {
+		subCmd := subCommands[i]
+		subCmdName := subCmd.Name()
+		if len(subCmdName) > maxNameLen {
+			maxNameLen = len(subCmdName)
+		}
+		elems = append(elems, printElem{
+			name:        subCmdName,
+			description: subCmd.Short,
+		})
+	}
+
+	buf.WriteString("## Available Commands\n\n")
+	buf.WriteString("```bash\n")
+	for i := range elems {
+		separatorLen := maxNameLen - len(elems[i].name)
+		buf.WriteString(fmt.Sprintf("  %s%s - %s\n", elems[i].name, strings.Repeat(" ", separatorLen), elems[i].description))
+	}
+	buf.WriteString("```\n\n")
 }
 
 func printOptions(buf *bytes.Buffer, cmd *cobra.Command) error {
@@ -125,7 +167,7 @@ func printOptions(buf *bytes.Buffer, cmd *cobra.Command) error {
 	return nil
 }
 
-type seeAlsoElem struct {
+type printElem struct {
 	name        string
 	description string
 }
@@ -135,7 +177,7 @@ func printSeeAlso(buf *bytes.Buffer, cmd *cobra.Command) {
 		return
 	}
 
-	elems := []seeAlsoElem{}
+	elems := []printElem{}
 	maxNameLen := 0
 	name := cmd.CommandPath()
 
@@ -143,7 +185,7 @@ func printSeeAlso(buf *bytes.Buffer, cmd *cobra.Command) {
 	if cmd.HasParent() {
 		parent := cmd.Parent()
 		pname := parent.CommandPath()
-		elem := seeAlsoElem{
+		elem := printElem{
 			name:        fmt.Sprintf("[%s](%s)", pname, linkHandler(parent)),
 			description: parent.Short,
 		}
@@ -164,7 +206,7 @@ func printSeeAlso(buf *bytes.Buffer, cmd *cobra.Command) {
 			continue
 		}
 		cname := name + " " + child.Name()
-		elem := seeAlsoElem{
+		elem := printElem{
 			name:        fmt.Sprintf("[%s](%s)", cname, linkHandler(child)),
 			description: child.Short,
 		}
@@ -179,11 +221,6 @@ func printSeeAlso(buf *bytes.Buffer, cmd *cobra.Command) {
 		separatorLen := maxNameLen - len(elems[i].name)
 		buf.WriteString(fmt.Sprintf("* %s%s - %s\n", elems[i].name, strings.Repeat(" ", separatorLen), elems[i].description))
 	}
-}
-
-func filePrepender(cmd *cobra.Command) string {
-	name := cmd.CommandPath()
-	return fmt.Sprintf("---\ntitle: %s\n---\n\n", name)
 }
 
 func linkHandler(cmd *cobra.Command) string {

--- a/gen-docs/main.go
+++ b/gen-docs/main.go
@@ -59,6 +59,7 @@ func genMarkdownTree(cmd *cobra.Command, dir string) error {
 func genMarkdown(cmd *cobra.Command, w io.Writer) error {
 	cmd.InitDefaultHelpCmd()
 	cmd.InitDefaultHelpFlag()
+	cmd.InitDefaultCompletionCmd()
 
 	buf := new(bytes.Buffer)
 

--- a/internal/cmd/kyma.go
+++ b/internal/cmd/kyma.go
@@ -10,15 +10,11 @@ func NewKymaCMD() (*cobra.Command, clierror.Error) {
 	cmd := &cobra.Command{
 		Use:   "kyma",
 		Short: "Simple set of commands to manage a Kyma cluster",
+		Long:  "Use this command to manage Kyma modules and resources on a cluster.",
 		// Affects children as well
 		// by default Cobra adds `Error:` to the front of the error message, we want to suppress it
 		SilenceErrors: true,
 		SilenceUsage:  true,
-		Run: func(cmd *cobra.Command, _ []string) {
-			if err := cmd.Help(); err != nil {
-				_ = err
-			}
-		},
 	}
 	cmd.PersistentFlags().BoolP("help", "h", false, "Help for the command")
 

--- a/internal/cmdcommon/extension.go
+++ b/internal/cmdcommon/extension.go
@@ -149,11 +149,6 @@ func buildCommandFromExtension(config *KymaConfig, extension *Extension, availab
 		Use:   extension.RootCommand.Name,
 		Short: extension.RootCommand.Description,
 		Long:  extension.RootCommand.DescriptionLong,
-		Run: func(cmd *cobra.Command, _ []string) {
-			if err := cmd.Help(); err != nil {
-				_ = err
-			}
-		},
 	}
 
 	if extension.TemplateCommands != nil {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- improve the section about possible sub-commands
- remove all `Run` commands that are calling `cmd.Help()` because it's the default behaviour
- adjust the generator to be compatible with the `kyma-project.io` format
- add the Long description for the `kyma` command to do not duplicate one string in docs

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/cli/issues/2352#issue-2868528222