### PR TITLE
Differentiate between cluster-wide and namespaced kubeconfig generation

### DIFF
--- a/docs/user/gen-docs/kyma.md
+++ b/docs/user/gen-docs/kyma.md
@@ -27,7 +27,7 @@ kyma <command> [flags]
   -h, --help                    Help for the command
       --kubeconfig string       Path to the Kyma kubeconfig file
       --show-extensions-error   Prints a possible error when fetching extensions fails
-      --skip-extensions         Skip fetching extensions from the cluster
+      --skip-extensions         Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_alpha.md
+++ b/docs/user/gen-docs/kyma_alpha.md
@@ -25,7 +25,7 @@ kyma alpha <command> [flags]
   -h, --help                    Help for the command
       --kubeconfig string       Path to the Kyma kubeconfig file
       --show-extensions-error   Prints a possible error when fetching extensions fails
-      --skip-extensions         Skip fetching extensions from the cluster
+      --skip-extensions         Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_alpha_hana.md
+++ b/docs/user/gen-docs/kyma_alpha_hana.md
@@ -22,7 +22,7 @@ kyma alpha hana <command> [flags]
   -h, --help                    Help for the command
       --kubeconfig string       Path to the Kyma kubeconfig file
       --show-extensions-error   Prints a possible error when fetching extensions fails
-      --skip-extensions         Skip fetching extensions from the cluster
+      --skip-extensions         Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_alpha_hana_map.md
+++ b/docs/user/gen-docs/kyma_alpha_hana_map.md
@@ -18,7 +18,7 @@ kyma alpha hana map [flags]
   -h, --help                      Help for the command
       --kubeconfig string         Path to the Kyma kubeconfig file
       --show-extensions-error     Prints a possible error when fetching extensions fails
-      --skip-extensions           Skip fetching extensions from the cluster
+      --skip-extensions           Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_alpha_kubeconfig.md
+++ b/docs/user/gen-docs/kyma_alpha_kubeconfig.md
@@ -22,7 +22,7 @@ kyma alpha kubeconfig <command> [flags]
   -h, --help                    Help for the command
       --kubeconfig string       Path to the Kyma kubeconfig file
       --show-extensions-error   Prints a possible error when fetching extensions fails
-      --skip-extensions         Skip fetching extensions from the cluster
+      --skip-extensions         Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_alpha_kubeconfig_generate.md
+++ b/docs/user/gen-docs/kyma_alpha_kubeconfig_generate.md
@@ -13,9 +13,12 @@ kyma alpha kubeconfig generate [flags]
 ## Examples
 
 ```bash
-# generate a kubeconfig with a ServiceAccount-based token and certificate
+# generate a permanent access (kubeconfig) for a new or existing ServiceAccount and a namespaced binding to a given ClusterRole
   kyma alpha kubeconfig generate --serviceaccount <sa_name> --clusterrole <cr_name> --namespace <ns_name> --permanent
 
+# generate time-constrained access (kubeconfig) for a new or existing ServiceAccount and a cluster-wide binding to a given ClusterRole
+  kyma alpha kubeconfig generate --serviceaccount <sa_name> --clusterrole <cr_name> --namespace <ns_name> --cluster-wide --time 2h
+  
 # generate a kubeconfig with an OIDC token
   kyma alpha kubeconfig generate --token <token>
 
@@ -36,19 +39,21 @@ kyma alpha kubeconfig generate [flags]
 
 ```text
       --audience string               Audience of the token
+      --cluster-wide                  Determines if the binding to the ClusterRole is cluster-wide
       --clusterrole string            Name of the Cluster Role to bind the Service Account to
       --credentials-path string       Path to the CIS credentials file
       --id-token-request-url string   URL to request the ID token, defaults to ACTIONS_ID_TOKEN_REQUEST_URL env variable
-      --namespace string              Namespace in which the resource is created (default "default")
+      --namespace string              Namespace in which the service account exists or will be created
+      --oidc-name string              Name of the OIDC Custom Resource from which the kubeconfig will be generated
       --output string                 Path to the kubeconfig file output. If not provided, the kubeconfig will be printed
       --permanent                     Determines if the token is valid indefinitely
-      --serviceaccount string         Name of the Service Account to be created
+      --serviceaccount string         Name of the Service Account to be used or created
       --time string                   Determines how long the token should be valid, by default 1h (use h for hours and d for days) (default "1h")
       --token string                  Token used in the kubeconfig
   -h, --help                          Help for the command
       --kubeconfig string             Path to the Kyma kubeconfig file
       --show-extensions-error         Prints a possible error when fetching extensions fails
-      --skip-extensions               Skip fetching extensions from the cluster
+      --skip-extensions               Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_alpha_provision.md
+++ b/docs/user/gen-docs/kyma_alpha_provision.md
@@ -23,7 +23,7 @@ kyma alpha provision [flags]
   -h, --help                      Help for the command
       --kubeconfig string         Path to the Kyma kubeconfig file
       --show-extensions-error     Prints a possible error when fetching extensions fails
