### PR TITLE
Make cluster-/role binding optional when generating kubeconfig

### DIFF
--- a/docs/user/gen-docs/kyma_alpha_kubeconfig_generate.md
+++ b/docs/user/gen-docs/kyma_alpha_kubeconfig_generate.md
@@ -13,11 +13,17 @@ kyma alpha kubeconfig generate [flags]
 ## Examples
 
 ```bash
-# generate a permanent access (kubeconfig) for a new or existing ServiceAccount and a namespaced binding to a given ClusterRole
-  kyma alpha kubeconfig generate --serviceaccount <sa_name> --clusterrole <cr_name> --namespace <ns_name> --permanent
+# generate a permanent access (kubeconfig) for a new or existing ServiceAccount 
+  kyma alpha kubeconfig generate --serviceaccount <sa_name> --namespace <ns_name> --permanent
 
-# generate time-constrained access (kubeconfig) for a new or existing ServiceAccount and a cluster-wide binding to a given ClusterRole
-  kyma alpha kubeconfig generate --serviceaccount <sa_name> --clusterrole <cr_name> --namespace <ns_name> --cluster-wide --time 2h
+# generate a permanent access (kubeconfig) for a new or existing ServiceAccount in a given namespace with a namespaced binding to a given ClusterRole
+  kyma alpha kubeconfig generate --serviceaccount <sa_name> --namespace <ns_name> --clusterrole <cr_name> --permanent
+
+# generate a permanent access (kubeconfig) for a new or existing ServiceAccount in a given namespace with a namespaced binding to a given Role
+  kyma alpha kubeconfig generate --serviceaccount <sa_name> --namespace <ns_name> --role <r_name> --permanent
+
+# generate time-constrained access (kubeconfig) for a new or existing ServiceAccount in a given namespace with a cluster-wide binding to a given ClusterRole
+  kyma alpha kubeconfig generate --serviceaccount <sa_name> --namespace <ns_name> --clusterrole <cr_name> --cluster-wide --time 2h
   
 # generate a kubeconfig with an OIDC token
   kyma alpha kubeconfig generate --token <token>
@@ -40,14 +46,15 @@ kyma alpha kubeconfig generate [flags]
 ```text
       --audience string               Audience of the token
       --cluster-wide                  Determines if the binding to the ClusterRole is cluster-wide
-      --clusterrole string            Name of the Cluster Role to bind the Service Account to
+      --clusterrole string            Name of the Cluster Role to bind the Service Account to (optional)
       --credentials-path string       Path to the CIS credentials file
       --id-token-request-url string   URL to request the ID token, defaults to ACTIONS_ID_TOKEN_REQUEST_URL env variable
-      --namespace string              Namespace in which the service account exists or will be created
+      --namespace string              Namespace in which the subject Service Account is to be found or will be created (default: "default") (default "default")
       --oidc-name string              Name of the OIDC Custom Resource from which the kubeconfig will be generated
       --output string                 Path to the kubeconfig file output. If not provided, the kubeconfig will be printed
       --permanent                     Determines if the token is valid indefinitely
-      --serviceaccount string         Name of the Service Account to be used or created
+      --role string                   Name of the Role in the given Namespace to bind the Service Account to (optional)
+      --serviceaccount string         Name of the Service Account (in the given Namespace) to be used as a subject of the generated kubeconfig. If the Service Account does not exist, it will be created
       --time string                   Determines how long the token should be valid, by default 1h (use h for hours and d for days) (default "1h")
       --token string                  Token used in the kubeconfig
   -h, --help                          Help for the command

--- a/docs/user/gen-docs/kyma_alpha_kubeconfig_generate.md
+++ b/docs/user/gen-docs/kyma_alpha_kubeconfig_generate.md
@@ -49,7 +49,7 @@ kyma alpha kubeconfig generate [flags]
       --clusterrole string            Name of the Cluster Role to bind the Service Account to (optional)
       --credentials-path string       Path to the CIS credentials file
       --id-token-request-url string   URL to request the ID token, defaults to ACTIONS_ID_TOKEN_REQUEST_URL env variable
-      --namespace string              Namespace in which the subject Service Account is to be found or will be created (default: "default") (default "default")
+      --namespace string              Namespace in which the subject Service Account is to be found or will be created (default "default")
       --oidc-name string              Name of the OIDC Custom Resource from which the kubeconfig will be generated
       --output string                 Path to the kubeconfig file output. If not provided, the kubeconfig will be printed
       --permanent                     Determines if the token is valid indefinitely

