### PR TITLE
Get rid of the `go-www-aithenticate-parser` package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/buildpacks/pack v0.37.0
 	github.com/docker/cli v27.5.1+incompatible
 	github.com/docker/docker v27.5.1+incompatible
-	github.com/gboddin/go-www-authenticate-parser v0.0.0-20230926203616-ec0b649bb077
 	github.com/go-test/deep v1.1.1
 	github.com/google/go-containerregistry v0.20.3
 	github.com/itchyny/gojq v0.12.17

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,6 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
-github.com/gboddin/go-www-authenticate-parser v0.0.0-20230926203616-ec0b649bb077 h1:JvEO7eltd2aCHF+ABLquTUziO7hzC6G7H3tgENYkDBc=
-github.com/gboddin/go-www-authenticate-parser v0.0.0-20230926203616-ec0b649bb077/go.mod h1:RlYuEjNYq/NkhOCSkZGPKxP3dgZOBH94UwsQraDng8s=
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
 github.com/gdamore/encoding v1.0.1 h1:YzKZckdBL6jVt2Gc+5p82qhrGiqMdG/eNs6Wy0u3Uhw=
 github.com/gdamore/encoding v1.0.1/go.mod h1:0Z0cMFinngz9kS1QfMjCP8TY7em3bZYeeklsSDPivEo=

--- a/internal/btp/cis/auth.go
+++ b/internal/btp/cis/auth.go
@@ -1,0 +1,133 @@
+// Copied from:
+// https://github.com/gboddin/go-www-authenticate-parser/commit/ec0b649bb07701564d8bf002d0262a7bc4c13fe8
+
+package cis
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+type wwwAuthenticateSettings struct {
+	state        func() error
+	digestBuffer *bytes.Buffer
+	buffer       string
+	currentParam string
+	quoteOpened  bool
+	AuthType     string
+	Params       map[string]string
+}
+
+func ParseAuthSettings(digestBuffer string) wwwAuthenticateSettings {
+	digest := wwwAuthenticateSettings{
+		digestBuffer: bytes.NewBufferString(digestBuffer),
+		buffer:       "",
+		AuthType:     "",
+		Params:       make(map[string]string),
+	}
+	digest.state = digest.ParseType
+	for {
+		if err := digest.state(); err != nil {
+			break
+		}
+	}
+	return digest
+}
+
+func (d *wwwAuthenticateSettings) ParseType() error {
+	currentByte, err := d.digestBuffer.ReadByte()
+	if err != nil {
+		return err
+	}
+	if currentByte != ' ' && currentByte != '\n' {
+		d.buffer += string(currentByte)
+		return nil
+	}
+	d.AuthType = d.buffer
+	d.buffer = ""
+	d.state = d.ParseParamKey
+	return nil
+}
+
+func (d *wwwAuthenticateSettings) ParseParamKey() error {
+	currentByte, err := d.digestBuffer.ReadByte()
+	if err != nil {
+		return err
+	}
+	switch currentByte {
+	case '=':
+		d.currentParam = d.buffer
+		d.buffer = ""
+		d.state = d.ParseParamValue
+		return nil
+	case ' ':
+		if len(d.buffer) > 0 {
+			d.Params[d.buffer] = "true"
+			d.currentParam = ""
+			d.buffer = ""
+			d.state = d.ParseParamKey
+		}
+		return nil
+	case ',':
+		if len(d.buffer) > 0 {
+			d.Params[d.buffer] = "true"
+		}
+		d.currentParam = ""
+		d.buffer = ""
+		d.state = d.ParseParamKey
+		return nil
+	}
+	d.buffer += string(currentByte)
+	return nil
+}
+
+func (d *wwwAuthenticateSettings) ParseParamValue() error {
+	currentByte, err := d.digestBuffer.ReadByte()
+	if err != nil {
+		return err
+	}
+	switch currentByte {
+	case '\\':
+		nextByte, err := d.digestBuffer.ReadByte()
+		if err != nil {
+			return err
+		}
+		var unquoted string
+		err = json.Unmarshal([]byte("\""+string(currentByte)+string(nextByte)+"\""), &unquoted)
+		if err != nil {
+			return err
+		}
+		d.buffer += unquoted
+		return nil
+	case '"':
+		if d.quoteOpened {
+			d.quoteOpened = false
+			d.Params[d.currentParam] = d.buffer
+			d.currentParam = ""
+			d.buffer = ""
+			// Read until the next ','
+			_, err = d.digestBuffer.ReadString(',')
+			if err != nil {
+				return err
+			}
+			d.state = d.ParseParamKey
+			return nil
+		}
+		if !d.quoteOpened {
+			d.quoteOpened = true
+			return nil
+		}
+	case ',':
+		if !d.quoteOpened {
+			d.quoteOpened = false
+			d.Params[d.currentParam] = d.buffer
+			d.currentParam = ""
+			d.buffer = ""
+			d.state = d.ParseParamKey
+			return nil
+		}
+	}
+
+	d.buffer += string(currentByte)
+	return nil
+}

--- a/internal/btp/cis/client.go
+++ b/internal/btp/cis/client.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 
-	wwwAuthParser "github.com/gboddin/go-www-authenticate-parser"
 	"github.com/kyma-project/cli.v3/internal/btp/auth"
 )
 
@@ -127,6 +126,6 @@ func (c *httpClient) buildErrorFromHeaders(response *http.Response) error {
 		return fmt.Errorf("failed to parse http error for status: %s", response.Status)
 	}
 
-	wwwAuthHeader := wwwAuthParser.Parse(wwwAuthHeaderString)
+	wwwAuthHeader := ParseAuthSettings(wwwAuthHeaderString)
 	return fmt.Errorf("%s: %s", wwwAuthHeader.Params["error"], wwwAuthHeader.Params["error_description"])
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- copy the https://github.com/gboddin/go-www-authenticate-parser parser to our code to get rid of the stale dependency