-      --skip-extensions           Skip fetching extensions from the cluster
+      --skip-extensions           Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_alpha_reference-instance.md
+++ b/docs/user/gen-docs/kyma_alpha_reference-instance.md
@@ -25,7 +25,7 @@ kyma alpha reference-instance [flags]
   -h, --help                         Help for the command
       --kubeconfig string            Path to the Kyma kubeconfig file
       --show-extensions-error        Prints a possible error when fetching extensions fails
-      --skip-extensions              Skip fetching extensions from the cluster
+      --skip-extensions              Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_app.md
+++ b/docs/user/gen-docs/kyma_app.md
@@ -22,7 +22,7 @@ kyma app <command> [flags]
   -h, --help                    Help for the command
       --kubeconfig string       Path to the Kyma kubeconfig file
       --show-extensions-error   Prints a possible error when fetching extensions fails
-      --skip-extensions         Skip fetching extensions from the cluster
+      --skip-extensions         Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_app_push.md
+++ b/docs/user/gen-docs/kyma_app_push.md
@@ -29,7 +29,7 @@ kyma app push [flags]
   -h, --help                               Help for the command
       --kubeconfig string                  Path to the Kyma kubeconfig file
       --show-extensions-error              Prints a possible error when fetching extensions fails
-      --skip-extensions                    Skip fetching extensions from the cluster
+      --skip-extensions                    Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_completion.md
+++ b/docs/user/gen-docs/kyma_completion.md
@@ -27,7 +27,7 @@ kyma completion
   -h, --help                    Help for the command
       --kubeconfig string       Path to the Kyma kubeconfig file
       --show-extensions-error   Prints a possible error when fetching extensions fails
-      --skip-extensions         Skip fetching extensions from the cluster
+      --skip-extensions         Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_completion_bash.md
+++ b/docs/user/gen-docs/kyma_completion_bash.md
@@ -37,7 +37,7 @@ kyma completion bash
   -h, --help                    Help for the command
       --kubeconfig string       Path to the Kyma kubeconfig file
       --show-extensions-error   Prints a possible error when fetching extensions fails
-      --skip-extensions         Skip fetching extensions from the cluster
+      --skip-extensions         Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_completion_fish.md
+++ b/docs/user/gen-docs/kyma_completion_fish.md
@@ -28,7 +28,7 @@ kyma completion fish [flags]
   -h, --help                    Help for the command
       --kubeconfig string       Path to the Kyma kubeconfig file
       --show-extensions-error   Prints a possible error when fetching extensions fails
-      --skip-extensions         Skip fetching extensions from the cluster
+      --skip-extensions         Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_completion_powershell.md
+++ b/docs/user/gen-docs/kyma_completion_powershell.md
@@ -25,7 +25,7 @@ kyma completion powershell [flags]
   -h, --help                    Help for the command
       --kubeconfig string       Path to the Kyma kubeconfig file
       --show-extensions-error   Prints a possible error when fetching extensions fails
-      --skip-extensions         Skip fetching extensions from the cluster
+      --skip-extensions         Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_completion_zsh.md
+++ b/docs/user/gen-docs/kyma_completion_zsh.md
@@ -39,7 +39,7 @@ kyma completion zsh [flags]
   -h, --help                    Help for the command
       --kubeconfig string       Path to the Kyma kubeconfig file
       --show-extensions-error   Prints a possible error when fetching extensions fails
-      --skip-extensions         Skip fetching extensions from the cluster
+      --skip-extensions         Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_help.md
+++ b/docs/user/gen-docs/kyma_help.md
@@ -17,7 +17,7 @@ kyma help [command]
   -h, --help                    Help for the command
       --kubeconfig string       Path to the Kyma kubeconfig file
       --show-extensions-error   Prints a possible error when fetching extensions fails
-      --skip-extensions         Skip fetching extensions from the cluster
+      --skip-extensions         Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_module.md
+++ b/docs/user/gen-docs/kyma_module.md
@@ -27,7 +27,7 @@ kyma module <command> [flags]
   -h, --help                    Help for the command
       --kubeconfig string       Path to the Kyma kubeconfig file
       --show-extensions-error   Prints a possible error when fetching extensions fails