--- a/internal/cmd/alpha/kubeconfig/generate.go
+++ b/internal/cmd/alpha/kubeconfig/generate.go
@@ -25,6 +25,7 @@ type generateConfig struct {
 	// ServiceAccount-based flow flags
 	serviceAccount string
 	clusterRole    string
+	role           string
 	namespace      string
 	time           string
 	permanent      bool
@@ -48,11 +49,17 @@ func newGenerateCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use: "generate",
-		Example: `# generate a permanent access (kubeconfig) for a new or existing ServiceAccount and a namespaced binding to a given ClusterRole
-  kyma alpha kubeconfig generate --serviceaccount <sa_name> --clusterrole <cr_name> --namespace <ns_name> --permanent
+		Example: `# generate a permanent access (kubeconfig) for a new or existing ServiceAccount 
+  kyma alpha kubeconfig generate --serviceaccount <sa_name> --namespace <ns_name> --permanent
 
-# generate time-constrained access (kubeconfig) for a new or existing ServiceAccount and a cluster-wide binding to a given ClusterRole
-  kyma alpha kubeconfig generate --serviceaccount <sa_name> --clusterrole <cr_name> --namespace <ns_name> --cluster-wide --time 2h
+# generate a permanent access (kubeconfig) for a new or existing ServiceAccount in a given namespace with a namespaced binding to a given ClusterRole
+  kyma alpha kubeconfig generate --serviceaccount <sa_name> --namespace <ns_name> --clusterrole <cr_name> --permanent
+
+# generate a permanent access (kubeconfig) for a new or existing ServiceAccount in a given namespace with a namespaced binding to a given Role
+  kyma alpha kubeconfig generate --serviceaccount <sa_name> --namespace <ns_name> --role <r_name> --permanent
+
+# generate time-constrained access (kubeconfig) for a new or existing ServiceAccount in a given namespace with a cluster-wide binding to a given ClusterRole
+  kyma alpha kubeconfig generate --serviceaccount <sa_name> --namespace <ns_name> --clusterrole <cr_name> --cluster-wide --time 2h
   
 # generate a kubeconfig with an OIDC token
   kyma alpha kubeconfig generate --token <token>
@@ -75,9 +82,9 @@ func newGenerateCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 			cfg.complete(cmd)
 			clierror.Check(flags.Validate(cmd.Flags(),
 				flags.MarkOneRequired("serviceaccount", "token", "id-token-request-url", "oidc-name"),
-				flags.MarkRequiredTogether("serviceaccount", "clusterrole", "namespace"),
 				flags.MarkExclusive("token", "id-token-request-url", "audience"),
 				flags.MarkExclusive("permanent", "time"),
+				flags.MarkExclusive("cluster-wide", "role"),
 			))
 			clierror.Check(cfg.validate())
 		},
@@ -91,9 +98,10 @@ func newGenerateCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	cmd.Flags().StringVar(&cfg.output, "output", "", "Path to the kubeconfig file output. If not provided, the kubeconfig will be printed")
 
 	// ServiceAccount-based flow
-	cmd.Flags().StringVar(&cfg.serviceAccount, "serviceaccount", "", "Name of the Service Account to be used or created")
-	cmd.Flags().StringVar(&cfg.clusterRole, "clusterrole", "", "Name of the Cluster Role to bind the Service Account to")
-	cmd.Flags().StringVar(&cfg.namespace, "namespace", "", "Namespace in which the service account exists or will be created")
+	cmd.Flags().StringVar(&cfg.serviceAccount, "serviceaccount", "", "Name of the Service Account (in the given Namespace) to be used as a subject of the generated kubeconfig. If the Service Account does not exist, it will be created")
+	cmd.Flags().StringVar(&cfg.clusterRole, "clusterrole", "", "Name of the Cluster Role to bind the Service Account to (optional)")
+	cmd.Flags().StringVar(&cfg.role, "role", "", "Name of the Role in the given Namespace to bind the Service Account to (optional)")
+	cmd.Flags().StringVar(&cfg.namespace, "namespace", "default", "Namespace in which the subject Service Account is to be found or will be created (default: \"default\")")
 	cmd.Flags().StringVar(&cfg.time, "time", "1h", "Determines how long the token should be valid, by default 1h (use h for hours and d for days)")
 
 	cmd.Flags().BoolVar(&cfg.permanent, "permanent", false, "Determines if the token is valid indefinitely")
