### PR TITLE
Extract generic pod operations from registry pkg

### DIFF
--- a/internal/kube/resources/pod.go
+++ b/internal/kube/resources/pod.go
@@ -1,0 +1,60 @@
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func GetPodForSelector(ctx context.Context, client kubernetes.Interface, namespace string, labelSelector map[string]string) (*corev1.Pod, error) {
+	podList, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: LabelSelectorFor(labelSelector),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(podList.Items) == 0 {
+		return nil, fmt.Errorf("no pod found for selector %s in namespace %s", labelSelector, namespace)
+	}
+
+	readyPod, err := GetReadyPod(podList.Items)
+	if err != nil {
+		return nil, err
+	}
+
+	return readyPod, nil
+}
+
+func LabelSelectorFor(labels map[string]string) string {
+	labelSelectors := []string{}
+	for key, value := range labels {
+		labelSelectors = append(labelSelectors, fmt.Sprintf("%s=%s", key, value))
+	}
+
+	return strings.Join(labelSelectors, ",")
+}
+
+func GetReadyPod(pods []corev1.Pod) (*corev1.Pod, error) {
+	for _, registryPod := range pods {
+		if IsPodReady(registryPod) {
+			return &registryPod, nil
+		}
+	}
+
+	return nil, errors.New("no running registry pod found")
+}
+
+func IsPodReady(pod corev1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.ContainersReady && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/registry/config_test.go
+++ b/internal/registry/config_test.go
@@ -163,7 +163,7 @@ func Test_getWorkloadMeta(t *testing.T) {
 		// then
 		require.Error(t, err)
 		require.Nil(t, meta)
-		require.Contains(t, err.Error(), "no running registry pod found")
+		require.Contains(t, err.Error(), "no pod found for selector map[app:serverless-docker-registry] in namespace test-namespace")
 	})
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- move generic pod operations to the higher access level to reuse them later in other packages

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/serverless/issues/1838