-      --skip-extensions         Skip fetching extensions from the cluster
+      --skip-extensions         Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_module_add.md
+++ b/docs/user/gen-docs/kyma_module_add.md
@@ -13,13 +13,16 @@ kyma module add <module> [flags]
 ## Flags
 
 ```text
+      --auto-approve            Automatically approve community module installation
   -c, --channel string          Name of the Kyma channel to use for the module
+      --community               Install a community module (no official support, no binding SLA)
       --cr-path string          Path to the custom resource file
       --default-cr              Deploys the module with the default CR
+      --version string          Specify version of the community module to install
   -h, --help                    Help for the command
       --kubeconfig string       Path to the Kyma kubeconfig file
       --show-extensions-error   Prints a possible error when fetching extensions fails
-      --skip-extensions         Skip fetching extensions from the cluster
+      --skip-extensions         Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_module_catalog.md
+++ b/docs/user/gen-docs/kyma_module_catalog.md
@@ -17,7 +17,7 @@ kyma module catalog [flags]
   -h, --help                    Help for the command
       --kubeconfig string       Path to the Kyma kubeconfig file
       --show-extensions-error   Prints a possible error when fetching extensions fails
-      --skip-extensions         Skip fetching extensions from the cluster
+      --skip-extensions         Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_module_delete.md
+++ b/docs/user/gen-docs/kyma_module_delete.md
@@ -13,10 +13,12 @@ kyma module delete <module> [flags]
 ## Flags
 
 ```text
+      --auto-approve            Automatically approves module removal
+      --community               Delete the community module (if set, the operation targets a community module instead of a core module)
   -h, --help                    Help for the command
       --kubeconfig string       Path to the Kyma kubeconfig file
       --show-extensions-error   Prints a possible error when fetching extensions fails
-      --skip-extensions         Skip fetching extensions from the cluster
+      --skip-extensions         Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_module_list.md
+++ b/docs/user/gen-docs/kyma_module_list.md
@@ -14,10 +14,11 @@ kyma module list [flags]
 
 ```text
   -o, --output string           Output format (Possible values: table, json, yaml)
+      --show-errors             Indicates whether to show errors outputted by misconfigured modules
   -h, --help                    Help for the command
       --kubeconfig string       Path to the Kyma kubeconfig file
       --show-extensions-error   Prints a possible error when fetching extensions fails
-      --skip-extensions         Skip fetching extensions from the cluster
+      --skip-extensions         Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_module_manage.md
+++ b/docs/user/gen-docs/kyma_module_manage.md
@@ -17,7 +17,7 @@ kyma module manage <module> [flags]
   -h, --help                    Help for the command
       --kubeconfig string       Path to the Kyma kubeconfig file
       --show-extensions-error   Prints a possible error when fetching extensions fails
-      --skip-extensions         Skip fetching extensions from the cluster
+      --skip-extensions         Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_module_unmanage.md
+++ b/docs/user/gen-docs/kyma_module_unmanage.md
@@ -16,7 +16,7 @@ kyma module unmanage <module> [flags]
   -h, --help                    Help for the command
       --kubeconfig string       Path to the Kyma kubeconfig file
       --show-extensions-error   Prints a possible error when fetching extensions fails
-      --skip-extensions         Skip fetching extensions from the cluster
+      --skip-extensions         Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/docs/user/gen-docs/kyma_version.md
+++ b/docs/user/gen-docs/kyma_version.md
@@ -16,7 +16,7 @@ kyma version
   -h, --help                    Help for the command
       --kubeconfig string       Path to the Kyma kubeconfig file
       --show-extensions-error   Prints a possible error when fetching extensions fails
-      --skip-extensions         Skip fetching extensions from the cluster
+      --skip-extensions         Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/tests/btp/integration-test-btp.sh
+++ b/tests/btp/integration-test-btp.sh
@@ -6,7 +6,7 @@ echo "Running kyma integration tests uing connected managed kyma runtime"
 echo -e "\n--------------------------------------------------------------------------------------\n"
 echo -e "Step1: Generating temporary access for new service account\n"
 
-../../bin/kyma alpha kubeconfig generate --clusterrole cluster-admin --serviceaccount test-sa --output /tmp/kubeconfig.yaml --time 2h
+../../bin/kyma alpha kubeconfig generate --clusterrole cluster-admin --serviceaccount test-sa --output /tmp/kubeconfig.yaml --time 2h --cluster-wide --namespace default
 
 export KUBECONFIG="/tmp/kubeconfig.yaml"
 if [[ $(kubectl config view --minify --raw | yq '.users[0].name') != 'test-sa' ]]; then

--- a/tests/k3d/integration-test-k3d.sh
+++ b/tests/k3d/integration-test-k3d.sh
@@ -6,7 +6,7 @@ echo "Running basic test scenario for kyma CLI on k3d runtime"
 # Generate kubeconfig for service account
 
 echo "Step1: Generating temporary access for new service account"
-../../bin/kyma alpha kubeconfig generate --clusterrole cluster-admin --serviceaccount test-sa --output /tmp/kubeconfig.yaml --time 2h
+../../bin/kyma alpha kubeconfig generate --clusterrole cluster-admin --serviceaccount test-sa --output /tmp/kubeconfig.yaml --time 2h --cluster-wide --namespace default
 export KUBECONFIG="/tmp/kubeconfig.yaml"
 if [[ $(kubectl config view --minify --raw | yq '.users[0].name') != 'test-sa' ]]; then
     exit 1


### PR DESCRIPTION


**Description**

Changes proposed in this pull request:

- kubeconfig generate API refinements

**Related issue(s)**
#2602 