@@ -205,8 +213,8 @@ func generateWithServiceAccount(cfg *generateConfig) (*api.Config, clierror.Erro
 		return nil, clierr
 	}
 
-	// Create ServiceAccount, Binding and secret with token
-	clierr = registerServiceAccount(cfg, kubeClient)
+	// Ensure ServiceAccount, Bindings and secret with token
+	clierr = setupServiceAccountWithBindings(cfg, kubeClient)
 	if clierr != nil {
 		return nil, clierror.WrapE(clierr, clierror.New("failed to create k8s resources"))
 	}
@@ -224,21 +232,33 @@ func generateWithOpenIDConnectorCustomResource(cfg *generateConfig) (*api.Config
 	return kubeconfig.PrepareFromOpenIDConnectorResource(cfg.Ctx, kubeClient, cfg.oidcName)
 }
 
-func registerServiceAccount(cfg *generateConfig, kubeClient kube.Client) clierror.Error {
-	// Create Service Account
-	err := resources.CreateServiceAccount(cfg.Ctx, kubeClient, cfg.serviceAccount, cfg.namespace)
+func setupServiceAccountWithBindings(cfg *generateConfig, kubeClient kube.Client) clierror.Error {
+	// Get or Create Service Account
+	err := resources.EnsureServiceAccount(cfg.Ctx, kubeClient, cfg.serviceAccount, cfg.namespace)
 	if err != nil {
 		return clierror.Wrap(err, clierror.New("failed to create Service Account"))
 	}
-	if cfg.clusterWide {
-		// Create Role Binding for the Service Account
+
+	// Create Role or ClusterRole Binding for the Service Account
+	if cfg.clusterWide && cfg.clusterRole != "" {
+		// Create ClusterRoleBinding for the Service Account
 		err = resources.CreateClusterRoleBinding(cfg.Ctx, kubeClient, cfg.serviceAccount, cfg.namespace, cfg.clusterRole)
 		if err != nil {
 			return clierror.Wrap(err, clierror.New("failed to create Cluster Role Binding"))
 		}
-	} else {
-		// Create Role Binding for the Service Account
-		err = resources.CreateRoleBinding(cfg.Ctx, kubeClient, cfg.serviceAccount, cfg.namespace, cfg.clusterRole)
+	}
+
+	if !cfg.clusterWide && cfg.role != "" {
+		// Create Role Binding to Role for the Service Account
+		err = resources.CreateRoleBindingToRole(cfg.Ctx, kubeClient, cfg.serviceAccount, cfg.namespace, cfg.role)
+		if err != nil {
+			return clierror.Wrap(err, clierror.New("failed to create Role Binding"))
+		}
+	}
+
+	if !cfg.clusterWide && cfg.clusterRole != "" {
+		// Create Role Binding to Cluster Role for the Service Account
+		err = resources.CreateRoleBindingToClusterRole(cfg.Ctx, kubeClient, cfg.serviceAccount, cfg.namespace, cfg.clusterRole)
 		if err != nil {
 			return clierror.Wrap(err, clierror.New("failed to create Role Binding"))
 		}

--- a/internal/cmd/alpha/kubeconfig/generate.go
+++ b/internal/cmd/alpha/kubeconfig/generate.go
@@ -101,7 +101,7 @@ func newGenerateCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	cmd.Flags().StringVar(&cfg.serviceAccount, "serviceaccount", "", "Name of the Service Account (in the given Namespace) to be used as a subject of the generated kubeconfig. If the Service Account does not exist, it will be created")
 	cmd.Flags().StringVar(&cfg.clusterRole, "clusterrole", "", "Name of the Cluster Role to bind the Service Account to (optional)")
 	cmd.Flags().StringVar(&cfg.role, "role", "", "Name of the Role in the given Namespace to bind the Service Account to (optional)")
-	cmd.Flags().StringVar(&cfg.namespace, "namespace", "default", "Namespace in which the subject Service Account is to be found or will be created (default: \"default\")")
+	cmd.Flags().StringVar(&cfg.namespace, "namespace", "default", "Namespace in which the subject Service Account is to be found or will be created")
 	cmd.Flags().StringVar(&cfg.time, "time", "1h", "Determines how long the token should be valid, by default 1h (use h for hours and d for days)")
 
 	cmd.Flags().BoolVar(&cfg.permanent, "permanent", false, "Determines if the token is valid indefinitely")


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- kubeconfig should work also when no roles are given
- allow binding regular Roles next to ClusterRoles


**Related issue(s)**
#2602 