### PR TITLE
Command for generating kubeconfig for named OIDC

### DIFF
--- a/internal/kubeconfig/types.go
+++ b/internal/kubeconfig/types.go
@@ -1,0 +1,18 @@
+package kubeconfig
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+var OpenIdConnectGVR = schema.GroupVersionResource{
+	Group:    "authentication.gardener.cloud",
+	Version:  "v1alpha1",
+	Resource: "openidconnects",
+}
+
+type OpenIDConnect struct {
+	Spec OpenIDConnectSpec `json:"spec"`
+}
+
+type OpenIDConnectSpec struct {
+	ClientID  string `json:"clientID"`
+	IssuerURL string `json:"issuerURL"`
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Added new flag `--oidc-name` to `alpha kubeconfig generate` command that allows to provide a name of the OICD resource.
- Based on the OICD resource on the cluster a new kubeconfig is generated

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#2485 