### PR TITLE
Surface App URL from Virtualservice

### DIFF
--- a/internal/cmd/app/push.go
+++ b/internal/cmd/app/push.go
@@ -177,27 +177,28 @@ func runAppPush(cfg *appPushConfig) clierror.Error {
 
 	if cfg.expose {
 		fmt.Printf("\nCreating API Rule %s/%s\n", cfg.namespace, cfg.name)
-		domain := "<CLUSTER_DOMAIN>"
-		// try to get domain from istio gateway
-		// Check if the user can get gateways in kyma-system namespace
-		authRes, authErr := resources.CreateSelfSubjectAccessReview(cfg.Ctx, client, "get", "gateways", "kyma-system", "networking.istio.io")
-
-		if authErr != nil {
-			return clierror.Wrap(authErr, clierror.New("failed to check permissions for getting gateways in kyma-system"))
-		}
-		if authRes.Status.Allowed {
-			domain, clierr = client.Istio().GetClusterAddressFromGateway(cfg.Ctx)
-			if clierr != nil {
-				return clierror.WrapE(clierr, clierror.New("failed to domain address of the Kyma environment from gateway", "Make sure Istio module is installed"))
-			}
-		}
+		url := fmt.Sprintf("%s.<CLUSTER_DOMAIN>", cfg.name)
 
 		err = resources.CreateAPIRule(cfg.Ctx, client.RootlessDynamic(), cfg.name, cfg.namespace, cfg.name, uint32(*cfg.containerPort.Value))
 		if err != nil {
 			return clierror.Wrap(err, clierror.New("failed to create API Rule resource", "Make sure API Gateway module is installed", "Make sure APIRule CRD is available in v2 version"))
 		}
 
-		fmt.Printf("\nThe %s app is available under the https://%s/ address\n", cfg.name, fmt.Sprintf("%s.%s", cfg.name, domain))
+		// try to get domain from resulting virtual service
+		// Check if the user can watch virtualservices
+		authRes, authErr := resources.CreateSelfSubjectAccessReview(cfg.Ctx, client, "watch", "virtualservices", cfg.namespace, "networking.istio.io")
+
+		if authErr != nil {
+			return clierror.Wrap(authErr, clierror.New("failed to check permissions to get virtualservices"))
+		}
+		if authRes.Status.Allowed {
+			url, clierr = client.Istio().GetHostFromVirtualServiceByApiruleName(cfg.Ctx, cfg.name, cfg.namespace)
+			if clierr != nil {
+				return clierror.WrapE(clierr, clierror.New("failed to get host address of ApiRule's Virtual Service"))
+			}
+		}
+
+		fmt.Printf("\nThe %s app is available under the https://%s/ address\n", cfg.name, url)
 	}
 
 	return nil

--- a/internal/kube/resources/service.go
+++ b/internal/kube/resources/service.go
@@ -73,7 +73,7 @@ func buildAPIRule(name, namespace, host string, port uint32) *v2alpha1.APIRule {
 			Hosts: []*v2alpha1.Host{
 				ptr.To(v2alpha1.Host(host)),
 			},
-			Gateway: ptr.To(fmt.Sprintf("%s/%s", istio.GatewayNamespace, istio.GatewayName)),
+			Gateway: ptr.To(fmt.Sprintf("%s/%s", istio.DefaultGatewayNamespace, istio.DefaultGatewayName)),
 			Rules: []v2alpha1.Rule{
 				{
 					Path:    "/*",

--- a/internal/kube/resources/service_test.go
+++ b/internal/kube/resources/service_test.go
@@ -87,7 +87,7 @@ func fixAPIRule(apiRuleName, namespace, host string, port uint32) unstructured.U
 				"hosts": []interface{}{
 					host,
 				},
-				"gateway": fmt.Sprintf("%s/%s", istio.GatewayNamespace, istio.GatewayName),
+				"gateway": fmt.Sprintf("%s/%s", istio.DefaultGatewayNamespace, istio.DefaultGatewayName),
 				"rules": []interface{}{
 					map[string]interface{}{
 						"path":    "/*",


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Read the resulting app's URL from the namespace scope (not from kyma-system resources, which reduces necessary priviliges in order to get the URL of the pushed app) 
- This would need to be changed once  API rule surface that url ( https://github.com/kyma-project/api-gateway/issues/2264)

**Related issue(s)**
#2606 
