### PR TITLE
Fetching community modules from remote repository

### DIFF
--- a/internal/cmd/module/catalog.go
+++ b/internal/cmd/module/catalog.go
@@ -4,6 +4,7 @@ import (
 	"github.com/kyma-project/cli.v3/internal/clierror"
 	"github.com/kyma-project/cli.v3/internal/cmdcommon"
 	"github.com/kyma-project/cli.v3/internal/modules"
+	"github.com/kyma-project/cli.v3/internal/modules/repo"
 	"github.com/kyma-project/cli.v3/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -37,8 +38,9 @@ func catalogModules(cfg *catalogConfig) clierror.Error {
 	if clierr != nil {
 		return clierr
 	}
+	moduleTemplatesRepo := repo.NewModuleTemplatesRepo(client)
 
-	modulesList, err := modules.ListCatalog(cfg.Ctx, client)
+	modulesList, err := modules.ListCatalog(cfg.Ctx, client, moduleTemplatesRepo)
 	if err != nil {
 		return clierror.Wrap(err, clierror.New("failed to list available modules from the cluster"))
 	}

--- a/internal/cmd/module/manage.go
+++ b/internal/cmd/module/manage.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kyma-project/cli.v3/internal/cmdcommon"
 	"github.com/kyma-project/cli.v3/internal/cmdcommon/prompt"
 	"github.com/kyma-project/cli.v3/internal/kube"
+	"github.com/kyma-project/cli.v3/internal/kube/kyma"
 	"github.com/kyma-project/cli.v3/internal/modules"
 	"github.com/kyma-project/cli.v3/internal/modules/repo"
 	"github.com/spf13/cobra"
@@ -112,7 +113,9 @@ func manageModuleMissingInKyma(cfg *manageConfig, client kube.Client) clierror.E
 		return clierr
 	}
 
-	clierr = modules.Enable(cfg.Ctx, client, cfg.module, selectedChannel, false, []unstructured.Unstructured{}...)
+	defaultCrFlag := cfg.policy == kyma.CustomResourcePolicyCreateAndDelete
+
+	clierr = modules.Enable(cfg.Ctx, client, moduleTemplatesRepo, cfg.module, selectedChannel, defaultCrFlag, []unstructured.Unstructured{}...)
 	if clierr != nil {
 		return clierr
 	}
@@ -129,7 +132,7 @@ func promptForAlternativeChannel(channelsAndVersions map[string]string) (string,
 		channelOpts = append(channelOpts, *valWithDesc)
 	}
 
-	fmt.Println("There is a mismatch between the default channel configured for your Kyma cluster and the channel where the installed module version is available.")
+	fmt.Println("The version of the module you have installed is not available in the default Kyma channel.")
 	fmt.Println("To proceed, please select one of the available channels below to manage the module with the desired version.")
 
 	channelPrompt := prompt.NewOneOfEnumList("Available versions:\n", "Type the option number: ", channelOpts)

