### PR TITLE
Return clierror.Error on any error

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/kyma-project/cli.v3/internal/clierror"
 	"github.com/kyma-project/cli.v3/internal/cmd"
 )
@@ -13,7 +10,6 @@ func main() {
 	clierror.Check(err)
 
 	if err := cmd.Execute(); err != nil {
-		fmt.Println(err.Error())
-		os.Exit(1)
+		clierror.Check(clierror.Wrap(err, clierror.New("failed to execute command")))
 	}
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- return every error as clierror.Error to diplay errors always in the same way

before:

```text
go run main.go alpha kubeconfig gen --serviceaccount t

if any flags in the group [serviceaccount clusterrole] are set they must all be set; missing [clusterrole]
```

after:

```text
go run main.go alpha kubeconfig gen --serviceaccount t

Error:
  failed to execute command

Error Details:
  if any flags in the group [serviceaccount clusterrole] are set they must all be set; missing [clusterrole]
```