### PR TITLE
Improve some of the error messages

### DIFF
--- a/internal/btp/hana/hana.go
+++ b/internal/btp/hana/hana.go
@@ -3,9 +3,10 @@ package hana
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/kyma-project/cli.v3/internal/clierror"
 	"io"
 	"net/http"
+
+	"github.com/kyma-project/cli.v3/internal/clierror"
 )
 
 func GetID(baseURL, token string) (string, clierror.Error) {
@@ -16,13 +17,13 @@ func getID(baseURL, token string) (string, clierror.Error) {
 	client := &http.Client{}
 	requestGet, err := http.NewRequest("GET", fmt.Sprintf("%s/inventory/v2/serviceInstances", baseURL), nil)
 	if err != nil {
-		return "", clierror.Wrap(err, clierror.New("failed to create a get Hana instances request"))
+		return "", clierror.Wrap(err, clierror.New("failed to create a get SAP Hana instances request"))
 	}
 	requestGet.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
 
 	response, err := client.Do(requestGet)
 	if err != nil {
-		return "", clierror.Wrap(err, clierror.New("failed to get Hana instances"))
+		return "", clierror.Wrap(err, clierror.New("failed to get SAP Hana instances"))
 	}
 
 	if response.StatusCode != http.StatusOK {
@@ -30,15 +31,15 @@ func getID(baseURL, token string) (string, clierror.Error) {
 	}
 	hanaInstanceBytes, err := io.ReadAll(response.Body)
 	if err != nil {
-		return "", clierror.Wrap(err, clierror.New("failed to read Hana instances from the response"))
+		return "", clierror.Wrap(err, clierror.New("failed to read SAP Hana instances from the response"))
 	}
 	hanaInstance := HanaInstance{}
 	err = json.Unmarshal(hanaInstanceBytes, &hanaInstance)
 	if err != nil {
-		return "", clierror.Wrap(err, clierror.New("failed to parse Hana instances from the response"))
+		return "", clierror.Wrap(err, clierror.New("failed to parse SAP Hana instances from the response"))
 	}
 	if len(hanaInstance.Data) == 0 {
-		return "", clierror.New("no Hana instances found in the response")
+		return "", clierror.New("no SAP Hana instances found in the response")
 	}
 	return hanaInstance.Data[0].ID, nil
 }

--- a/internal/btp/hana/hana_test.go
+++ b/internal/btp/hana/hana_test.go
@@ -2,10 +2,11 @@ package hana
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetID(t *testing.T) {
@@ -38,17 +39,17 @@ func TestGetID(t *testing.T) {
 		defer testServer.Close()
 
 		id, err := getID(testServer.URL, authToken)
-		require.Contains(t, err.String(), "no Hana instances found in the response")
+		require.Contains(t, err.String(), "no SAP Hana instances found in the response")
 		require.Empty(t, id)
 	})
 	t.Run("can't create new GET request", func(t *testing.T) {
 		id, err := getID(":		", authToken)
-		require.Contains(t, err.String(), "failed to create a get Hana instances request")
+		require.Contains(t, err.String(), "failed to create a get SAP Hana instances request")
 		require.Empty(t, id)
 	})
 	t.Run("can't send GET request", func(t *testing.T) {
 		id, err := getID("https://localhost", authToken)
-		require.Contains(t, err.String(), "failed to get Hana instances")
+		require.Contains(t, err.String(), "failed to get SAP Hana instances")
 		require.Empty(t, id)
 	})
 	t.Run("response status not OK", func(t *testing.T) {
@@ -70,7 +71,7 @@ func TestGetID(t *testing.T) {
 		defer testServer.Close()
 
 		id, err := getID(testServer.URL, authToken)
-		require.Contains(t, err.String(), "failed to parse Hana instances from the response")
+		require.Contains(t, err.String(), "failed to parse SAP Hana instances from the response")
 		require.Empty(t, id)
 	})
 }

--- a/internal/cmd/alpha/hana/map.go
+++ b/internal/cmd/alpha/hana/map.go
@@ -54,12 +54,12 @@ func runHanaMap(config *hanaMapConfig) clierror.Error {
 
 	clusterID, err := getClusterID(config.Ctx, client.Static())
 	if err != nil {
-		return clierror.WrapE(err, clierror.New("while getting cluster ID"))
+		return clierror.WrapE(err, clierror.New("while getting Kyma cluster ID"))
 	}
 
 	credentials, err := hana.ReadCredentialsFromFile(config.credentialsPath)
 	if err != nil {
-		return clierror.WrapE(err, clierror.New("while reading Hana credentials from file"))
+		return clierror.WrapE(err, clierror.New("while reading SAP Hana credentials from file"))
 	}
 
 	token, err := auth.GetOAuthToken("client_credentials", credentials.UAA.URL, credentials.UAA.ClientID, credentials.UAA.ClientSecret)
@@ -72,13 +72,13 @@ func runHanaMap(config *hanaMapConfig) clierror.Error {
 	if hanaID == "" {
 		hanaID, err = hana.GetID(credentials.BaseURL, token.AccessToken)
 		if err != nil {
-			return clierror.WrapE(err, clierror.New("while getting hana ID"))
+			return clierror.WrapE(err, clierror.New("while getting SAP Hana ID"))
 
 		}
 	}
 	err = hana.MapInstance(credentials.BaseURL, clusterID, hanaID, token.AccessToken)
 	if err != nil {
-		return clierror.WrapE(err, clierror.New("while mapping Hana instance"))
+		return clierror.WrapE(err, clierror.New("while mapping Kyma environment instance with SAP Hana instance"))
 	}
 
 	fmt.Printf("Hana with id '%s' is mapped to the cluster with id '%s'\n", hanaID, clusterID)

--- a/internal/cmd/alpha/kubeconfig/generate.go
+++ b/internal/cmd/alpha/kubeconfig/generate.go
@@ -175,7 +175,7 @@ func generateWithToken(cfg *generateConfig) (*api.Config, clierror.Error) {
 		// Get cluster kubeconfig from CIS
 		kubeconfigTemplate, clierr = kubeconfig.GetFromCIS(cfg.cisCredentialsPath)
 		if clierr != nil {
-			return nil, clierror.WrapE(clierr, clierror.New("failed to get kubeconfig from CIS"))
+			return nil, clierror.WrapE(clierr, clierror.New("failed to get kubeconfig template for Kyma environment"))
 		}
 	} else {
 		// Get cluster kubeconfig from cluster
@@ -200,7 +200,7 @@ func generateWithServiceAccount(cfg *generateConfig) (*api.Config, clierror.Erro
 	// Create ServiceAccount, ClusterRoleBinding and secret with token
 	clierr = registerServiceAccount(cfg, kubeClient)
 	if clierr != nil {
-		return nil, clierror.WrapE(clierr, clierror.New("failed to create objects"))
+		return nil, clierror.WrapE(clierr, clierror.New("failed to create k8s resources"))
 	}
 
 	// Fill kubeconfig

--- a/internal/cmd/app/push.go
+++ b/internal/cmd/app/push.go
@@ -180,13 +180,13 @@ func runAppPush(cfg *appPushConfig) clierror.Error {
 		var domain string
 		domain, clierr = client.Istio().GetClusterAddressFromGateway(cfg.Ctx)
 		if clierr != nil {
-			return clierror.WrapE(clierr, clierror.New("failed to get cluster address from gateway", "Make sure Istio module is installed"))
+			return clierror.WrapE(clierr, clierror.New("failed to domain address of the Kyma environment from gateway", "Make sure Istio module is installed"))
 		}
 
 		host := fmt.Sprintf("%s.%s", cfg.name, domain)
 		err = resources.CreateAPIRule(cfg.Ctx, client.RootlessDynamic(), cfg.name, cfg.namespace, host, uint32(*cfg.containerPort.Value))
 		if err != nil {
-			return clierror.Wrap(err, clierror.New("failed to create API Rule", "Make sure API Gateway module is installed", "Make sure APIRule is available in v2alpha1 version"))
+			return clierror.Wrap(err, clierror.New("failed to create API Rule resource", "Make sure API Gateway module is installed", "Make sure APIRule CRD is available in v2 version"))
 		}
 
 		fmt.Printf("\nThe %s app is available under the https://%s/ address\n", cfg.name, host)
@@ -228,7 +228,7 @@ func buildAndImportImage(client kube.Client, cfg *appPushConfig, registryConfig 
 		pushFunc,
 	)
 	if cliErr != nil {
-		return "", clierror.WrapE(cliErr, clierror.New("failed to import image to in-cluster registry"))
+		return "", clierror.WrapE(cliErr, clierror.New("failed to import image to in-cluster docker registry"))
 	}
 
 	return pushedImage, nil

--- a/internal/cmd/module/catalog.go
+++ b/internal/cmd/module/catalog.go
@@ -42,12 +42,12 @@ func catalogModules(cfg *catalogConfig) clierror.Error {
 
 	modulesList, err := modules.ListCatalog(cfg.Ctx, client, moduleTemplatesRepo)
 	if err != nil {
-		return clierror.Wrap(err, clierror.New("failed to list available modules from the cluster"))
+		return clierror.Wrap(err, clierror.New("failed to list available modules from the target Kyma environment"))
 	}
 
 	err = modules.Render(modulesList, modules.CatalogTableInfo, cfg.outputFormat)
 	if err != nil {
-		return clierror.Wrap(err, clierror.New("failed to render modules catalog"))
+		return clierror.Wrap(err, clierror.New("failed to list module catalog"))
 	}
 
 	return nil

--- a/internal/cmd/module/list.go
+++ b/internal/cmd/module/list.go
@@ -44,12 +44,12 @@ func listModules(cfg *modulesConfig) clierror.Error {
 
 	modulesList, err := modules.ListInstalled(cfg.Ctx, client, moduleTemplatesRepo, cfg.showErrors)
 	if err != nil {
-		return clierror.Wrap(err, clierror.New("failed to list installed modules from the cluster"))
+		return clierror.Wrap(err, clierror.New("failed to list installed modules from the target Kyma environment"))
 	}
 
 	err = modules.Render(modulesList, modules.ModulesTableInfo, cfg.outputFormat)
 	if err != nil {
-		return clierror.Wrap(err, clierror.New("failed to render modules catalog"))
+		return clierror.Wrap(err, clierror.New("failed to render module catalog"))
 	}
 
 	return nil

--- a/internal/cmd/module/manage.go
+++ b/internal/cmd/module/manage.go
@@ -63,7 +63,7 @@ func runManage(cfg *manageConfig) clierror.Error {
 
 	exists, err := modules.ModuleExistsInKymaCR(cfg.Ctx, client, cfg.module)
 	if err != nil {
-		return clierror.Wrap(err, clierror.New("failed to check if module exists in Kyma CR"))
+		return clierror.Wrap(err, clierror.New("failed to check if module exists in the target Kyma environment"))
 	}
 
 	if exists {
@@ -80,7 +80,7 @@ func runManage(cfg *manageConfig) clierror.Error {
 func manageModuleInKyma(cfg *manageConfig, client kube.Client) clierror.Error {
 	err := modules.ManageModuleInKymaCR(cfg.Ctx, client, cfg.module, cfg.policy)
 	if err != nil {
-		return clierror.Wrap(err, clierror.New("failed to manage module in Kyma CR"))
+		return clierror.Wrap(err, clierror.New("failed to manage module in the target Kyma environment"))
 	}
 	fmt.Printf("Module %s set to managed\n", cfg.module)
 
@@ -96,7 +96,7 @@ func manageModuleMissingInKyma(cfg *manageConfig, client kube.Client) clierror.E
 		return nil
 	}
 	if !errors.Is(err, modules.ErrModuleInstalledVersionNotInKymaChannel) {
-		return clierror.Wrap(err, clierror.New("failed to mark module as managed"))
+		return clierror.Wrap(err, clierror.New("failed to set module as managed"))
 	}
 
 	// If not found, prompt for alternative channel

--- a/internal/cmdcommon/kubeconfig.go
+++ b/internal/cmdcommon/kubeconfig.go
@@ -39,7 +39,7 @@ func (kcc *kubeClientConfig) GetKubeClient() (kube.Client, error) {
 func (kcc *kubeClientConfig) GetKubeClientWithClierr() (kube.Client, clierror.Error) {
 	if kcc.kubeClientErr != nil {
 		return nil, clierror.Wrap(kcc.kubeClientErr,
-			clierror.New("failed to create cluster connection", "Make sure that kubeconfig is proper."),
+			clierror.New("failed to create connection with the target Kyma environment", "Make sure that kubeconfig is proper."),
 		)
 	}
 

--- a/internal/dockerfile/build.go
+++ b/internal/dockerfile/build.go
@@ -55,7 +55,7 @@ func (b *imageBuilder) do(ctx context.Context, opts *BuildOptions) error {
 
 	err = build.ValidateContextDirectory(opts.BuildContext, excludes)
 	if err != nil {
-		return errors.Wrap(err, "error checking context")
+		return errors.Wrap(err, "error validating docker context")
 	}
 
 	buildCtx, err := archive.TarWithOptions(opts.BuildContext, &archive.TarOptions{

--- a/internal/dockerfile/build_test.go
+++ b/internal/dockerfile/build_test.go
@@ -97,7 +97,7 @@ func TestBuild(t *testing.T) {
 			BuildContext:   tmpDir,
 			DockerfilePath: dockerfilePath,
 		})
-		require.ErrorContains(t, err, "error checking context: syntax error in pattern")
+		require.ErrorContains(t, err, "error validating docker context: syntax error in pattern")
 	})
 
 	t.Run("dockerfile not found error", func(t *testing.T) {

--- a/internal/extensions/actions/function_init.go
+++ b/internal/extensions/actions/function_init.go
@@ -33,15 +33,15 @@ func (c *functionInitActionConfig) validate() clierror.Error {
 	if _, ok := c.Runtimes[c.UseRuntime]; !ok {
 		return clierror.New(
 			fmt.Sprintf("unsupported runtime %s", c.UseRuntime),
-			fmt.Sprintf("use on the allowed runtimes on this cluster [ %s ]", sortedRuntimesString(c.Runtimes)),
+			fmt.Sprintf("allowed runtimes on this Kyma environment [ %s ]", sortedRuntimesString(c.Runtimes)),
 		)
 	}
 
 	for runtimeName, runtimeCfg := range c.Runtimes {
 		if !filepath.IsLocal(runtimeCfg.DepsFilename) {
 			return clierror.New(
-				fmt.Sprintf("invalid deps filename %s for runtime %s", runtimeCfg.DepsFilename, runtimeName),
-				"deps filename must be a local path or single file name",
+				fmt.Sprintf("invalid dependency filename %s for runtime %s", runtimeCfg.DepsFilename, runtimeName),
+				"dependency filename must be a local path or single file name",
 			)
 		}
 

--- a/internal/extensions/actions/registry_image-import.go
+++ b/internal/extensions/actions/registry_image-import.go
@@ -81,7 +81,7 @@ func (a *registryImageImportAction) Run(cmd *cobra.Command, _ []string) clierror
 		pushFunc,
 	)
 	if err != nil {
-		return clierror.WrapE(err, clierror.New("failed to import image to in-cluster registry"))
+		return clierror.WrapE(err, clierror.New("failed to import image to in-cluster docker registry"))
 	}
 
 	pullImageName := fmt.Sprintf("%s/%s", registryConfig.SecretData.PullRegAddr, pushedImage)

--- a/internal/extensions/extensions.go
+++ b/internal/extensions/extensions.go
@@ -42,7 +42,7 @@ func NewBuilder(kymaConfig *cmdcommon.KymaConfig) *Builder {
 
 func AddCmdPersistentFlags(cmd *cobra.Command) {
 	// these flags are not operational. it's only to print the help description, and the help cobra with validation
-	_ = cmd.PersistentFlags().Bool("skip-extensions", false, "Skip fetching extensions from the cluster")
+	_ = cmd.PersistentFlags().Bool("skip-extensions", false, "Skip fetching extensions from the target Kyma environment")
 	_ = cmd.PersistentFlags().Bool("show-extensions-error", false, "Prints a possible error when fetching extensions fails")
 }
 
@@ -56,7 +56,7 @@ func (b *Builder) DisplayWarnings(warningWriter io.Writer) {
 		// print error as warning if expected and continue
 		fmt.Fprintf(warningWriter, "Extensions Warning:\n%s\n\n", errors.NewList(b.extensionsErrors...).Error())
 	} else if len(b.extensionsErrors) > 0 {
-		fmt.Fprintf(warningWriter, "Extensions Warning:\nfailed to fetch all extensions from the cluster. Use the '--show-extensions-error' flag to see more details.\n\n")
+		fmt.Fprintf(warningWriter, "Extensions Warning:\nfailed to fetch all extensions from the target Kyma environment. Use the '--show-extensions-error' flag to see more details.\n\n")
 	}
 }
 

--- a/internal/extensions/extensions_test.go
+++ b/internal/extensions/extensions_test.go
@@ -115,7 +115,7 @@ func Test_DisplayWarnings(t *testing.T) {
 		b.DisplayWarnings(buffer)
 
 		require.Equal(t, "Extensions Warning:\n"+
-			"failed to fetch all extensions from the cluster. Use the '--show-extensions-error' flag to see more details.\n\n", buffer.String())
+			"failed to fetch all extensions from the target Kyma environment. Use the '--show-extensions-error' flag to see more details.\n\n", buffer.String())
 	})
 
 	t.Run("display warning details", func(t *testing.T) {

--- a/internal/modules/disable.go
+++ b/internal/modules/disable.go
@@ -20,7 +20,7 @@ import (
 
 // Disable takes care about disabling module whatever if CustomResourcePolicy is set to Ignore or CreateAndDelete
 // if CustomResourcePolicy is Ignore then it first deletes module CR and waits for removal
-// at the end removes module from the Kyma CR
+// at the end removes module from the target Kyma environment
 func Disable(ctx context.Context, client kube.Client, repo repo.ModuleTemplatesRepository, module string, community bool) clierror.Error {
 	if community {
 		return disableCommunity(os.Stdout, ctx, repo, module)
@@ -48,7 +48,7 @@ func GetRunningResourcesOfCommunityModule(ctx context.Context, repo repo.ModuleT
 }
 
 func disableCommunity(writer io.Writer, ctx context.Context, repo repo.ModuleTemplatesRepository, module string) clierror.Error {
-	fmt.Fprintf(writer, "removing %s community module from the cluster\n", module)
+	fmt.Fprintf(writer, "removing %s community module from the target Kyma environment\n", module)
 
 	moduleTemplateToDelete, err := getModuleTemplateToDelete(ctx, repo, module)
 	if err != nil {
@@ -112,7 +112,7 @@ func disableCore(writer io.Writer, ctx context.Context, client kube.Client, modu
 		return clierr
 	}
 
-	fmt.Fprintf(writer, "removing %s module from the Kyma CR\n", module)
+	fmt.Fprintf(writer, "removing %s module from the target Kyma environment\n", module)
 	err := client.Kyma().DisableModule(ctx, module)
 	if err != nil {
 		return clierror.Wrap(err, clierror.New("failed to disable module"))
@@ -125,7 +125,7 @@ func disableCore(writer io.Writer, ctx context.Context, client kube.Client, modu
 func removeModuleCR(writer io.Writer, ctx context.Context, client kube.Client, module string) clierror.Error {
 	info, err := client.Kyma().GetModuleInfo(ctx, module)
 	if err != nil {
-		return clierror.Wrap(err, clierror.New("failed to get module info from the Kyma CR"))
+		return clierror.Wrap(err, clierror.New("failed to get module info from the target Kyma environment"))
 	}
 
 	if info.Spec.CustomResourcePolicy == kyma.CustomResourcePolicyCreateAndDelete {

--- a/internal/modules/disable_test.go
+++ b/internal/modules/disable_test.go
@@ -51,7 +51,7 @@ func TestDisableCore(t *testing.T) {
 		err := disableCore(buffer, context.Background(), &fakeKubeClient, "keda")
 		require.Nil(t, err)
 		require.Equal(t, []string{"keda"}, fakeKymaClient.DisabledModules)
-		require.Equal(t, "removing keda module from the Kyma CR\nkeda module disabled\n", buffer.String())
+		require.Equal(t, "removing keda module from the target Kyma environment\nkeda module disabled\n", buffer.String())
 	})
 
 	t.Run("disable module with Ignore policy for module with no CR", func(t *testing.T) {
@@ -78,7 +78,7 @@ func TestDisableCore(t *testing.T) {
 		err := disableCore(buffer, context.Background(), &fakeKubeClient, "keda")
 		require.Nil(t, err)
 		require.Equal(t, []string{"keda"}, fakeKymaClient.DisabledModules)
-		require.Equal(t, "removing keda module from the Kyma CR\nkeda module disabled\n", buffer.String())
+		require.Equal(t, "removing keda module from the target Kyma environment\nkeda module disabled\n", buffer.String())
 	})
 
 	t.Run("disable module with Ignore policy for module", func(t *testing.T) {
@@ -115,7 +115,7 @@ func TestDisableCore(t *testing.T) {
 		err := disableCore(buffer, context.Background(), &fakeKubeClient, "keda")
 		require.Nil(t, err)
 		require.Equal(t, []string{"keda"}, fakeKymaClient.DisabledModules)
-		require.Equal(t, "removing kyma-system/default CR\nwaiting for kyma-system/default CR to be removed\nremoving keda module from the Kyma CR\nkeda module disabled\n", buffer.String())
+		require.Equal(t, "removing kyma-system/default CR\nwaiting for kyma-system/default CR to be removed\nremoving keda module from the target Kyma environment\nkeda module disabled\n", buffer.String())
 	})
 
 	t.Run("failed to disable module", func(t *testing.T) {
@@ -139,7 +139,7 @@ func TestDisableCore(t *testing.T) {
 
 		err := disableCore(buffer, context.Background(), &fakeKubeClient, "keda")
 		require.Equal(t, expectedCliErr, err)
-		require.Equal(t, "removing keda module from the Kyma CR\n", buffer.String())
+		require.Equal(t, "removing keda module from the target Kyma environment\n", buffer.String())
 	})
 
 	t.Run("failed to get module info", func(t *testing.T) {
@@ -153,7 +153,7 @@ func TestDisableCore(t *testing.T) {
 
 		expectedCliErr := clierror.Wrap(
 			errors.New("test error"),
-			clierror.New("failed to get module info from the Kyma CR"),
+			clierror.New("failed to get module info from the target Kyma environment"),
 		)
 
 		err := disableCore(buffer, context.Background(), &fakeKubeClient, "keda")
@@ -431,7 +431,7 @@ func TestDisableCommunity(t *testing.T) {
 
 		require.NotNil(t, err)
 		require.Equal(t, expectedCliErr, err)
-		require.Equal(t, "removing test community module from the cluster\n", buffer.String())
+		require.Equal(t, "removing test community module from the target Kyma environment\n", buffer.String())
 	})
 
 	t.Run("fails to find any version for the module", func(t *testing.T) {
@@ -450,7 +450,7 @@ func TestDisableCommunity(t *testing.T) {
 
 		require.NotNil(t, err)
 		require.Equal(t, expectedCliErr, err)
-		require.Equal(t, "removing test community module from the cluster\n", buffer.String())
+		require.Equal(t, "removing test community module from the target Kyma environment\n", buffer.String())
 	})
 
 	t.Run("fails to determine version to remove", func(t *testing.T) {
@@ -482,7 +482,7 @@ func TestDisableCommunity(t *testing.T) {
 
 		require.NotNil(t, err)
 		require.Equal(t, expectedCliErr, err)
-		require.Equal(t, "removing test community module from the cluster\n", buffer.String())
+		require.Equal(t, "removing test community module from the target Kyma environment\n", buffer.String())
 	})
 
 	t.Run("fails to get modules resources", func(t *testing.T) {
@@ -549,7 +549,7 @@ func TestDisableCommunity(t *testing.T) {
 		err := disableCommunity(buffer, ctx, &fakeModuleTemplatesRepo, "test")
 
 		require.Nil(t, err)
-		require.Equal(t, "removing test community module from the cluster\nfailed to delete resource test-secret (Secret): DeleteResourceReturnWatcherError\nfailed to delete resource test-namespace (Namespace): DeleteResourceReturnWatcherError\nsome errors occured during the test community module removal\n", buffer.String())
+		require.Equal(t, "removing test community module from the target Kyma environment\nfailed to delete resource test-secret (Secret): DeleteResourceReturnWatcherError\nfailed to delete resource test-namespace (Namespace): DeleteResourceReturnWatcherError\nsome errors occured during the test community module removal\n", buffer.String())
 	})
 
 	t.Run("timeouts waiting for the resource removal", func(t *testing.T) {
@@ -603,7 +603,7 @@ func TestDisableCommunity(t *testing.T) {
 
 		require.NotNil(t, err)
 		require.Equal(t, expectedCliErr, err)
-		require.Equal(t, buffer.String(), "removing test community module from the cluster\nwaiting for resource deletion: test-secret (Secret)\n")
+		require.Equal(t, buffer.String(), "removing test community module from the target Kyma environment\nwaiting for resource deletion: test-secret (Secret)\n")
 	})
 
 	t.Run("successfully removes the module", func(t *testing.T) {
@@ -651,6 +651,6 @@ func TestDisableCommunity(t *testing.T) {
 		err := disableCommunity(buffer, ctx, &fakeModuleTemplatesRepo, "test")
 
 		require.Nil(t, err)
-		require.Equal(t, buffer.String(), "removing test community module from the cluster\nwaiting for resource deletion: test-secret (Secret)\nwaiting for resource deletion: test-namespace (Namespace)\ntest community module successfully removed\n")
+		require.Equal(t, buffer.String(), "removing test community module from the target Kyma environment\nwaiting for resource deletion: test-secret (Secret)\nwaiting for resource deletion: test-namespace (Namespace)\ntest community module successfully removed\n")
 	})
 }

--- a/internal/modules/enable.go
+++ b/internal/modules/enable.go
@@ -23,7 +23,12 @@ func Enable(ctx context.Context, client kube.Client, repo repo.ModuleTemplatesRe
 
 func enable(writer io.Writer, ctx context.Context, client kube.Client, repo repo.ModuleTemplatesRepository, module, channel string, defaultCR bool, crs ...unstructured.Unstructured) clierror.Error {
 	if err := validateModuleAvailability(ctx, client, repo, module); err != nil {
-		return clierror.Wrap(err, clierror.New("invalid module name or version"))
+		hints := []string{
+			"make sure you provide valid module name and channel (or version)",
+			"list available modules by calling `kyma module catalog`",
+			"if you want to add a community module, use `--community` flag",
+		}
+		return clierror.Wrap(err, clierror.New("unknown module name", hints...))
 	}
 
 	crPolicy := kyma.CustomResourcePolicyIgnore
@@ -79,7 +84,7 @@ func validateModuleAvailability(ctx context.Context, client kube.Client, repo re
 	}
 
 	if len(availableCoreVersions) == 0 {
-		return fmt.Errorf("module is not available")
+		return fmt.Errorf("%s not found in the catalog of available modules", module)
 	}
 
 	return nil

--- a/internal/modules/enable.go
+++ b/internal/modules/enable.go
@@ -23,7 +23,7 @@ func Enable(ctx context.Context, client kube.Client, repo repo.ModuleTemplatesRe
 
 func enable(writer io.Writer, ctx context.Context, client kube.Client, repo repo.ModuleTemplatesRepository, module, channel string, defaultCR bool, crs ...unstructured.Unstructured) clierror.Error {
 	if err := validateModuleAvailability(ctx, client, repo, module); err != nil {
-		return clierror.Wrap(err, clierror.New("module invalid"))
+		return clierror.Wrap(err, clierror.New("invalid module name or version"))
 	}
 
 	crPolicy := kyma.CustomResourcePolicyIgnore

--- a/internal/modules/enable_test.go
+++ b/internal/modules/enable_test.go
@@ -110,7 +110,7 @@ func TestEnable(t *testing.T) {
 
 		expectedCliErr := clierror.Wrap(
 			errors.New("module is not available"),
-			clierror.New("module invalid"),
+			clierror.New("invalid module name or version"),
 		)
 
 		err := enable(buffer, context.Background(), &client, repo, "keda", "fast", true)
@@ -133,7 +133,7 @@ func TestEnable(t *testing.T) {
 
 		expectedCliErr := clierror.Wrap(
 			errors.New("module is not available"),
-			clierror.New("module invalid"),
+			clierror.New("invalid module name or version"),
 		)
 
 		err := enable(buffer, context.Background(), &client, repo, "keda", "fast", true)

--- a/internal/modules/enable_test.go
+++ b/internal/modules/enable_test.go
@@ -108,9 +108,11 @@ func TestEnable(t *testing.T) {
 		}
 		repo := &modulesfake.ModuleTemplatesRepo{}
 
+		hints := []string{"make sure you provide valid module name and channel (or version)", "list available modules by calling `kyma module catalog`", "if you want to add a community module, use `--community` flag"}
+
 		expectedCliErr := clierror.Wrap(
-			errors.New("module is not available"),
-			clierror.New("invalid module name or version"),
+			errors.New("keda not found in the catalog of available modules"),
+			clierror.New("unknown module name", hints...),
 		)
 
 		err := enable(buffer, context.Background(), &client, repo, "keda", "fast", true)
@@ -131,9 +133,11 @@ func TestEnable(t *testing.T) {
 		}
 		repo := &modulesfake.ModuleTemplatesRepo{}
 
+		hints := []string{"make sure you provide valid module name and channel (or version)", "list available modules by calling `kyma module catalog`", "if you want to add a community module, use `--community` flag"}
+
 		expectedCliErr := clierror.Wrap(
-			errors.New("module is not available"),
-			clierror.New("invalid module name or version"),
+			errors.New("keda not found in the catalog of available modules"),
+			clierror.New("unknown module name", hints...),
 		)
 
 		err := enable(buffer, context.Background(), &client, repo, "keda", "fast", true)

--- a/internal/modules/list.go
+++ b/internal/modules/list.go
@@ -70,7 +70,7 @@ func ListInstalled(ctx context.Context, client kube.Client, repo repo.ModuleTemp
 func listCoreInstalled(ctx context.Context, client kube.Client, repo repo.ModuleTemplatesRepository, showErrors bool) (ModulesList, error) {
 	defaultKyma, err := client.Kyma().GetDefaultKyma(ctx)
 	if err != nil && !apierrors.IsNotFound(err) {
-		return nil, errors.Wrap(err, "failed to get default Kyma CR from the cluster")
+		return nil, errors.Wrap(err, "failed to get default Kyma CR from the target Kyma environment")
 	}
 	if err != nil && apierrors.IsNotFound(err) {
 		// if cluster is not managed by KLM we won't be looking into Kyma CR spec
@@ -239,7 +239,7 @@ func ListCatalog(ctx context.Context, client kube.Client, repo repo.ModuleTempla
 func listCoreModulesCatalog(ctx context.Context, client kube.Client) (ModulesList, error) {
 	moduleTemplates, err := client.Kyma().ListModuleTemplate(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to list all ModuleTemplate CRs from the cluster")
+		return nil, errors.Wrap(err, "failed to list all ModuleTemplate resources from the target Kyma environment")
 	}
 
 	moduleReleaseMetas, err := client.Kyma().ListModuleReleaseMeta(ctx)
@@ -248,7 +248,7 @@ func listCoreModulesCatalog(ctx context.Context, client kube.Client) (ModulesLis
 		if len(moduleList) != 0 {
 			return moduleList, nil
 		}
-		return nil, errors.New("failed to list modules catalog with and without ModuleRelease meta resource from the cluster")
+		return nil, errors.New("failed to list module catalog from the target Kyma environment")
 	}
 
 	modulesList := ModulesList{}
@@ -799,7 +799,7 @@ func getModuleIndex(list ModulesList, name string, isCommunityModule bool) int {
 func findMatchingModuleTemplate(ctx context.Context, client kube.Client, moduleStatus kyma.ModuleStatus) (*kyma.ModuleTemplate, error) {
 	moduleTemplates, err := client.Kyma().ListModuleTemplate(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to list ModuleTemplates")
+		return nil, errors.Wrap(err, "failed to list modules available on the target Kyma environment")
 	}
 	for _, mt := range moduleTemplates.Items {
 		if mt.Spec.ModuleName == moduleStatus.Name && mt.Spec.Version == moduleStatus.Version {
@@ -807,5 +807,5 @@ func findMatchingModuleTemplate(ctx context.Context, client kube.Client, moduleS
 		}
 	}
 
-	return nil, errors.Errorf("no matching ModuleTemplate found for module: %s, version: %s", moduleStatus.Name, moduleStatus.Version)
+	return nil, errors.Errorf("no matching module version found for module: %s, version: %s", moduleStatus.Name, moduleStatus.Version)
 }

--- a/internal/modules/manage.go
+++ b/internal/modules/manage.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-var ErrModuleInstalledVersionNotInKymaChannel = errors.New("version of the installed module don't exist in default kyma channel")
+var ErrModuleInstalledVersionNotInKymaChannel = errors.New("version of the installed module doesn't exist in the configured release channel")
 
 func ModuleExistsInKymaCR(ctx context.Context, client kube.Client, moduleName string) (bool, error) {
 	defaultKyma, err := client.Kyma().GetDefaultKyma(ctx)

--- a/internal/modules/repo/moduletemplates.go
+++ b/internal/modules/repo/moduletemplates.go
@@ -188,7 +188,7 @@ func (r *moduleTemplatesRepo) InstalledManager(ctx context.Context, moduleTempla
 
 	installedManager, err := r.getInstalledManager(ctx, managerFromResources)
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve installed manager from the cluster %v", err)
+		return nil, fmt.Errorf("failed to retrieve installed manager from the target Kyma environment %v", err)
 	}
 
 	return installedManager, nil

--- a/internal/registry/config.go
+++ b/internal/registry/config.go
@@ -60,7 +60,7 @@ func getExternalConfig(ctx context.Context, client kube.Client) (*ExternalRegist
 		return nil, err
 	}
 	if dockerRegistry.Status.ExternalAccess.Enabled == "false" {
-		return nil, errors.New("external access is not enabled")
+		return nil, errors.New("docker registry is not configured for external access")
 	}
 	secretConfig, err := getRegistrySecretData(ctx, client.Static(), dockerRegistry.Status.ExternalAccess.SecretName, dockerRegistry.GetNamespace())
 	if err != nil {
@@ -173,7 +173,7 @@ func getReadyPod(pods []corev1.Pod) (*corev1.Pod, error) {
 		}
 	}
 
-	return nil, errors.New("no ready registry pod found")
+	return nil, errors.New("no running registry pod found")
 }
 
 func isPodReady(pod corev1.Pod) bool {

--- a/internal/registry/config_test.go
+++ b/internal/registry/config_test.go
@@ -163,7 +163,7 @@ func Test_getWorkloadMeta(t *testing.T) {
 		// then
 		require.Error(t, err)
 		require.Nil(t, meta)
-		require.Contains(t, err.Error(), "no ready registry pod found")
+		require.Contains(t, err.Error(), "no running registry pod found")
 	})
 }
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Make error messages more informative
- Use `kyma environment` instead of `cluster`
- Add `SAP` before `Hana`
- hide technical details like `cis`


**Related issue(s)**
Related to feedback from one of the users