### PR TITLE
Add the `--show-extensions-error` flag to root (`kyma`) command level

### DIFF
--- a/docs/user/gen-docs/kyma.md
+++ b/docs/user/gen-docs/kyma.md
@@ -21,7 +21,8 @@ kyma <command> [flags]
 ## Flags
 
 ```text
-  -h, --help   Help for the command
+  -h, --help                    Help for the command
+      --show-extensions-error   Prints a possible error when fetching extensions fails
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_alpha.md
+++ b/docs/user/gen-docs/kyma_alpha.md
@@ -27,8 +27,8 @@ kyma alpha <command> [flags]
 
 ```text
       --kubeconfig string       Path to the Kyma kubeconfig file
-      --show-extensions-error   Prints a possible error when fetching extensions fails
   -h, --help                    Help for the command
+      --show-extensions-error   Prints a possible error when fetching extensions fails
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_completion.md
+++ b/docs/user/gen-docs/kyma_completion.md
@@ -25,7 +25,8 @@ kyma completion [flags]
 ## Flags
 
 ```text
-  -h, --help   Help for the command
+  -h, --help                    Help for the command
+      --show-extensions-error   Prints a possible error when fetching extensions fails
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_completion_bash.md
+++ b/docs/user/gen-docs/kyma_completion_bash.md
@@ -33,8 +33,9 @@ kyma completion bash
 ## Flags
 
 ```text
-      --no-descriptions   disable completion descriptions
-  -h, --help              Help for the command
+      --no-descriptions         disable completion descriptions
+  -h, --help                    Help for the command
+      --show-extensions-error   Prints a possible error when fetching extensions fails
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_completion_fish.md
+++ b/docs/user/gen-docs/kyma_completion_fish.md
@@ -24,8 +24,9 @@ kyma completion fish [flags]
 ## Flags
 
 ```text
-      --no-descriptions   disable completion descriptions
-  -h, --help              Help for the command
+      --no-descriptions         disable completion descriptions
+  -h, --help                    Help for the command
+      --show-extensions-error   Prints a possible error when fetching extensions fails
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_completion_powershell.md
+++ b/docs/user/gen-docs/kyma_completion_powershell.md
@@ -21,8 +21,9 @@ kyma completion powershell [flags]
 ## Flags
 
 ```text
-      --no-descriptions   disable completion descriptions
-  -h, --help              Help for the command
+      --no-descriptions         disable completion descriptions
+  -h, --help                    Help for the command
+      --show-extensions-error   Prints a possible error when fetching extensions fails
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_completion_zsh.md
+++ b/docs/user/gen-docs/kyma_completion_zsh.md
@@ -35,8 +35,9 @@ kyma completion zsh [flags]
 ## Flags
 
 ```text
-      --no-descriptions   disable completion descriptions
-  -h, --help              Help for the command
+      --no-descriptions         disable completion descriptions
+  -h, --help                    Help for the command
+      --show-extensions-error   Prints a possible error when fetching extensions fails
 ```
 
 ## See also

--- a/internal/cmd/kyma.go
+++ b/internal/cmd/kyma.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/kyma-project/cli.v3/internal/clierror"
 	"github.com/kyma-project/cli.v3/internal/cmd/alpha"
+	"github.com/kyma-project/cli.v3/internal/cmdcommon"
 	"github.com/spf13/cobra"
 )
 
@@ -16,6 +17,7 @@ func NewKymaCMD() (*cobra.Command, clierror.Error) {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 	}
+	cmdcommon.AddShowExtensionsErrorFlag(cmd)
 	cmd.PersistentFlags().BoolP("help", "h", false, "Help for the command")
 
 	alpha, err := alpha.NewAlphaCMD()

--- a/internal/cmdcommon/extension.go
+++ b/internal/cmdcommon/extension.go
@@ -23,7 +23,7 @@ type KymaExtensionsConfig struct {
 	extensions ExtensionList
 }
 
