### PR TITLE
Added deduplication to unmanaged core modules listing

### DIFF
--- a/internal/modules/list.go
+++ b/internal/modules/list.go
@@ -191,8 +191,19 @@ func collectUnmanagedCoreModules(ctx context.Context, client kube.Client, repo r
 
 	modulesList := ModulesList{}
 	for m := range results {
-		modulesList = append(modulesList, m)
+		var moduleAlreadyExists bool
+		for _, module := range modulesList {
+			if module.Name == m.Name && module.InstallDetails.Version == m.InstallDetails.Version {
+				moduleAlreadyExists = true
+				break
+			}
+		}
+
+		if !moduleAlreadyExists {
+			modulesList = append(modulesList, m)
+		}
 	}
+
 	return modulesList
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- The duplication was occurring when the unmanaged module was also missing in the Kyma CR. 
- In such situation we were iterating over the module templates available on the cluster and verifying if their module manager is running.
- Since there were multiple versions of the same module among module templates, the CLI was finding duplicated manager entries (e.g. `serverless-1.7.4` and `serverless-1.8.1` have the same manager definitions in their module templates.)
- The module version is later extracted from the data gathered from the running instance of the manager - hence the duplication.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#2567

