### PR TITLE
Revert extensions config path concept

### DIFF
--- a/internal/extensions/actions/common/configurator.go
+++ b/internal/extensions/actions/common/configurator.go
@@ -1,25 +1,33 @@
 package common
 
 import (
+	"bytes"
+	"html/template"
+
 	"github.com/kyma-project/cli.v3/internal/clierror"
+	"github.com/kyma-project/cli.v3/internal/extensions/types"
 	"gopkg.in/yaml.v3"
 )
 
+// TemplateConfigurator is a struct that implements the Configure for the types.Action interface.
+// It is used to configure an action using go tempaltes.
 type TemplateConfigurator[T any] struct {
 	Cfg T
 }
 
-func (c *TemplateConfigurator[T]) Configure(in map[string]interface{}) clierror.Error {
-	if in == nil {
-		return clierror.New("empty config object")
-	}
-
-	configBytes, err := yaml.Marshal(in)
+func (c *TemplateConfigurator[T]) Configure(cfgTmpl types.ActionConfigTmpl, overwrites types.ActionConfigOverwrites) clierror.Error {
+	configTmpl, err := template.New("config").Parse(cfgTmpl)
 	if err != nil {
-		return clierror.Wrap(err, clierror.New("failed to marshal config"))
+		return clierror.Wrap(err, clierror.New("failed to parse config template"))
 	}
 
-	err = yaml.Unmarshal(configBytes, &c.Cfg)
+	templatedConfig := bytes.NewBuffer([]byte{})
+	err = configTmpl.Option("missingkey=zero").Execute(templatedConfig, overwrites)
+	if err != nil {
+		return clierror.Wrap(err, clierror.New("failed to template config"))
+	}
+
+	err = yaml.Unmarshal(templatedConfig.Bytes(), &c.Cfg)
 	if err != nil {
 		return clierror.Wrap(err, clierror.New("failed to unmarshal config"))
 	}

--- a/internal/extensions/actions/common/configurator.go
+++ b/internal/extensions/actions/common/configurator.go
@@ -3,7 +3,8 @@ package common
 import (
 	"bytes"
 	"fmt"
-	"html/template"
+	"strings"
+	"text/template"
 
 	"github.com/kyma-project/cli.v3/internal/clierror"
 	"github.com/kyma-project/cli.v3/internal/extensions/types"
@@ -16,29 +17,40 @@ type TemplateConfigurator[T any] struct {
 	Cfg T
 }
 
+var funcMap = template.FuncMap{
+	"newLineIndent": newLineIndent,
+}
+
 func (c *TemplateConfigurator[T]) Configure(cfgTmpl types.ActionConfig, overwrites types.ActionConfigOverwrites) clierror.Error {
 	tmplBytes, err := yaml.Marshal(cfgTmpl)
 	if err != nil {
 		return clierror.Wrap(err, clierror.New("failed to marshal config template"))
 	}
 
-	tmplBytes = bytes.ReplaceAll(tmplBytes, []byte("${{"), []byte("{{"))
-	configTmpl, err := template.New("config").Parse(string(tmplBytes))
+	configTmpl, err := template.
+		New("config").
+		Option("missingkey=zero").
+		Delims("${{", "}}").Funcs(funcMap).
+		Parse(string(tmplBytes))
 	if err != nil {
 		return clierror.Wrap(err, clierror.New("failed to parse config template"))
 	}
 
 	templatedConfig := bytes.NewBuffer([]byte{})
-	err = configTmpl.Option("missingkey=zero").Execute(templatedConfig, overwrites)
+	err = configTmpl.
+		Execute(templatedConfig, overwrites)
 	if err != nil {
 		return clierror.Wrap(err, clierror.New("failed to template config"))
 	}
 
-	fmt.Println("templated config:", templatedConfig.String())
 	err = yaml.Unmarshal(templatedConfig.Bytes(), &c.Cfg)
 	if err != nil {
 		return clierror.Wrap(err, clierror.New("failed to unmarshal config"))
 	}
 
 	return nil
+}
+
+func newLineIndent(n int, s string) string {
+	return strings.ReplaceAll(s, "\n", fmt.Sprintf("\n%s", strings.Repeat(" ", n)))
 }

--- a/internal/extensions/actions/common/configurator.go
+++ b/internal/extensions/actions/common/configurator.go
@@ -1,11 +1,6 @@
 package common
 
 import (
-	"bytes"
-	"fmt"
-	"strings"
-	"text/template"
-
 	"github.com/kyma-project/cli.v3/internal/clierror"
 	"github.com/kyma-project/cli.v3/internal/extensions/types"
 	"gopkg.in/yaml.v3"
@@ -17,40 +12,21 @@ type TemplateConfigurator[T any] struct {
 	Cfg T
 }
 
-var funcMap = template.FuncMap{
-	"newLineIndent": newLineIndent,
-}
-
 func (c *TemplateConfigurator[T]) Configure(cfgTmpl types.ActionConfig, overwrites types.ActionConfigOverwrites) clierror.Error {
 	tmplBytes, err := yaml.Marshal(cfgTmpl)
 	if err != nil {
 		return clierror.Wrap(err, clierror.New("failed to marshal config template"))
 	}
 
-	configTmpl, err := template.
-		New("config").
-		Option("missingkey=zero").
-		Delims("${{", "}}").Funcs(funcMap).
-		Parse(string(tmplBytes))
-	if err != nil {
-		return clierror.Wrap(err, clierror.New("failed to parse config template"))
+	configBytes, clierr := templateConfig(tmplBytes, overwrites)
+	if clierr != nil {
+		return clierror.WrapE(clierr, clierror.New("failed to template config"))
 	}
 
-	templatedConfig := bytes.NewBuffer([]byte{})
-	err = configTmpl.
-		Execute(templatedConfig, overwrites)
-	if err != nil {
-		return clierror.Wrap(err, clierror.New("failed to template config"))
-	}
-
-	err = yaml.Unmarshal(templatedConfig.Bytes(), &c.Cfg)
+	err = yaml.Unmarshal(configBytes, &c.Cfg)
 	if err != nil {
 		return clierror.Wrap(err, clierror.New("failed to unmarshal config"))
 	}
 
 	return nil
-}
-
-func newLineIndent(n int, s string) string {
-	return strings.ReplaceAll(s, "\n", fmt.Sprintf("\n%s", strings.Repeat(" ", n)))
 }

--- a/internal/extensions/actions/common/template.go
+++ b/internal/extensions/actions/common/template.go
@@ -1,0 +1,45 @@
+package common
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/kyma-project/cli.v3/internal/clierror"
+	"github.com/kyma-project/cli.v3/internal/extensions/types"
+)
+
+var funcMap = template.FuncMap{
+	"newLineIndent": newLineIndent,
+	"toEnvs":        toEnvs,
+}
+
+func templateConfig(tmpl []byte, overwrites types.ActionConfigOverwrites) ([]byte, clierror.Error) {
+	configTmpl, err := template.
+		New("config").
+		Option("missingkey=zero").
+		Delims("${{", "}}").Funcs(funcMap).
+		Parse(string(tmpl))
+	if err != nil {
+		return nil, clierror.Wrap(err, clierror.New("failed to parse config template"))
+	}
+
+	templatedConfig := bytes.NewBuffer([]byte{})
+	err = configTmpl.
+		Execute(templatedConfig, overwrites)
+	if err != nil {
+		return nil, clierror.New(err.Error())
+	}
+
+	return templatedConfig.Bytes(), nil
+}
+
+func newLineIndent(n int, s string) string {
+	return strings.ReplaceAll(s, "\n", fmt.Sprintf("\n%s", strings.Repeat(" ", n)))
+}
+
+func toEnvs(val interface{}) string {
+
+	return ""
+}

--- a/internal/extensions/args.go
+++ b/internal/extensions/args.go
@@ -17,7 +17,7 @@ func buildArgs(extensionArgs *types.Args) args {
 		return args{}
 	}
 
-	value := parameters.NewTyped(extensionArgs.Type, extensionArgs.ConfigPath)
+	value := parameters.NewTyped(extensionArgs.Type, ".args")
 	return args{
 		value: value,
 		run: func(_ *cobra.Command, args []string) error {

--- a/internal/extensions/args.go
+++ b/internal/extensions/args.go
@@ -17,13 +17,15 @@ func buildArgs(extensionArgs *types.Args, overwrites map[string]interface{}) arg
 		return args{}
 	}
 
+	value := parameters.NewTyped(extensionArgs.Type, ".args.value")
+
 	// append args to overwrites
 	overwrites["args"] = map[string]interface{}{
 		"type":     extensionArgs.Type,
 		"optional": extensionArgs.Optional,
+		"value":    "",
 	}
 
-	value := parameters.NewTyped(extensionArgs.Type, ".args.value")
 	return args{
 		value: value,
 		run: func(_ *cobra.Command, args []string) error {

--- a/internal/extensions/args.go
+++ b/internal/extensions/args.go
@@ -23,7 +23,7 @@ func buildArgs(extensionArgs *types.Args, overwrites map[string]interface{}) arg
 	overwrites["args"] = map[string]interface{}{
 		"type":     extensionArgs.Type,
 		"optional": extensionArgs.Optional,
-		"value":    "",
+		"value":    value.GetValue(),
 	}
 
 	return args{

--- a/internal/extensions/args.go
+++ b/internal/extensions/args.go
@@ -12,12 +12,18 @@ type args struct {
 	value parameters.Value
 }
 
-func buildArgs(extensionArgs *types.Args) args {
+func buildArgs(extensionArgs *types.Args, overwrites map[string]interface{}) args {
 	if extensionArgs == nil {
 		return args{}
 	}
 
-	value := parameters.NewTyped(extensionArgs.Type, ".args")
+	// append args to overwrites
+	overwrites["args"] = map[string]interface{}{
+		"type":     extensionArgs.Type,
+		"optional": extensionArgs.Optional,
+	}
+
+	value := parameters.NewTyped(extensionArgs.Type, ".args.value")
 	return args{
 		value: value,
 		run: func(_ *cobra.Command, args []string) error {

--- a/internal/extensions/args_test.go
+++ b/internal/extensions/args_test.go
@@ -11,27 +11,32 @@ import (
 
 func Test_buildArgs(t *testing.T) {
 	t.Run("skip nil args", func(t *testing.T) {
-		require.Equal(t, args{}, buildArgs(nil))
+		require.Equal(t, args{}, buildArgs(nil, nil))
 	})
 
 	t.Run("set arg value", func(t *testing.T) {
+		overwrites := fixEmptyOverwrites()
 		testArgs := buildArgs(&types.Args{
 			Type:     parameters.StringCustomType,
 			Optional: false,
-		})
+		}, overwrites)
 
 		err := testArgs.run(&cobra.Command{}, []string{"test"})
 
 		require.NoError(t, err)
 		require.Equal(t, "test", testArgs.value.GetValue())
-		require.Equal(t, ".args", testArgs.value.GetPath())
+		require.Equal(t, ".args.value", testArgs.value.GetPath())
+		require.Equal(t, overwrites["args"].(map[string]interface{}), map[string]interface{}{
+			"type":     parameters.StringCustomType,
+			"optional": false,
+		})
 	})
 
 	t.Run("too many given args", func(t *testing.T) {
 		testArgs := buildArgs(&types.Args{
 			Type:     parameters.StringCustomType,
 			Optional: false,
-		})
+		}, fixEmptyOverwrites())
 
 		err := testArgs.run(&cobra.Command{}, []string{"test", "another, not expected arg"})
 
@@ -42,7 +47,7 @@ func Test_buildArgs(t *testing.T) {
 		testArgs := buildArgs(&types.Args{
 			Type:     parameters.IntCustomType,
 			Optional: false,
-		})
+		}, fixEmptyOverwrites())
 
 		err := testArgs.run(&cobra.Command{}, []string{})
 
@@ -53,7 +58,7 @@ func Test_buildArgs(t *testing.T) {
 		testArgs := buildArgs(&types.Args{
 			Type:     parameters.IntCustomType,
 			Optional: false,
-		})
+		}, fixEmptyOverwrites())
 
 		err := testArgs.run(&cobra.Command{}, []string{"WRONG TYPE"})
 
@@ -64,7 +69,7 @@ func Test_buildArgs(t *testing.T) {
 		testArgs := buildArgs(&types.Args{
 			Type:     parameters.IntCustomType,
 			Optional: true,
-		})
+		}, fixEmptyOverwrites())
 
 		err := testArgs.run(&cobra.Command{}, []string{})
 
@@ -76,7 +81,7 @@ func Test_buildArgs(t *testing.T) {
 		testArgs := buildArgs(&types.Args{
 			Type:     parameters.IntCustomType,
 			Optional: true,
-		})
+		}, fixEmptyOverwrites())
 
 		err := testArgs.run(&cobra.Command{}, []string{"2"})
 
@@ -88,7 +93,7 @@ func Test_buildArgs(t *testing.T) {
 		testArgs := buildArgs(&types.Args{
 			Type:     parameters.IntCustomType,
 			Optional: true,
-		})
+		}, fixEmptyOverwrites())
 
 		err := testArgs.run(&cobra.Command{}, []string{"2", "3", "4", "6"})
 

--- a/internal/extensions/args_test.go
+++ b/internal/extensions/args_test.go
@@ -16,22 +16,21 @@ func Test_buildArgs(t *testing.T) {
 
 	t.Run("set arg value", func(t *testing.T) {
 		testArgs := buildArgs(&types.Args{
-			Type:       parameters.StringCustomType,
-			Optional:   false,
-			ConfigPath: ".test",
+			Type:     parameters.StringCustomType,
+			Optional: false,
 		})
 
 		err := testArgs.run(&cobra.Command{}, []string{"test"})
 
 		require.NoError(t, err)
 		require.Equal(t, "test", testArgs.value.GetValue())
+		require.Equal(t, ".args", testArgs.value.GetPath())
 	})
 
 	t.Run("too many given args", func(t *testing.T) {
 		testArgs := buildArgs(&types.Args{
-			Type:       parameters.StringCustomType,
-			Optional:   false,
-			ConfigPath: ".test",
+			Type:     parameters.StringCustomType,
+			Optional: false,
 		})
 
 		err := testArgs.run(&cobra.Command{}, []string{"test", "another, not expected arg"})
@@ -41,9 +40,8 @@ func Test_buildArgs(t *testing.T) {
 
 	t.Run("not enough args", func(t *testing.T) {
 		testArgs := buildArgs(&types.Args{
-			Type:       parameters.IntCustomType,
-			Optional:   false,
-			ConfigPath: ".test",
+			Type:     parameters.IntCustomType,
+			Optional: false,
 		})
 
 		err := testArgs.run(&cobra.Command{}, []string{})
@@ -53,9 +51,8 @@ func Test_buildArgs(t *testing.T) {
 
 	t.Run("wrong arg type", func(t *testing.T) {
 		testArgs := buildArgs(&types.Args{
-			Type:       parameters.IntCustomType,
-			Optional:   false,
-			ConfigPath: ".test",
+			Type:     parameters.IntCustomType,
+			Optional: false,
 		})
 
 		err := testArgs.run(&cobra.Command{}, []string{"WRONG TYPE"})
@@ -65,9 +62,8 @@ func Test_buildArgs(t *testing.T) {
 
 	t.Run("optional args with no given values", func(t *testing.T) {
 		testArgs := buildArgs(&types.Args{
-			Type:       parameters.IntCustomType,
-			Optional:   true,
-			ConfigPath: ".test",
+			Type:     parameters.IntCustomType,
+			Optional: true,
 		})
 
 		err := testArgs.run(&cobra.Command{}, []string{})
@@ -78,9 +74,8 @@ func Test_buildArgs(t *testing.T) {
 
 	t.Run("optional args with one given values", func(t *testing.T) {
 		testArgs := buildArgs(&types.Args{
-			Type:       parameters.IntCustomType,
-			Optional:   true,
-			ConfigPath: ".test",
+			Type:     parameters.IntCustomType,
+			Optional: true,
 		})
 
 		err := testArgs.run(&cobra.Command{}, []string{"2"})
@@ -91,9 +86,8 @@ func Test_buildArgs(t *testing.T) {
 
 	t.Run("optional args with too much args", func(t *testing.T) {
 		testArgs := buildArgs(&types.Args{
-			Type:       parameters.IntCustomType,
-			Optional:   true,
-			ConfigPath: ".test",
+			Type:     parameters.IntCustomType,
+			Optional: true,
 		})
 
 		err := testArgs.run(&cobra.Command{}, []string{"2", "3", "4", "6"})

--- a/internal/extensions/args_test.go
+++ b/internal/extensions/args_test.go
@@ -24,11 +24,12 @@ func Test_buildArgs(t *testing.T) {
 		err := testArgs.run(&cobra.Command{}, []string{"test"})
 
 		require.NoError(t, err)
-		require.Equal(t, "test", testArgs.value.GetValue())
+		require.Equal(t, "test", testArgs.value.String())
 		require.Equal(t, ".args.value", testArgs.value.GetPath())
 		require.Equal(t, overwrites["args"].(map[string]interface{}), map[string]interface{}{
 			"type":     parameters.StringCustomType,
 			"optional": false,
+			"value":    "",
 		})
 	})
 
@@ -74,7 +75,7 @@ func Test_buildArgs(t *testing.T) {
 		err := testArgs.run(&cobra.Command{}, []string{})
 
 		require.NoError(t, err)
-		require.Nil(t, testArgs.value.GetValue())
+		require.Empty(t, testArgs.value.String())
 	})
 
 	t.Run("optional args with one given values", func(t *testing.T) {
@@ -86,7 +87,7 @@ func Test_buildArgs(t *testing.T) {
 		err := testArgs.run(&cobra.Command{}, []string{"2"})
 
 		require.NoError(t, err)
-		require.Equal(t, int64(2), testArgs.value.GetValue())
+		require.Equal(t, "2", testArgs.value.String())
 	})
 
 	t.Run("optional args with too much args", func(t *testing.T) {

--- a/internal/extensions/args_test.go
+++ b/internal/extensions/args_test.go
@@ -24,7 +24,7 @@ func Test_buildArgs(t *testing.T) {
 		err := testArgs.run(&cobra.Command{}, []string{"test"})
 
 		require.NoError(t, err)
-		require.Equal(t, "test", testArgs.value.String())
+		require.Equal(t, "test", testArgs.value.GetValue())
 		require.Equal(t, ".args.value", testArgs.value.GetPath())
 		require.Equal(t, overwrites["args"].(map[string]interface{}), map[string]interface{}{
 			"type":     parameters.StringCustomType,
@@ -75,7 +75,7 @@ func Test_buildArgs(t *testing.T) {
 		err := testArgs.run(&cobra.Command{}, []string{})
 
 		require.NoError(t, err)
-		require.Empty(t, testArgs.value.String())
+		require.Empty(t, testArgs.value.GetValue())
 	})
 
 	t.Run("optional args with one given values", func(t *testing.T) {
@@ -87,7 +87,7 @@ func Test_buildArgs(t *testing.T) {
 		err := testArgs.run(&cobra.Command{}, []string{"2"})
 
 		require.NoError(t, err)
-		require.Equal(t, "2", testArgs.value.String())
+		require.Equal(t, int64(2), testArgs.value.GetValue())
 	})
 
 	t.Run("optional args with too much args", func(t *testing.T) {

--- a/internal/extensions/commands.go
+++ b/internal/extensions/commands.go
@@ -86,7 +86,7 @@ func buildSingleCommand(extension types.Extension, availableActions types.Action
 		clierror.Check(parameters.Set(overwrites, values))
 
 		// configure action
-		clierror.Check(action.Configure(extension.ConfigTmpl, overwrites))
+		clierror.Check(action.Configure(extension.Config, overwrites))
 	}
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {

--- a/internal/extensions/commands.go
+++ b/internal/extensions/commands.go
@@ -45,10 +45,13 @@ func buildSingleCommand(extension types.Extension, availableActions types.Action
 	}
 
 	// set flags
+	overwrites := types.ActionConfigOverwrites{
+		"flags": map[string]interface{}{},
+	}
 	values := []parameters.Value{}
 	requiredFlags := []string{}
 	for _, extensionFlag := range extension.Flags {
-		cmdFlag := buildFlag(extensionFlag)
+		cmdFlag := buildFlag(extensionFlag, overwrites)
 		if cmdFlag.warning != nil {
 			errs = append(errs, errors.Newf("flag '%s' error: %s", extensionFlag.Name, cmdFlag.warning.Error()))
 		}
@@ -62,7 +65,7 @@ func buildSingleCommand(extension types.Extension, availableActions types.Action
 	}
 
 	// set args
-	cmdArgs := buildArgs(extension.Args)
+	cmdArgs := buildArgs(extension.Args, overwrites)
 	cmd.Args = cmdArgs.run
 	values = append(values, cmdArgs.value)
 
@@ -80,7 +83,6 @@ func buildSingleCommand(extension types.Extension, availableActions types.Action
 			flags.MarkRequired(requiredFlags...),
 		))
 		// set parameters from flag and args as overwrites
-		overwrites := types.ActionConfigOverwrites{}
 		clierror.Check(parameters.Set(overwrites, values))
 
 		// configure action

--- a/internal/extensions/commands_test.go
+++ b/internal/extensions/commands_test.go
@@ -23,12 +23,23 @@ func Test_buildCommand(t *testing.T) {
 		err = cmd.Execute()
 		require.NoError(t, err)
 
-		expectedConfig := "\"cmd2\": true"
-		require.Equal(t, expectedConfig, actionMock.configureArg)
+		require.Equal(t, map[string]interface{}{
+			"cmd2": true,
+		}, actionMock.configureArg)
 		require.Equal(t, types.ActionConfigOverwrites{
-			"args": true,
+			"args": map[string]interface{}{
+				"optional": false,
+				"type":     parameters.BoolCustomType,
+				"value":    true},
 			"flags": map[string]interface{}{
-				"flag1": int64(20),
+				"flag1": map[string]interface{}{
+					"default":     "5",
+					"description": "flag-desc1",
+					"name":        "flag1",
+					"shorthand":   "f",
+					"type":        parameters.IntCustomType,
+					"value":       int64(20),
+				},
 			},
 		}, actionMock.configureOverwritesArg)
 	})
@@ -79,7 +90,9 @@ func fixTestExtension() types.Extension {
 			Description:     "desc1",
 			DescriptionLong: "desc-long1",
 		},
-		ConfigTmpl: `"cmd1": true`,
+		Config: map[string]interface{}{
+			"cmd1": true,
+		},
 		SubCommands: []types.Extension{
 			{
 				Metadata: types.Metadata{
@@ -102,7 +115,9 @@ func fixTestExtension() types.Extension {
 					Type:     parameters.BoolCustomType,
 					Optional: false,
 				},
-				ConfigTmpl: `"cmd2": true`,
+				Config: map[string]interface{}{
+					"cmd2": true,
+				},
 			},
 		},
 	}
@@ -112,12 +127,12 @@ type mockAction struct {
 	configureError clierror.Error
 	runError       clierror.Error
 
-	configureArg           types.ActionConfigTmpl
+	configureArg           types.ActionConfig
 	configureOverwritesArg types.ActionConfigOverwrites
 	runArgs                []string
 }
 
-func (m *mockAction) Configure(arg types.ActionConfigTmpl, overwritesArg types.ActionConfigOverwrites) clierror.Error {
+func (m *mockAction) Configure(arg types.ActionConfig, overwritesArg types.ActionConfigOverwrites) clierror.Error {
 	m.configureArg = arg
 	m.configureOverwritesArg = overwritesArg
 	return m.configureError

--- a/internal/extensions/commands_test.go
+++ b/internal/extensions/commands_test.go
@@ -30,7 +30,8 @@ func Test_buildCommand(t *testing.T) {
 			"args": map[string]interface{}{
 				"optional": false,
 				"type":     parameters.BoolCustomType,
-				"value":    "true"},
+				"value":    true,
+			},
 			"flags": map[string]interface{}{
 				"flag1": map[string]interface{}{
 					"default":     "5",
@@ -38,7 +39,7 @@ func Test_buildCommand(t *testing.T) {
 					"name":        "flag1",
 					"shorthand":   "f",
 					"type":        parameters.IntCustomType,
-					"value":       "20",
+					"value":       int64(20),
 				},
 			},
 		}, actionMock.configureOverwritesArg)

--- a/internal/extensions/commands_test.go
+++ b/internal/extensions/commands_test.go
@@ -30,7 +30,7 @@ func Test_buildCommand(t *testing.T) {
 			"args": map[string]interface{}{
 				"optional": false,
 				"type":     parameters.BoolCustomType,
-				"value":    true},
+				"value":    "true"},
 			"flags": map[string]interface{}{
 				"flag1": map[string]interface{}{
 					"default":     "5",
@@ -38,7 +38,7 @@ func Test_buildCommand(t *testing.T) {
 					"name":        "flag1",
 					"shorthand":   "f",
 					"type":        parameters.IntCustomType,
-					"value":       int64(20),
+					"value":       "20",
 				},
 			},
 		}, actionMock.configureOverwritesArg)

--- a/internal/extensions/extensions.go
+++ b/internal/extensions/extensions.go
@@ -64,9 +64,6 @@ func (b *Builder) DisplayWarnings(warningWriter io.Writer) {
 // any errors can be displayed by using the DisplayExtensionsErrors func
 func (b *Builder) Build(parentCmd *cobra.Command, availableActions types.ActionsMap) {
 	for _, cmExt := range b.extensions {
-		// default
-		cmExt.Extension.Default()
-
 		// validate
 		err := cmExt.Extension.Validate(availableActions)
 		if err != nil {

--- a/internal/extensions/extensions_test.go
+++ b/internal/extensions/extensions_test.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	testExtensionString = `
-with:
+with: |-
   resource:
     apiVersion: v1
     kind: ConfigMap
@@ -34,22 +34,17 @@ subCommands:
 - metadata:
     name: create
   uses: action-1
-  with: {}
 - metadata:
     name: delete
   uses: action-2
-  with: {}
 `
 )
 
 var (
 	testExtension = types.Extension{
-		Config: map[string]interface{}{
-			"resource": map[string]interface{}{
-				"apiVersion": "v1",
-				"kind":       "ConfigMap",
-			},
-		},
+		ConfigTmpl: `resource:
+  apiVersion: v1
+  kind: ConfigMap`,
 		Metadata: types.Metadata{
 			Name:            "resource",
 			Description:     "manage resources",
@@ -57,14 +52,14 @@ var (
 		},
 		SubCommands: []types.Extension{
 			{
-				Config: map[string]interface{}{},
+				ConfigTmpl: "",
 				Metadata: types.Metadata{
 					Name: "create",
 				},
 				Action: "action-1",
 			},
 			{
-				Config: map[string]interface{}{},
+				ConfigTmpl: "",
 				Metadata: types.Metadata{
 					Name: "delete",
 				},
@@ -324,7 +319,6 @@ func Test_Build(t *testing.T) {
 						Flags: []types.Flag{
 							{
 								Name:         "test-flag",
-								ConfigPath:   ".test",
 								Type:         parameters.IntCustomType,
 								DefaultValue: "WRONG VALUE",
 							},

--- a/internal/extensions/extensions_test.go
+++ b/internal/extensions/extensions_test.go
@@ -55,14 +55,12 @@ var (
 		},
 		SubCommands: []types.Extension{
 			{
-				// Config: "",
 				Metadata: types.Metadata{
 					Name: "create",
 				},
 				Action: "action-1",
 			},
 			{
-				// Config: "",
 				Metadata: types.Metadata{
 					Name: "delete",
 				},

--- a/internal/extensions/extensions_test.go
+++ b/internal/extensions/extensions_test.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	testExtensionString = `
-with: |-
+with:
   resource:
     apiVersion: v1
     kind: ConfigMap
@@ -42,9 +42,12 @@ subCommands:
 
 var (
 	testExtension = types.Extension{
-		ConfigTmpl: `resource:
-  apiVersion: v1
-  kind: ConfigMap`,
+		Config: map[string]interface{}{
+			"resource": map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+			},
+		},
 		Metadata: types.Metadata{
 			Name:            "resource",
 			Description:     "manage resources",
@@ -52,14 +55,14 @@ var (
 		},
 		SubCommands: []types.Extension{
 			{
-				ConfigTmpl: "",
+				// Config: "",
 				Metadata: types.Metadata{
 					Name: "create",
 				},
 				Action: "action-1",
 			},
 			{
-				ConfigTmpl: "",
+				// Config: "",
 				Metadata: types.Metadata{
 					Name: "delete",
 				},

--- a/internal/extensions/flags.go
+++ b/internal/extensions/flags.go
@@ -1,6 +1,9 @@
 package extensions
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/kyma-project/cli.v3/internal/extensions/parameters"
 	"github.com/kyma-project/cli.v3/internal/extensions/types"
 	"github.com/spf13/pflag"
@@ -13,7 +16,8 @@ type flag struct {
 }
 
 func buildFlag(commandFlag types.Flag) flag {
-	value := parameters.NewTyped(commandFlag.Type, commandFlag.ConfigPath)
+	valuePath := fmt.Sprintf(".flags.%s", strings.ReplaceAll(commandFlag.Name, "-", ""))
+	value := parameters.NewTyped(commandFlag.Type, valuePath)
 	warning := value.SetValue(commandFlag.DefaultValue)
 
 	pflag := &pflag.Flag{

--- a/internal/extensions/flags.go
+++ b/internal/extensions/flags.go
@@ -42,7 +42,7 @@ func buildFlag(commandFlag types.Flag, overwrites map[string]interface{}) flag {
 		"shorthand":   pflag.Shorthand,
 		"description": pflag.Usage,
 		"default":     pflag.DefValue,
-		"value":       "",
+		"value":       value.GetValue(),
 	}
 	overwrites["flags"] = flagsOverwrites
 

--- a/internal/extensions/flags.go
+++ b/internal/extensions/flags.go
@@ -42,6 +42,7 @@ func buildFlag(commandFlag types.Flag, overwrites map[string]interface{}) flag {
 		"shorthand":   pflag.Shorthand,
 		"description": pflag.Usage,
 		"default":     pflag.DefValue,
+		"value":       "",
 	}
 	overwrites["flags"] = flagsOverwrites
 

--- a/internal/extensions/flags.go
+++ b/internal/extensions/flags.go
@@ -15,8 +15,9 @@ type flag struct {
 	warning error
 }
 
-func buildFlag(commandFlag types.Flag) flag {
-	valuePath := fmt.Sprintf(".flags.%s", strings.ReplaceAll(commandFlag.Name, "-", ""))
+func buildFlag(commandFlag types.Flag, overwrites map[string]interface{}) flag {
+	flagOverwriteName := strings.ReplaceAll(commandFlag.Name, "-", "")
+	valuePath := fmt.Sprintf(".flags.%s.value", flagOverwriteName)
 	value := parameters.NewTyped(commandFlag.Type, valuePath)
 	warning := value.SetValue(commandFlag.DefaultValue)
 
@@ -32,6 +33,17 @@ func buildFlag(commandFlag types.Flag) flag {
 		// set default value for bool flag used without value (for example "--flag" instead of "--flag value")
 		pflag.NoOptDefVal = "true"
 	}
+
+	// append flag to overwrites
+	flagsOverwrites := overwrites["flags"].(map[string]interface{})
+	flagsOverwrites[flagOverwriteName] = map[string]interface{}{
+		"type":        commandFlag.Type,
+		"name":        pflag.Name,
+		"shorthand":   pflag.Shorthand,
+		"description": pflag.Usage,
+		"default":     pflag.DefValue,
+	}
+	overwrites["flags"] = flagsOverwrites
 
 	return flag{
 		pflag:   pflag,

--- a/internal/extensions/flags_test.go
+++ b/internal/extensions/flags_test.go
@@ -11,7 +11,7 @@ import (
 
 func Test_buildFlag(t *testing.T) {
 	t.Run("build string flag", func(t *testing.T) {
-		expectedValue := parameters.NewTyped(parameters.StringCustomType, ".test.path")
+		expectedValue := parameters.NewTyped(parameters.StringCustomType, ".flags.testname")
 		_ = expectedValue.SetValue("defval")
 		expectedFlag := flag{
 			value:   expectedValue,
@@ -30,7 +30,6 @@ func Test_buildFlag(t *testing.T) {
 			Name:         "test-name",
 			Description:  "test description",
 			Shorthand:    "t",
-			ConfigPath:   ".test.path",
 			DefaultValue: "defval",
 			Required:     true,
 		})
@@ -38,7 +37,7 @@ func Test_buildFlag(t *testing.T) {
 	})
 
 	t.Run("build bool flag", func(t *testing.T) {
-		expectedValue := parameters.NewTyped(parameters.BoolCustomType, ".test.path")
+		expectedValue := parameters.NewTyped(parameters.BoolCustomType, ".flags.testname")
 		_ = expectedValue.SetValue("true")
 		expectedFlag := flag{
 			value:   expectedValue,
@@ -58,7 +57,6 @@ func Test_buildFlag(t *testing.T) {
 			Name:         "test-name",
 			Description:  "test description",
 			Shorthand:    "t",
-			ConfigPath:   ".test.path",
 			DefaultValue: "true",
 			Required:     true,
 		})

--- a/internal/extensions/flags_test.go
+++ b/internal/extensions/flags_test.go
@@ -35,19 +35,19 @@ func Test_buildFlag(t *testing.T) {
 			Required:     true,
 		}, overwrites)
 		require.Equal(t, expectedFlag, givenFlag)
-		require.Equal(t, overwrites["flags"].(map[string]interface{})["testname"], map[string]interface{}{
+		require.Equal(t, map[string]interface{}{
 			"type":        parameters.StringCustomType,
 			"name":        "test-name",
 			"shorthand":   "t",
 			"description": "test description",
-			"default":     expectedValue.String(),
-			"value":       "",
-		})
+			"default":     "defval",
+			"value":       "defval",
+		}, overwrites["flags"].(map[string]interface{})["testname"])
 	})
 
 	t.Run("build bool flag", func(t *testing.T) {
+		overwrites := fixEmptyOverwrites()
 		expectedValue := parameters.NewTyped(parameters.BoolCustomType, ".flags.testname.value")
-		_ = expectedValue.SetValue("true")
 		expectedFlag := flag{
 			value:   expectedValue,
 			warning: nil,
@@ -62,14 +62,21 @@ func Test_buildFlag(t *testing.T) {
 		}
 
 		givenFlag := buildFlag(types.Flag{
-			Type:         parameters.BoolCustomType,
-			Name:         "test-name",
-			Description:  "test description",
-			Shorthand:    "t",
-			DefaultValue: "true",
-			Required:     true,
-		}, fixEmptyOverwrites())
+			Type:        parameters.BoolCustomType,
+			Name:        "test-name",
+			Description: "test description",
+			Shorthand:   "t",
+			Required:    true,
+		}, overwrites)
 		require.Equal(t, expectedFlag, givenFlag)
+		require.Equal(t, map[string]interface{}{
+			"type":        parameters.BoolCustomType,
+			"name":        "test-name",
+			"shorthand":   "t",
+			"description": "test description",
+			"default":     "",
+			"value":       false,
+		}, overwrites["flags"].(map[string]interface{})["testname"])
 	})
 
 	t.Run("build warning", func(t *testing.T) {

--- a/internal/extensions/flags_test.go
+++ b/internal/extensions/flags_test.go
@@ -41,6 +41,7 @@ func Test_buildFlag(t *testing.T) {
 			"shorthand":   "t",
 			"description": "test description",
 			"default":     expectedValue.String(),
+			"value":       "",
 		})
 	})
 

--- a/internal/extensions/flags_test.go
+++ b/internal/extensions/flags_test.go
@@ -11,7 +11,8 @@ import (
 
 func Test_buildFlag(t *testing.T) {
 	t.Run("build string flag", func(t *testing.T) {
-		expectedValue := parameters.NewTyped(parameters.StringCustomType, ".flags.testname")
+		overwrites := fixEmptyOverwrites()
+		expectedValue := parameters.NewTyped(parameters.StringCustomType, ".flags.testname.value")
 		_ = expectedValue.SetValue("defval")
 		expectedFlag := flag{
 			value:   expectedValue,
@@ -32,12 +33,19 @@ func Test_buildFlag(t *testing.T) {
 			Shorthand:    "t",
 			DefaultValue: "defval",
 			Required:     true,
-		})
+		}, overwrites)
 		require.Equal(t, expectedFlag, givenFlag)
+		require.Equal(t, overwrites["flags"].(map[string]interface{})["testname"], map[string]interface{}{
+			"type":        parameters.StringCustomType,
+			"name":        "test-name",
+			"shorthand":   "t",
+			"description": "test description",
+			"default":     expectedValue.String(),
+		})
 	})
 
 	t.Run("build bool flag", func(t *testing.T) {
-		expectedValue := parameters.NewTyped(parameters.BoolCustomType, ".flags.testname")
+		expectedValue := parameters.NewTyped(parameters.BoolCustomType, ".flags.testname.value")
 		_ = expectedValue.SetValue("true")
 		expectedFlag := flag{
 			value:   expectedValue,
@@ -59,7 +67,7 @@ func Test_buildFlag(t *testing.T) {
 			Shorthand:    "t",
 			DefaultValue: "true",
 			Required:     true,
-		})
+		}, fixEmptyOverwrites())
 		require.Equal(t, expectedFlag, givenFlag)
 	})
 
@@ -67,7 +75,13 @@ func Test_buildFlag(t *testing.T) {
 		givenFlag := buildFlag(types.Flag{
 			Type:         parameters.IntCustomType,
 			DefaultValue: "WRONG VALUE",
-		})
+		}, fixEmptyOverwrites())
 		require.ErrorContains(t, givenFlag.warning, "parsing \"WRONG VALUE\": invalid syntax")
 	})
+}
+
+func fixEmptyOverwrites() map[string]interface{} {
+	return map[string]interface{}{
+		"flags": map[string]interface{}{},
+	}
 }

--- a/internal/extensions/parameters/parameters.go
+++ b/internal/extensions/parameters/parameters.go
@@ -15,6 +15,7 @@ import (
 type Value interface {
 	pflag.Value
 	SetValue(string) error
+	GetValue() interface{}
 	GetPath() string
 }
 
@@ -37,7 +38,11 @@ func Set(obj map[string]interface{}, values []Value) clierror.Error {
 			continue
 		}
 
-		value := extraValue.String()
+		value := extraValue.GetValue()
+		if value == nil {
+			// value is not set and has no default value
+			continue
+		}
 
 		fields := splitPath(extraValue.GetPath())
 		subObj, err := buildExtraValuesObject(value, fields...)

--- a/internal/extensions/parameters/parameters.go
+++ b/internal/extensions/parameters/parameters.go
@@ -15,7 +15,6 @@ import (
 type Value interface {
 	pflag.Value
 	SetValue(string) error
-	GetValue() interface{}
 	GetPath() string
 }
 
@@ -38,11 +37,7 @@ func Set(obj map[string]interface{}, values []Value) clierror.Error {
 			continue
 		}
 
-		value := extraValue.GetValue()
-		if value == nil {
-			// value is not set and has no default value
-			continue
-		}
+		value := extraValue.String()
 
 		fields := splitPath(extraValue.GetPath())
 		subObj, err := buildExtraValuesObject(value, fields...)

--- a/internal/extensions/parameters/types.go
+++ b/internal/extensions/parameters/types.go
@@ -30,6 +30,10 @@ type boolValue struct {
 	path string
 }
 
+func (v *boolValue) GetValue() interface{} {
+	return getValue(v.Value)
+}
+
 func (v *boolValue) GetPath() string {
 	return v.path
 }
@@ -43,6 +47,10 @@ type int64Value struct {
 	path string
 }
 
+func (v *int64Value) GetValue() interface{} {
+	return getValue(v.Value)
+}
+
 func (v *int64Value) GetPath() string {
 	return v.path
 }
@@ -54,6 +62,10 @@ func (v *int64Value) SetValue(value string) error {
 type stringValue struct {
 	cmdcommontypes.NullableString
 	path string
+}
+
+func (v *stringValue) GetValue() interface{} {
+	return getValue(v.Value)
 }
 
 func (sv *stringValue) GetPath() string {
@@ -79,4 +91,13 @@ func (pv *pathValue) Set(value string) error {
 
 func (pv *pathValue) SetValue(value string) error {
 	return pv.stringValue.Set(value)
+}
+
+func getValue[T any](value *T) interface{} {
+	if value != nil {
+		return *value
+	}
+
+	var emptyValue T
+	return emptyValue
 }

--- a/internal/extensions/parameters/types.go
+++ b/internal/extensions/parameters/types.go
@@ -30,14 +30,6 @@ type boolValue struct {
 	path string
 }
 
-func (v *boolValue) GetValue() interface{} {
-	if v.Value == nil {
-		return nil
-	}
-
-	return *v.Value
-}
-
 func (v *boolValue) GetPath() string {
 	return v.path
 }
@@ -51,14 +43,6 @@ type int64Value struct {
 	path string
 }
 
-func (v *int64Value) GetValue() interface{} {
-	if v.Value == nil {
-		return nil
-	}
-
-	return *v.Value
-}
-
 func (v *int64Value) GetPath() string {
 	return v.path
 }
@@ -70,14 +54,6 @@ func (v *int64Value) SetValue(value string) error {
 type stringValue struct {
 	cmdcommontypes.NullableString
 	path string
-}
-
-func (v *stringValue) GetValue() interface{} {
-	if v.Value == nil {
-		return nil
-	}
-
-	return *v.Value
 }
 
 func (sv *stringValue) GetPath() string {

--- a/internal/extensions/types/types.go
+++ b/internal/extensions/types/types.go
@@ -17,14 +17,14 @@ const (
 )
 
 type Action interface {
-	Configure(ActionConfigTmpl, ActionConfigOverwrites) clierror.Error
+	Configure(ActionConfig, ActionConfigOverwrites) clierror.Error
 	Run(*cobra.Command, []string) clierror.Error
 }
 
 // map of allowed action commands in format ID: ACTION
 type ActionsMap map[string]Action
 
-type ActionConfigTmpl = string
+type ActionConfig = map[string]interface{}
 
 type ActionConfigOverwrites = map[string]interface{}
 
@@ -105,7 +105,7 @@ type Extension struct {
 	// args used to set specific fields in config
 	Args *Args `yaml:"args"`
 	// additional config pass to the command
-	ConfigTmpl ActionConfigTmpl `yaml:"with"`
+	Config ActionConfig `yaml:"with"`
 	// list of sub commands
 	SubCommands []Extension `yaml:"subCommands"`
 }

--- a/internal/extensions/types/types_test.go
+++ b/internal/extensions/types/types_test.go
@@ -34,9 +34,8 @@ func TestExtension_Validate(t *testing.T) {
 						Action: "create",
 						Flags: []Flag{
 							{
-								Type:       "string",
-								Name:       "test-flag",
-								ConfigPath: ".test",
+								Type: "string",
+								Name: "test-flag",
 							},
 						},
 						SubCommands: []Extension{
@@ -46,8 +45,7 @@ func TestExtension_Validate(t *testing.T) {
 								},
 								Action: "demo",
 								Args: &Args{
-									Type:       "bool",
-									ConfigPath: ".test",
+									Type: "bool",
 								},
 							},
 						},
@@ -58,9 +56,9 @@ func TestExtension_Validate(t *testing.T) {
 		{
 			name: "validation error - broken flag",
 			wantErr: "wrong .uses: unsupported value 'wrong-action'\n" +
-				"wrong .flags: empty name, unknown type '', empty configPath\n" +
+				"wrong .flags: empty name, unknown type ''\n" +
 				"wrong .subCommands[0].metadata: empty name\n" +
-				"wrong .subCommands[0].subCommands[1].args: unknown type '', empty ConfigPath",
+				"wrong .subCommands[0].subCommands[1].args: unknown type ''",
 			extension: Extension{
 				Metadata: Metadata{
 					Name: "function",
@@ -99,7 +97,6 @@ func TestExtension_Validate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.extension.Default()
 			err := tt.extension.Validate(testActionsMap)
 			if tt.wantErr != "" {
 				require.EqualError(t, err, tt.wantErr)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- remove the `.flags[].configPath` and the `.args.configPath` fields
- support go templates inside the `with` field
- allow which value should be used and where on the `with` field level

Tested using CMs:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: serverless.function.cli
  namespace: kyma-system
  labels:
    kyma-cli/extension: commands
    kyma-cli/extension-version: v1
data:
  kyma-commands.yaml: |
    metadata:
      name: function
      description: A set of commands for managing Functions
      descriptionLong: Use this command to manage Functions.

    subCommands:
    - metadata:
        name: "get [<resource_name>] [flags]"
        description: "Get Functions"
        descriptionLong: "Use this command to get Functions from a cluster."
      uses: resource_get
      args:
        type: string
        optional: true
      flags:
      - type: string
        name: "namespace"
        shorthand: "n"
        description: "Function's namespace"
        default: "default"
      - type: bool
        name: "all-namespaces"
        shorthand: "A"
        default: false
      with:
        fromAllNamespaces: ${{.flags.allnamespaces.value}}
        resource:
          apiVersion: serverless.kyma-project.io/v1alpha2
          kind: Function
          metadata:
            name: ${{.args.value}}
            namespace: ${{.flags.namespace.value}}
        outputParameters:
        - resourcePath: '.status.conditions[] | select(.type=="ConfigurationReady") | .status'
          name: "configured"
        - resourcePath: '.status.conditions[] | select(.type=="BuildReady") | .status'
          name: "built"
        - resourcePath: '.status.conditions[] | select(.type=="Running") | .status'
          name: "running"
        - resourcePath: ".spec.runtime"
          name: "runtime"
        - resourcePath: ".metadata.generation"
          name: "generation"

    - metadata:
        name: "explain [flags]"
        description: "Explain Functions"
        descriptionLong: "Use this command to explain what Function is."
      uses: resource_explain
      with:
        output: |
          With Functions you can run code without
          writing servers and maintaining them. 
          
          There are two possible runtime variants: Node.js and Python.

          You can find more details here:
          https://kyma-project.io/#/serverless-manager/user/resources/06-10-function-cr

    - metadata:
        name: "delete <resource_name> [flags]"
        description: "Delete Function"
        descriptionLong: "Use this command to delete Function from a cluster."
      uses: resource_delete
      args:
        type: string
      flags:
      - type: string
        name: "namespace"
        shorthand: "n"
        description: "Function's namespace"
        default: "default"
      with:
        resource:
          apiVersion: serverless.kyma-project.io/v1alpha2
          kind: Function
          metadata:
            name: ${{ .args.value }}
            namespace: ${{ .flags.namespace.value }}

    - metadata:
        name: "create <resource_name> [flags]"
        description: "Create Function"
        descriptionLong: "Use this command to create Function on a cluster."
      uses: resource_create
      args:
        type: string
      flags:
      - type: string
        name: "runtime-image-override"
        description: "custom runtime image to be used as Function's runtime base"
        default: "\"\""
      - type: string
        name: "namespace"
        shorthand: "n"
        description: "Function's namespace"
        default: "default"
      - type: string
        name: "runtime"
        description: "function runtime"
        shorthand: "r"
        default: "nodejs22"
      - type: int
        name: "replicas"
        description: "function replicas"
        default: "1"
      - type: path
        name: "source"
        description: "function source file path"
        shorthand: "s"
        default: |
          module.exports = {
            main: function(event, context) {
              return 'Hello World!'
            }
          }
      - type: path
        name: "dependencies"
        description: "function dependencies file path"
        shorthand: "d"
        default: |
          {
            "dependencies": {}
          }
      with:
        resource:
          apiVersion: serverless.kyma-project.io/v1alpha2
          kind: Function
          metadata:
            name: ${{ .args.value }}
            namespace: ${{ .flags.namespace.value }}
          spec:
            runtimeImageOverride: ${{ .flags.runtimeimageoverride.value }}
            runtime: ${{ .flags.runtime.value }}
            replicas: ${{ .flags.replicas.value }}
            source:
              inline:
                source: |
                  ${{ .flags.source.value | newLineIndent 20 }}
                dependencies: |
                  ${{ .flags.dependencies.value | newLineIndent 20 }}

    - metadata:
        name: "init [flags]"
        description: Init source and dependencies files locally
        descriptionLong: Use this command to initialize source and dependencies files for a Function.
      uses: function_init
      flags:
      - name: runtime
        type: string
        description: "Runtime for which the files are generated [ nodejs22, nodejs20, python312 ]"
        default: "nodejs22"
      - name: dir
        type: string
        description: "Path to the directory where files must be created"
        default: "."
      with:
        useRuntime: ${{ .flags.runtime.value }}
        outputDir: ${{ .flags.dir.value }}
        runtimes:
          python312:
            depsFilename: requirements.txt
            depsData: ""
            handlerFilename: handler.py
            handlerData: |
              def main(event, context):
                message = "Hello World from the Kyma Function "+context['function-name']+" running on "+context['runtime']+ "!";
                print(message)
                return message
          nodejs22:
            depsFilename: package.json
            depsData: |
              {
                "dependencies": {}
              }
            handlerFilename: handler.js
            handlerData: |
              module.exports = {
                main: async function (event, context) {
                  /*
                  If you prefer mjs import/export syntax over cjs you need to specify
                  'type': 'module'
                  in the Function dependencies (package.json) and along with that change the import/export syntax to:
                  import foo from 'foo'
                  export function main(event, context) {
                    //your logic using foo library
                    return
                  }
                  */

                  const message = `Hello World`
                    + ` from the Kyma Function ${context["function-name"]}`
                    + ` running on ${context.runtime}!`;
                  console.log(message);
                  return message;
                }
              }
          nodejs20:
            depsFilename: package.json
            depsData: |
              {
                "dependencies": {}
              }
            handlerFilename: handler.js
            handlerData: |
              module.exports = {
                main: async function (event, context) {
                  /*
                  If you prefer mjs import/export syntax over cjs you need to specify
                  'type': 'module'
                  in the Function dependencies (package.json) and along with that change the import/export syntax to:
                  import foo from 'foo'
                  export function main(event, context) {
                    //your logic using foo library
                    return
                  }
                  */

                  const message = `Hello World`
                    + ` from the Kyma Function ${context["function-name"]}`
                    + ` running on ${context.runtime}!`;
                  console.log(message);
                  return message;
                }
              }
```

and

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: registry.cli
  namespace: kyma-system
  labels:
    kyma-cli/extension: commands
    kyma-cli/extension-version: v1
data:
  kyma-commands.yaml: |
    metadata:
      name: registry
      description: A set of commands for the Kyma registry
      descriptionLong: Use this command to manage resources related to the Kyma registry.

    subCommands:
    - metadata:
        name: "config-external [flags]"
        description: "Saves Kyma registry external dockerconfig"
        descriptionLong: "Use this command to save Kyma registry external dockerconfig."
      uses: registry_config
      flags:
      - type: bool
        name: "push-reg-addr"
        description: "Get external registry push address only"
        default: "false"
      - type: bool
        name: "pull-reg-addr"
        description: "Get external registry address used to pull images"
        default: "false"
      - type: string
        name: "output"
        description: "Path where the output file should be saved to. NOTE: docker expects the file to be named 'config.json'"
      with:
        pushRegAddrOnly: ${{  .flags.pushregaddr.value }}
        pullRegAddrOnly: ${{  .flags.pullregaddr.value }}
        output: ${{  .flags.output.value }}
        useExternal: true

    - metadata:
        name: "config-internal [flags]"
        description: "Saves Kyma registry internal dockerconfig"
        descriptionLong: "Use this command to save Kyma registry internal dockerconfig."
      uses: registry_config
      flags:
      - type: bool
        name: "push-reg-addr"
        description: "Get in-cluster registry address only"
        default: "false"
      - type: bool
        name: "pull-reg-addr"
        description: "Get in-cluster registry address used to pull images by Kubernetes only"
        default: "false"
      - type: string
        name: "output"
        description: "Path where the output file should be saved to. NOTE: docker expects the file to be named 'config.json'"
      with:
        pushRegAddrOnly: ${{  .flags.pushregaddr.value }}
        pullRegAddrOnly: ${{  .flags.pullregaddr.value }}
        output: ${{  .flags.output.value }}
        useExternal: false

    - metadata:
        name: "image-import <image> [flags]"
        description: "Import image to in-cluster registry"
        descriptionLong: "Import image from daemon to in-cluster registry."
      uses: registry_image_import
      args:
        type: string
      with:
        image: ${{ .args.value}}
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/cli/issues/2428