-func newExtensionsConfig(warningWriter io.Writer, config *KymaConfig, cmd *cobra.Command) *KymaExtensionsConfig {
+func newExtensionsConfig(warningWriter io.Writer, config *KymaConfig) *KymaExtensionsConfig {
 	extensions, err := loadExtensionsFromCluster(config.Ctx, config.KubeClientConfig)
 	if err != nil && shouldShowExtensionsError() {
 		// print error as warning if expected and continue

--- a/internal/cmdcommon/extension.go
+++ b/internal/cmdcommon/extension.go
@@ -36,12 +36,11 @@ func newExtensionsConfig(warningWriter io.Writer, config *KymaConfig, cmd *cobra
 		kymaConfig: config,
 		extensions: extensions,
 	}
-	extensionsConfig.addFlag(cmd)
 
 	return extensionsConfig
 }
 
-func (kec *KymaExtensionsConfig) addFlag(cmd *cobra.Command) {
+func AddShowExtensionsErrorFlag(cmd *cobra.Command) {
 	// this flag is not operational. it's only to print help description and help cobra with validation
 	_ = cmd.PersistentFlags().Bool("show-extensions-error", false, "Prints a possible error when fetching extensions fails")
 }

--- a/internal/cmdcommon/extension_test.go
+++ b/internal/cmdcommon/extension_test.go
@@ -45,7 +45,6 @@ func TestListFromCluster(t *testing.T) {
 		got := newExtensionsConfig(warnBuf, kymaConfig, cmd)
 		require.Equal(t, want, got.extensions)
 		require.Empty(t, warnBuf.Bytes())
-		require.True(t, cmd.PersistentFlags().HasFlags())
 	})
 
 	t.Run("extensions duplications warning", func(t *testing.T) {
@@ -82,7 +81,6 @@ func TestListFromCluster(t *testing.T) {
 		got := newExtensionsConfig(warnBuf, kymaConfig, cmd)
 		require.Equal(t, want, got.extensions)
 		require.Equal(t, wantWarning, warnBuf.String())
-		require.True(t, cmd.PersistentFlags().HasFlags())
 	})
 
 	t.Run("missing rootCommand error", func(t *testing.T) {

--- a/internal/cmdcommon/extension_test.go
+++ b/internal/cmdcommon/extension_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/kyma-project/cli.v3/internal/cmd/alpha/templates/types"
 	"github.com/kyma-project/cli.v3/internal/kube/fake"
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,8 +28,6 @@ func TestListFromCluster(t *testing.T) {
 			},
 		}
 
-		cmd := &cobra.Command{}
-
 		want := ExtensionList{
 			fixTestExtension("test-1"),
 			fixTestExtension("test-2"),
@@ -42,7 +39,7 @@ func TestListFromCluster(t *testing.T) {
 			KubeClientConfig: kubeClientConfig,
 		}
 
-		got := newExtensionsConfig(warnBuf, kymaConfig, cmd)
+		got := newExtensionsConfig(warnBuf, kymaConfig)
 		require.Equal(t, want, got.extensions)
 		require.Empty(t, warnBuf.Bytes())
 	})
@@ -63,8 +60,6 @@ func TestListFromCluster(t *testing.T) {
 			},
 		}
 
-		cmd := &cobra.Command{}
-
 		want := ExtensionList{
 			fixTestExtension("test-1"),
 		}
@@ -78,7 +73,7 @@ func TestListFromCluster(t *testing.T) {
 			"failed to validate configmap '/test-2': extension with rootCommand.name='test-1' already exists\n" +
 			"failed to validate configmap '/test-3': extension with rootCommand.name='test-1' already exists\n\n"
 
-		got := newExtensionsConfig(warnBuf, kymaConfig, cmd)
+		got := newExtensionsConfig(warnBuf, kymaConfig)
 		require.Equal(t, want, got.extensions)
 		require.Equal(t, wantWarning, warnBuf.String())
 	})
@@ -109,7 +104,7 @@ func TestListFromCluster(t *testing.T) {
 			KubeClientConfig: kubeClientConfig,
 		}
 
-		got := newExtensionsConfig(warnBuf, kymaConfig, &cobra.Command{})
+		got := newExtensionsConfig(warnBuf, kymaConfig)
 		require.Equal(t, wantWarning, warnBuf.String())
 		require.Empty(t, got.extensions)
 	})
@@ -153,7 +148,7 @@ descriptionLong: test-description-long
 			KubeClientConfig: kubeClientConfig,
 		}
 
-		got := newExtensionsConfig(warnBuf, kymaConfig, &cobra.Command{})
+		got := newExtensionsConfig(warnBuf, kymaConfig)
 		require.Empty(t, warnBuf.Bytes())
 		require.Equal(t, want, got.extensions)
 	})

--- a/internal/cmdcommon/kymaconfig.go
+++ b/internal/cmdcommon/kymaconfig.go
@@ -21,7 +21,7 @@ func NewKymaConfig(cmd *cobra.Command) (*KymaConfig, clierror.Error) {
 	kymaConfig := &KymaConfig{}
 	kymaConfig.Ctx = ctx
 	kymaConfig.KubeClientConfig = newKubeClientConfig(cmd)
-	kymaConfig.KymaExtensionsConfig = newExtensionsConfig(cmd.OutOrStderr(), kymaConfig, cmd)
+	kymaConfig.KymaExtensionsConfig = newExtensionsConfig(cmd.OutOrStderr(), kymaConfig)
 
 	return kymaConfig, nil
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- propagate flag to the root level to avoid situations, when users cast `kyma --show-extensions-error` and we throw an error because the flag is not added to the `kyma` cmd.
- regenerate docs

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/cli/issues/2372#issue-2881000241