### PR TITLE
Skip arguments validation for extension subcommands

### DIFF
--- a/internal/extensions/args.go
+++ b/internal/extensions/args.go
@@ -28,7 +28,15 @@ func buildArgs(extensionArgs *types.Args, overwrites map[string]interface{}) arg
 
 	return args{
 		value: value,
-		run: func(_ *cobra.Command, args []string) error {
+		run: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				for _, sub := range cmd.Commands() {
+					if sub.Name() == args[0] {
+						return nil
+					}
+				}
+			}
+
 			if extensionArgs.Optional {
 				return setOptionalArg(value, args)
 			}

--- a/internal/extensions/args_test.go
+++ b/internal/extensions/args_test.go
@@ -100,4 +100,28 @@ func Test_buildArgs(t *testing.T) {
 
 		require.ErrorContains(t, err, "accepts at most one argument, received 4")
 	})
+
+	t.Run("subcommand not treated as argument", func(t *testing.T) {
+		testArgs := buildArgs(&types.Args{
+			Type:     parameters.StringCustomType,
+			Optional: false,
+		}, fixEmptyOverwrites())
+
+		root := &cobra.Command{
+			Use: "root",
+		}
+
+		subcmd := &cobra.Command{
+			Use: "subcmd",
+			Run: func(cmd *cobra.Command, args []string) {
+				// subcommand logic
+			},
+		}
+		root.AddCommand(subcmd)
+
+		err := testArgs.run(root, []string{"subcmd"})
+
+		require.NoError(t, err)
+		require.Empty(t, testArgs.value.GetValue())
+	})
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:
- When extension command has defined subcommands, we were unable to differentiate the command from a command argument which was causing an argument validation error when subcommand was provided.
- Skipping validation when a subcommand is detected.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