--- a/internal/modules/enable.go
+++ b/internal/modules/enable.go
@@ -10,18 +10,19 @@ import (
 	"github.com/kyma-project/cli.v3/internal/clierror"
 	"github.com/kyma-project/cli.v3/internal/kube"
 	"github.com/kyma-project/cli.v3/internal/kube/kyma"
+	"github.com/kyma-project/cli.v3/internal/modules/repo"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // Enable takes care about enabling kyma module in order:
 // 1. add module to the Kyma CR with CustomResourcePolicy set to CreateAndDelete if defaultCR is true and to Ignore in any other case
 // 2. if crs array is not empty wait for the module to be ready and add crs to the cluster
-func Enable(ctx context.Context, client kube.Client, module, channel string, defaultCR bool, crs ...unstructured.Unstructured) clierror.Error {
-	return enable(os.Stdout, ctx, client, module, channel, defaultCR, crs...)
+func Enable(ctx context.Context, client kube.Client, repo repo.ModuleTemplatesRepository, module, channel string, defaultCR bool, crs ...unstructured.Unstructured) clierror.Error {
+	return enable(os.Stdout, ctx, client, repo, module, channel, defaultCR, crs...)
 }
 
-func enable(writer io.Writer, ctx context.Context, client kube.Client, module, channel string, defaultCR bool, crs ...unstructured.Unstructured) clierror.Error {
-	if err := validateModuleAvailability(ctx, client, module); err != nil {
+func enable(writer io.Writer, ctx context.Context, client kube.Client, repo repo.ModuleTemplatesRepository, module, channel string, defaultCR bool, crs ...unstructured.Unstructured) clierror.Error {
+	if err := validateModuleAvailability(ctx, client, repo, module); err != nil {
 		return clierror.Wrap(err, clierror.New("module invalid"))
 	}
 
@@ -71,8 +72,8 @@ func applyCustomCR(writer io.Writer, ctx context.Context, client kube.Client, mo
 	return nil
 }
 
-func validateModuleAvailability(ctx context.Context, client kube.Client, module string) error {
-	availableCoreVersions, err := ListAvailableVersions(ctx, client, module, false)
+func validateModuleAvailability(ctx context.Context, client kube.Client, repo repo.ModuleTemplatesRepository, module string) error {
+	availableCoreVersions, err := ListAvailableVersions(ctx, client, repo, module, false)
 	if err != nil {
 		return err
 	}

--- a/internal/modules/fake/moduletemplates.go
+++ b/internal/modules/fake/moduletemplates.go
@@ -9,7 +9,6 @@ import (
 )
 
 type ModuleTemplatesRepo struct {
-	ReturnAll                                []kyma.ModuleTemplate
 	ReturnCore                               []kyma.ModuleTemplate
 	ReturnCommunity                          []kyma.ModuleTemplate
 	ReturnCommunityByName                    []kyma.ModuleTemplate
@@ -19,7 +18,6 @@ type ModuleTemplatesRepo struct {
 	ReturnInstalledManager                   *unstructured.Unstructured
 	ReturnDeleteResourceReturnWatcher        watch.Interface
 
-	AllErr                                error
 	CoreErr                               error
 	CommunityErr                          error
 	CommunityByNameErr                    error
@@ -28,10 +26,6 @@ type ModuleTemplatesRepo struct {
 	ResourcesErr                          error
 	DeleteResourceReturnWatcherErr        error
 	InstalledManagerErr                   error
-}
-
-func (r *ModuleTemplatesRepo) All(_ context.Context) ([]kyma.ModuleTemplate, error) {
-	return r.ReturnAll, r.AllErr
 }
 
 func (r *ModuleTemplatesRepo) Core(_ context.Context) ([]kyma.ModuleTemplate, error) {

--- a/internal/modules/fake/moduletemplatesremote.go
+++ b/internal/modules/fake/moduletemplatesremote.go
@@ -1,0 +1,12 @@
+package fake
+
+import "github.com/kyma-project/cli.v3/internal/kube/kyma"
+
+type ModuleTemplatesRemoteRepo struct {
+	ReturnCommunity []kyma.ModuleTemplate
+	CommunityErr    error
+}
+
+func (r *ModuleTemplatesRemoteRepo) Community() ([]kyma.ModuleTemplate, error) {
+	return r.ReturnCommunity, r.CommunityErr
+}

--- a/internal/modules/list_community_test.go
+++ b/internal/modules/list_community_test.go
@@ -196,7 +196,7 @@ func TestListInstalled_NoCommunityModules(t *testing.T) {
 		ReturnCommunity: []kyma.ModuleTemplate{},
 	}
 
-	modules, err := listCommunityInstalled(context.Background(), fakeClient, fakeModuleTemplatesRepo)
+	modules, err := listCommunityInstalled(context.Background(), fakeClient, fakeModuleTemplatesRepo, ModulesList{})
 	require.NoError(t, err)
 	require.Len(t, modules, 0)
 }
@@ -222,7 +222,7 @@ func TestListInstalled_CommunityModuleInstalledNotRunning(t *testing.T) {
 		ReturnInstalledManager: &runningManagerMock,
 	}
 
-	modules, err := listCommunityInstalled(context.Background(), fakeClient, fakeModuleTemplatesRepo)
+	modules, err := listCommunityInstalled(context.Background(), fakeClient, fakeModuleTemplatesRepo, ModulesList{})
 
 	require.NoError(t, err)
 	require.Len(t, modules, 1)
@@ -256,7 +256,7 @@ func TestListInstalled_CommunityModuleInstalledRunning(t *testing.T) {
 		ReturnInstalledManager: &runningManagerMock,
 	}
 
-	modules, err := listCommunityInstalled(context.Background(), fakeClient, fakeModuleTemplatesRepo)
+	modules, err := listCommunityInstalled(context.Background(), fakeClient, fakeModuleTemplatesRepo, ModulesList{})
 
 	require.NoError(t, err)
 	require.Len(t, modules, 1)
@@ -290,7 +290,7 @@ func TestListInstalled_CommunityModuleVersionFromImage(t *testing.T) {
 		ReturnInstalledManager: &runningManagerMockWithoutVersionLabel,
 	}
 
-	modules, err := listCommunityInstalled(context.Background(), fakeClient, fakeModuleTemplatesRepo)
+	modules, err := listCommunityInstalled(context.Background(), fakeClient, fakeModuleTemplatesRepo, ModulesList{})
 
 	require.NoError(t, err)
 	require.Len(t, modules, 1)

--- a/internal/modules/list_test.go
+++ b/internal/modules/list_test.go
@@ -135,21 +135,6 @@ var (
 		},
 	}
 
-	testCommunityModuleTemplate = unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "operator.kyma-project.io/v1beta2",
-			"kind":       "ModuleTemplate",
-			"metadata": map[string]interface{}{
-				"name":      "cluster-ip-02",
-				"namespace": "kyma-system",
-			},
-			"spec": map[string]interface{}{
-				"moduleName": "cluster-ip",
-				"version":    "0.2",
-			},
-		},
-	}
-
 	testReleaseMeta1 = unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "operator.kyma-project.io/v1beta2",
@@ -535,8 +520,9 @@ func TestListCatalog(t *testing.T) {
 			TestKymaInterface:            kyma.NewClient(dynamicClient),
 			TestRootlessDynamicInterface: fakeRootless,
 		}
+		repo := &modulesfake.ModuleTemplatesRepo{}
 
-		modules, err := ListCatalog(context.Background(), fakeClient)
+		modules, err := ListCatalog(context.Background(), fakeClient, repo)
 
 		require.NoError(t, err)
 		require.Equal(t, ModulesList(testModuleList), modules)
@@ -563,8 +549,9 @@ func TestListCatalog(t *testing.T) {
 			TestKymaInterface:            kyma.NewClient(dynamicClient),
 			TestRootlessDynamicInterface: fakeRootless,
 		}
+		repo := &modulesfake.ModuleTemplatesRepo{}
 
-		modules, err := ListCatalog(context.Background(), fakeClient)
+		modules, err := ListCatalog(context.Background(), fakeClient, repo)
 
 		require.NoError(t, err)
 		require.Equal(t, ModulesList(testModuleList), modules)
@@ -574,9 +561,7 @@ func TestListCatalog(t *testing.T) {
 		scheme := runtime.NewScheme()
 		scheme.AddKnownTypes(kyma.GVRModuleTemplate.GroupVersion())
 		scheme.AddKnownTypes(kyma.GVRModuleReleaseMeta.GroupVersion())
-		dynamicClient := dynamic_fake.NewSimpleDynamicClient(scheme,
-			&testCommunityModuleTemplate,
-		)
+		dynamicClient := dynamic_fake.NewSimpleDynamicClient(scheme)
 
 		fakeRootless := &fake.RootlessDynamicClient{}
 
@@ -584,8 +569,17 @@ func TestListCatalog(t *testing.T) {
 			TestKymaInterface:            kyma.NewClient(dynamicClient),
 			TestRootlessDynamicInterface: fakeRootless,
 		}
+		repo := &modulesfake.ModuleTemplatesRepo{
+			ReturnCommunity: []kyma.ModuleTemplate{
+				{
+					Spec: kyma.ModuleTemplateSpec{
+						ModuleName: "cluster-ip",
+					},
+				},
+			},
+		}
 
-		modules, err := ListCatalog(context.Background(), fakeClient)
+		modules, err := ListCatalog(context.Background(), fakeClient, repo)
 
 		require.NoError(t, err)
 		require.Equal(t, 1, len(modules))

--- a/internal/modules/manage.go
+++ b/internal/modules/manage.go
@@ -62,7 +62,7 @@ func ManageModuleMissingInKyma(ctx context.Context, client kube.Client, repo rep
 		return ErrModuleInstalledVersionNotInKymaChannel
 	}
 
-	clierr := Enable(ctx, client, moduleName, channelAssignedToModuleVersion, enableDefaultCr(policy), []unstructured.Unstructured{}...)
+	clierr := Enable(ctx, client, repo, moduleName, channelAssignedToModuleVersion, enableDefaultCr(policy), []unstructured.Unstructured{}...)
 	if clierr != nil {
 		return fmt.Errorf("failed to manage module: %v", clierr)
 	}

--- a/internal/modules/repo/moduletemplatesremote.go
+++ b/internal/modules/repo/moduletemplatesremote.go
@@ -1,0 +1,46 @@
+package repo
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/kyma-project/cli.v3/internal/kube/kyma"
+)
+
+const (
+	ALL_COMMUNITY_MODULES_URL = "https://kyma-project.github.io/community-modules/all-modules.json"
+)
+
+type ModuleTemplatesRemoteRepository interface {
+	Community() ([]kyma.ModuleTemplate, error)
+}
+
+type moduleTemplateRemoteRepo struct {
+	url string
+}
+
+func (m *moduleTemplateRemoteRepo) Community() ([]kyma.ModuleTemplate, error) {
+	moduleTemplatesDefinitions, err := getFileFromURL(m.url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get community modules definitions: %v", err)
+	}
+
+	var result []kyma.ModuleTemplate
+	if err := json.Unmarshal(moduleTemplatesDefinitions, &result); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal module template: %w", err)
+	}
+
+	return result, nil
+}
+
+func newModuleTemplatesRemoteRepo() *moduleTemplateRemoteRepo {
+	return &moduleTemplateRemoteRepo{
+		url: ALL_COMMUNITY_MODULES_URL,
+	}
+}
+
+func newModuleTemplatesRemoteRepoWithURL(url string) *moduleTemplateRemoteRepo {
+	return &moduleTemplateRemoteRepo{
+		url: url,
+	}
+}

--- a/internal/modules/repo/moduletemplatesremote_test.go
+++ b/internal/modules/repo/moduletemplatesremote_test.go
@@ -1,0 +1,112 @@
+package repo
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kyma-project/cli.v3/internal/kube/kyma"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	communityModuleJSON = `[
+	{
+    	"apiVersion": "operator.kyma-project.io/v1beta2",
+    	"kind": "ModuleTemplate",
+    	"metadata": {
+      		"name": "test-module-2",
+      		"labels": {
+        		"operator.kyma-project.io/module-name": "test-module"
+      		}
+    	},
+    	"spec": {
+			"moduleName": "test-module",
+			"version": "0.0.2",
+			"manager": {
+				"name": "dockerregistry-operator",
+				"namespace": "kyma-system",
+				"group": "apps",
+				"version": "v1",
+				"kind": "Deployment"
+			},
+			"resources": [],
+			"descriptor": {}
+		}
+	}
+]
+`
+)
+
+func TestModuleTemplateRemoteRepo_Community(t *testing.T) {
+	validTemplates := []kyma.ModuleTemplate{
+		{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "operator.kyma-project.io/v1beta2",
+				Kind:       "ModuleTemplate",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-module-2",
+				Namespace: "test-module-namespace",
+			},
+			Spec: kyma.ModuleTemplateSpec{
+				ModuleName: "test-module",
+				Version:    "0.0.2",
+			},
+		}}
+
+	tests := []struct {
+		name         string
+		serverFunc   http.HandlerFunc
+		expectErr    bool
+		expectResult []kyma.ModuleTemplate
+	}{
+		{
+			name: "success",
+			serverFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(communityModuleJSON))
+			},
+			expectErr:    false,
+			expectResult: validTemplates,
+		},
+		{
+			name: "server error",
+			serverFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte("error"))
+			},
+			expectErr: true,
+		},
+		{
+			name: "invalid json",
+			serverFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("not json"))
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			ts := httptest.NewServer(http.HandlerFunc(tt.serverFunc))
+			defer ts.Close()
+
+			repo := newModuleTemplatesRemoteRepoWithURL(ts.URL)
+			result, err := repo.Community()
+
+			if tt.expectErr {
+				require.Error(err, "expected error, got nil")
+			} else {
+				require.NoError(err, "unexpected error: %v", err)
+				require.Equal(len(tt.expectResult), len(result), "unexpected number of modules")
+
+				require.Equal(tt.expectResult[0].Spec.ModuleName, result[0].Spec.ModuleName, "module name mismatch")
+				require.Equal(tt.expectResult[0].Spec.Version, result[0].Spec.Version, "module version mismatch")
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Adjusted `module catalog`, `module install` and `module list` commands to make use of remote repository when dealing with community modules
- Adjusted the `Community` method in `ModuleTemplatesRepository` so it makes a request to the remote repo
- Allowed for installation of local module templates of community modules but they are not listed in the catalog (for the development purposes)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#2542 