### PR TITLE
Include istio label in the deployment template

### DIFF
--- a/internal/kube/resources/deployment.go
+++ b/internal/kube/resources/deployment.go
@@ -55,7 +55,8 @@ func buildDeployment(opts *CreateDeploymentOpts) *appsv1.Deployment {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: opts.Name,
 					Labels: map[string]string{
-						"app": opts.Name,
+						"app":                     opts.Name,
+						"sidecar.istio.io/inject": "true",
 					},
 				},
 				Spec: corev1.PodSpec{


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:
- Always add istio label to the pod template


**Reason**
Missing label makes apirule ineffective: 
```
description: 'Validation errors: Attribute ''.spec.rules[0]'': Pod default/httpbin-7497666c7d-xhvjp does not have an injected istio sidecar'
state: Error
```