### PR TITLE
Support the `aarch64` and the `amd64` architectures

### DIFF
--- a/hack/install_cli_latest.sh
+++ b/hack/install_cli_latest.sh
@@ -12,8 +12,16 @@ cd ${CLI_TMPDIR}
 
 VERSION=$(curl -sL https://api.github.com/repos/kyma-project/cli/releases | jq -r 'map(select(.tag_name!="0.0.0-dev")) | first | .tag_name')
 
+DIST=$(uname -s)
+ARCH=$(uname -m)
+if [ "${ARCH}" = "amd64" ]; then
+    ARCH="x86_64"
+elif [ "${ARCH}" = "aarch64" ]; then
+    ARCH="arm64"
+fi
+
 echo "downloading ${VERSION} release..."
-curl -sL "https://github.com/kyma-project/cli/releases/download/${VERSION}/kyma_$(uname -s)_$(uname -m).tar.gz" -o ${CLI_TMPDIR}/cli.tar.gz
+curl -sL "https://github.com/kyma-project/cli/releases/download/${VERSION}/kyma_${DIST}_${ARCH}.tar.gz" -o ${CLI_TMPDIR}/cli.tar.gz
 
 echo "untaring..."
 tar -zxvf ${CLI_TMPDIR}/cli.tar.gz kyma

--- a/hack/install_cli_nightly.sh
+++ b/hack/install_cli_nightly.sh
@@ -10,8 +10,16 @@ echo "creating tmp dir..."
 mkdir ${CLI_TMPDIR}
 cd ${CLI_TMPDIR}
 
+DIST=$(uname -s)
+ARCH=$(uname -m)
+if [ "${ARCH}" = "amd64" ]; then
+    ARCH="x86_64"
+elif [ "${ARCH}" = "aarch64" ]; then
+    ARCH="arm64"
+fi
+
 echo "downloading nightly release..."
-curl -sL "https://github.com/kyma-project/cli/releases/download/0.0.0-dev/kyma_$(uname -s)_$(uname -m).tar.gz" -o ${CLI_TMPDIR}/cli.tar.gz
+curl -sL "https://github.com/kyma-project/cli/releases/download/0.0.0-dev/kyma_${DIST}_${ARCH}.tar.gz" -o ${CLI_TMPDIR}/cli.tar.gz
 
 echo "untaring..."
 tar -zxvf ${CLI_TMPDIR}/cli.tar.gz kyma

--- a/hack/install_cli_stable.sh
+++ b/hack/install_cli_stable.sh
@@ -12,8 +12,16 @@ cd ${CLI_TMPDIR}
 
 VERSION=$(curl -sL https://api.github.com/repos/kyma-project/cli/releases/latest | jq -r '.tag_name')
 
+DIST=$(uname -s)
+ARCH=$(uname -m)
+if [ "${ARCH}" = "amd64" ]; then
+    ARCH="x86_64"
+elif [ "${ARCH}" = "aarch64" ]; then
+    ARCH="arm64"
+fi
+
 echo "downloading ${VERSION} release..."
-curl -sL "https://github.com/kyma-project/cli/releases/download/${VERSION}/kyma_$(uname -s)_$(uname -m).tar.gz" -o ${CLI_TMPDIR}/cli.tar.gz
+curl -sL "https://github.com/kyma-project/cli/releases/download/${VERSION}/kyma_${DIST}_${ARCH}.tar.gz" -o ${CLI_TMPDIR}/cli.tar.gz
 
 echo "untaring..."
 tar -zxvf ${CLI_TMPDIR}/cli.tar.gz kyma


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- installation scripts are using the `uname -m` command to collect information about the user's architecture. In some cases, output needs to be sanitized, for example, for the `amd64` architecture, we should look for a binary with the `x86_64` suffix
