### PR TITLE
Fixed module CR calculation for unmanaged module

### DIFF
--- a/internal/modules/list_test.go
+++ b/internal/modules/list_test.go
@@ -117,6 +117,24 @@ var (
 		},
 	}
 
+	testModuleTemplate6 = unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "operator.kyma-project.io/v1beta2",
+			"kind":       "ModuleTemplate",
+			"metadata": map[string]interface{}{
+				"name":      "keda-1",
+				"namespace": "kyma-system",
+			},
+			"spec": map[string]interface{}{
+				"moduleName": "keda",
+				"version":    "0.2",
+				"info": map[string]interface{}{
+					"repository": "url-3",
+				},
+			},
+		},
+	}
+
 	testCommunityModuleTemplate = unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "operator.kyma-project.io/v1beta2",
@@ -236,7 +254,7 @@ var (
 				Managed:              ManagedFalse,
 				Channel:              "fast",
 				Version:              "0.2",
-				ModuleState:          "Unmanaged",
+				ModuleState:          "Unknown",
 				InstallationState:    "Unmanaged",
 				CustomResourcePolicy: "CreateAndDelete",
 			},
@@ -414,6 +432,7 @@ func TestListInstalled(t *testing.T) {
 		scheme.AddKnownTypes(kyma.GVRKyma.GroupVersion())
 		dynamicClient := dynamic_fake.NewSimpleDynamicClient(scheme,
 			&testModuleTemplate1,
+			&testModuleTemplate6,
 			&testKymaCR,
 		)
 

--- a/internal/modules/render_test.go
+++ b/internal/modules/render_test.go
@@ -62,7 +62,7 @@ const (
 		"serverless   0.0.1(fast), 0.0.2        false       \n" +
 		"cluster-ip   0.1.1, 0.1.2              true        \n"
 	testInstalledModulesTableView = "NAME         VERSION       CR POLICY         MANAGED   MODULE STATUS   INSTALLATION STATUS   \n" +
-		"keda         0.2(fast)     CreateAndDelete   false     Unmanaged       Unmanaged             \n" +
+		"keda         0.2(fast)     CreateAndDelete   false     Unknown         Unmanaged             \n" +
 		"serverless   0.0.1(fast)   Ignore            true      Ready           Ready                 \n"
 
 	testCatalogJSONView = `[


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Earlier, for the unmanaged modules we were using the same status for the installation status and module CR status (`Unmanaged`)
- Now, when we have the unmanaged module, we perform a lookup on the ModuleTemplates collection to find module with the matching name and version - based on that MT we check the status of the custom resource (`spec.data`)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#2533 