### PR TITLE
Add shorthand -n for --namespace flag

### DIFF
--- a/internal/cmd/alpha/kubeconfig/generate.go
+++ b/internal/cmd/alpha/kubeconfig/generate.go
@@ -101,7 +101,7 @@ func newGenerateCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	cmd.Flags().StringVar(&cfg.serviceAccount, "serviceaccount", "", "Name of the Service Account (in the given Namespace) to be used as a subject of the generated kubeconfig. If the Service Account does not exist, it will be created")
 	cmd.Flags().StringVar(&cfg.clusterRole, "clusterrole", "", "Name of the Cluster Role to bind the Service Account to (optional)")
 	cmd.Flags().StringVar(&cfg.role, "role", "", "Name of the Role in the given Namespace to bind the Service Account to (optional)")
-	cmd.Flags().StringVar(&cfg.namespace, "namespace", "default", "Namespace in which the subject Service Account is to be found or will be created")
+	cmd.Flags().StringVarP(&cfg.namespace, "namespace", "n", "default", "Namespace in which the subject Service Account is to be found or will be created")
 	cmd.Flags().StringVar(&cfg.time, "time", "1h", "Determines how long the token should be valid, by default 1h (use h for hours and d for days)")
 
 	cmd.Flags().BoolVar(&cfg.permanent, "permanent", false, "Determines if the token is valid indefinitely")

--- a/internal/cmd/alpha/referenceinstance/referenceinstance.go
+++ b/internal/cmd/alpha/referenceinstance/referenceinstance.go
@@ -44,7 +44,7 @@ func NewReferenceInstanceCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&config.namespace, "namespace", "default", "Namespace of the reference instance")
+	cmd.Flags().StringVarP(&config.namespace, "namespace", "n", "default", "Namespace of the reference instance")
 	cmd.Flags().StringVar(&config.offeringName, "offering-name", "", "Offering name")
 	cmd.Flags().StringVar(&config.referenceName, "reference-name", "", "Name of the reference")
 	cmd.Flags().StringVar(&config.instanceID, "instance-id", "", "ID of the instance")

--- a/internal/cmd/app/push.go
+++ b/internal/cmd/app/push.go
@@ -78,7 +78,7 @@ func NewAppPushCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	cmd.Flags().StringVar(&config.packAppPath, "code-path", "", "Path to the application source code directory")
 
 	// k8s flags
-	cmd.Flags().StringVar(&config.namespace, "namespace", "default", "Namespace where the app is deployed")
+	cmd.Flags().StringVarP(&config.namespace, "namespace", "n", "default", "Namespace where the app is deployed")
 	cmd.Flags().Var(&config.containerPort, "container-port", "Port on which the application is exposed")
 	cmd.Flags().Var(&config.istioInject, "istio-inject", "Enables Istio for the app")
 	cmd.Flags().BoolVar(&config.expose, "expose", false, "Creates an APIRule for the app")


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Following `-n` convention  from kubectl
