### PR TITLE
Make use of instructions defined in extensions API for function_init

### DIFF
--- a/internal/extensions/actions/function_init.go
+++ b/internal/extensions/actions/function_init.go
@@ -17,9 +17,10 @@ import (
 )
 
 type functionInitActionConfig struct {
-	UseRuntime string                   `yaml:"useRuntime"`
-	OutputDir  string                   `yaml:"outputDir"`
-	Runtimes   map[string]runtimeConfig `yaml:"runtimes"`
+	UseRuntime            string                   `yaml:"useRuntime"`
+	OutputDir             string                   `yaml:"outputDir"`
+	Runtimes              map[string]runtimeConfig `yaml:"runtimes"`
+	NextStepsInstructions string                   `yaml:"nextStepsInstructions"`
 }
 
 type runtimeConfig struct {
@@ -103,10 +104,7 @@ func (fi *functionInitAction) Run(cmd *cobra.Command, _ []string) clierror.Error
 
 	out := cmd.OutOrStdout()
 	fmt.Fprintf(out, "Functions files of runtime %s initialized to dir %s\n", fi.Cfg.UseRuntime, outDir)
-	fmt.Fprint(out, "\nNext steps:\n")
-	fmt.Fprint(out, "* update output files in your favorite IDE\n")
-	fmt.Fprintf(out, "* create Function, for example:\n")
-	fmt.Fprintf(out, "  kyma function create %s --runtime %s --source %s --dependencies %s\n", fi.Cfg.UseRuntime, fi.Cfg.UseRuntime, handlerPath, depsPath)
+	fmt.Fprintf(out, "\n%s\n", fi.Cfg.NextStepsInstructions)
 	return nil
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Making use of the `nextStepsInstructions` field from the extension config.
- The change was required because after removing some flags the displayed instructions were no longer valid.
- For that reason I decided to store the instructions with the usage examples in the extension definition instead of the CLI.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

https://github.com/kyma-project/serverless/issues/1897