### PR TITLE
Ignore extension commands with wrong action name

### DIFF
--- a/internal/extensions/commands.go
+++ b/internal/extensions/commands.go
@@ -44,8 +44,9 @@ func buildSingleCommand(extension types.Extension, availableActions types.Action
 		Long:  extension.Metadata.DescriptionLong,
 	}
 
-	if extension.Action == "" {
-		// no action provided
+	action, ok := availableActions[extension.Action]
+	if extension.Action == "" || !ok {
+		// no action provided or action not found
 		// set help command as default run
 		cmd.RunE = emptyActionRun
 		return cmd, errors.NewList(errs...)
@@ -77,13 +78,6 @@ func buildSingleCommand(extension types.Extension, availableActions types.Action
 	values = append(values, cmdArgs.value)
 
 	// set action runs
-	action, ok := availableActions[extension.Action]
-	if !ok {
-		// unexpected behavior because actions list is validated and should be filled only with available data
-		errs = append(errs, errors.Newf("action '%s' not found", extension.Action))
-		return cmd, errors.NewList(errs...)
-	}
-
 	cmd.PreRun = func(_ *cobra.Command, _ []string) {
 		// check required flags
 		clierror.Check(flags.Validate(cmd.Flags(),

--- a/internal/extensions/commands_test.go
+++ b/internal/extensions/commands_test.go
@@ -49,12 +49,11 @@ func Test_buildCommand(t *testing.T) {
 		cmd, err := buildCommand(fixTestExtension(), types.ActionsMap{
 			// no actions defined
 		})
-		require.ErrorContains(t, err, "failed to build command 'cmd2':\n"+
-			"  action 'action1' not found")
+		require.NoError(t, err)
 		require.NotNil(t, cmd)
 	})
 
-	t.Run("wrong flags and missing action", func(t *testing.T) {
+	t.Run("no error with wrong flags when action is not defined (flags are not built)", func(t *testing.T) {
 		extension := fixTestExtension()
 		extension.Action = "action2"
 		extension.SubCommands[0].Flags = []types.Flag{
@@ -73,13 +72,7 @@ func Test_buildCommand(t *testing.T) {
 		cmd, err := buildCommand(extension, types.ActionsMap{
 			// no actions defined
 		})
-		require.ErrorContains(t, err,
-			"failed to build command 'cmd1':\n"+
-				"  action 'action2' not found\n"+
-				"failed to build command 'cmd2':\n"+
-				"  flag 'flag1' error: strconv.ParseBool: parsing \"WRONG VALUE\": invalid syntax\n"+
-				"  flag 'flag2' error: strconv.ParseInt: parsing \"WRONG VALUE\": invalid syntax\n"+
-				"  action 'action1' not found")
+		require.NoError(t, err)
 		require.NotNil(t, cmd)
 	})
 }

--- a/internal/extensions/extensions.go
+++ b/internal/extensions/extensions.go
@@ -65,7 +65,7 @@ func (b *Builder) DisplayWarnings(warningWriter io.Writer) {
 func (b *Builder) Build(parentCmd *cobra.Command, availableActions types.ActionsMap) {
 	for _, cmExt := range b.extensions {
 		// validate
-		err := cmExt.Extension.Validate(availableActions)
+		err := cmExt.Extension.Validate()
 		if err != nil {
 			b.extensionsErrors = append(b.extensionsErrors,
 				errors.Wrapf(err, "failed to validate extension from configmap '%s/%s'", cmExt.ConfigMapNamespace, cmExt.ConfigMapName))

--- a/internal/extensions/types/types.go
+++ b/internal/extensions/types/types.go
@@ -116,10 +116,6 @@ func (e *Extension) Validate(availableActions ActionsMap) error {
 
 func (e *Extension) validateWithPath(path string, availableActions ActionsMap) error {
 	var errs []error
-	if _, ok := availableActions[e.Action]; e.Action != "" && !ok {
-		errs = append(errs, errors.Newf("wrong %suses: unsupported value '%s'", path, e.Action))
-	}
-
 	if metaErr := e.Metadata.Validate(); metaErr != nil {
 		errs = append(errs, errors.Newf("wrong %smetadata: %s", path, metaErr.Error()))
 	}

--- a/internal/extensions/types/types.go
+++ b/internal/extensions/types/types.go
@@ -110,11 +110,11 @@ type Extension struct {
 	SubCommands []Extension `yaml:"subCommands"`
 }
 
-func (e *Extension) Validate(availableActions ActionsMap) error {
-	return e.validateWithPath(".", availableActions)
+func (e *Extension) Validate() error {
+	return e.validateWithPath(".")
 }
 
-func (e *Extension) validateWithPath(path string, availableActions ActionsMap) error {
+func (e *Extension) validateWithPath(path string) error {
 	var errs []error
 	if metaErr := e.Metadata.Validate(); metaErr != nil {
 		errs = append(errs, errors.Newf("wrong %smetadata: %s", path, metaErr.Error()))
@@ -133,7 +133,7 @@ func (e *Extension) validateWithPath(path string, availableActions ActionsMap) e
 	}
 
 	for i := range e.SubCommands {
-		subCmdErr := e.SubCommands[i].validateWithPath(fmt.Sprintf("%ssubCommands[%d].", path, i), availableActions)
+		subCmdErr := e.SubCommands[i].validateWithPath(fmt.Sprintf("%ssubCommands[%d].", path, i))
 		if subCmdErr != nil {
 			errs = append(errs, subCmdErr)
 		}

--- a/internal/extensions/types/types_test.go
+++ b/internal/extensions/types/types_test.go
@@ -6,14 +6,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	testActionsMap = map[string]Action{
-		"create": nil,
-		"debug":  nil,
-		"demo":   nil,
-	}
-)
-
 func TestExtension_Validate(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -96,7 +88,7 @@ func TestExtension_Validate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := tt.extension.Validate(testActionsMap)
+			err := tt.extension.Validate()
 			if tt.wantErr != "" {
 				require.EqualError(t, err, tt.wantErr)
 			} else {

--- a/internal/extensions/types/types_test.go
+++ b/internal/extensions/types/types_test.go
@@ -55,8 +55,7 @@ func TestExtension_Validate(t *testing.T) {
 		},
 		{
 			name: "validation error - broken flag",
-			wantErr: "wrong .uses: unsupported value 'wrong-action'\n" +
-				"wrong .flags: empty name, unknown type ''\n" +
+			wantErr: "wrong .flags: empty name, unknown type ''\n" +
 				"wrong .subCommands[0].metadata: empty name\n" +
 				"wrong .subCommands[0].subCommands[1].args: unknown type ''",
 			extension: Extension{


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- build extension even when the used action is not found (cover case when old CLI is building newer extension with action that is not implemented with the following version)
