### PR TITLE
Revamp app push --mount flags

### DIFF
--- a/docs/user/gen-docs/_sidebar.md
+++ b/docs/user/gen-docs/_sidebar.md
@@ -2,6 +2,7 @@
 * [Back to Kyma CLI](/cli/user/README.md)
 * [kyma](/cli/user/gen-docs/kyma.md)
 * [kyma alpha](/cli/user/gen-docs/kyma_alpha.md)
+* [kyma alpha authorize](/cli/user/gen-docs/kyma_alpha_authorize.md)
 * [kyma alpha diagnose](/cli/user/gen-docs/kyma_alpha_diagnose.md)
 * [kyma alpha hana](/cli/user/gen-docs/kyma_alpha_hana.md)
 * [kyma alpha hana map](/cli/user/gen-docs/kyma_alpha_hana_map.md)

--- a/docs/user/gen-docs/kyma_alpha.md
+++ b/docs/user/gen-docs/kyma_alpha.md
@@ -13,6 +13,7 @@ kyma alpha <command> [flags]
 ## Available Commands
 
 ```text
+  authorize          - Configure trust between a Kyma cluster and a GitHub repository
   diagnose           - Diagnose cluster health and configuration
   hana               - Manages an SAP HANA instance in the Kyma cluster
   kubeconfig         - Manages access to the Kyma cluster
@@ -32,6 +33,7 @@ kyma alpha <command> [flags]
 ## See also
 
 * [kyma](kyma.md)                                                   - A simple set of commands to manage a Kyma cluster
+* [kyma alpha authorize](kyma_alpha_authorize.md)                   - Configure trust between a Kyma cluster and a GitHub repository
 * [kyma alpha diagnose](kyma_alpha_diagnose.md)                     - Diagnose cluster health and configuration
 * [kyma alpha hana](kyma_alpha_hana.md)                             - Manages an SAP HANA instance in the Kyma cluster
 * [kyma alpha kubeconfig](kyma_alpha_kubeconfig.md)                 - Manages access to the Kyma cluster

--- a/docs/user/gen-docs/kyma_alpha_authorize.md
+++ b/docs/user/gen-docs/kyma_alpha_authorize.md
@@ -1,0 +1,35 @@
+# kyma alpha authorize
+
+Configure trust between a Kyma cluster and a GitHub repository.
+
+## Synopsis
+
+Configure trust between a Kyma cluster and a GitHub repository by creating an OpenIDConnect resource and RoleBinding or ClusterRoleBinding
+
+```bash
+kyma alpha authorize repository [flags]
+```
+
+## Flags
+
+```text
+      --clientId string         OIDC client ID (audience) expected in the token (required)
+      --cluster-wide            If true, create a ClusterRoleBinding; otherwise, a RoleBinding
+      --clusterrole string      ClusterRole name to bind (usable for RoleBinding or ClusterRoleBinding)
+      --dry-run                 Print resources without applying
+      --issuerURL string        OIDC issuer (default "https://token.actions.githubusercontent.com")
+      --name string             Name for the OpenIDConnect resource (optional; default derives from clientId)
+      --namespace string        Namespace for RoleBinding (required if not cluster-wide and binding a Role or namespaced ClusterRole)
+  -o, --output string           Output format (yaml or json)
+      --prefix string           Username prefix for the repository claim (e.g., gh-oidc:)
+      --repository string       GitHub repo in owner/name format (e.g., kyma-project/cli) (required)
+      --role string             Role name to bind (namespaced)
+  -h, --help                    Help for the command
+      --kubeconfig string       Path to the Kyma kubeconfig file
+      --show-extensions-error   Prints a possible error when fetching extensions fails
+      --skip-extensions         Skip fetching extensions from the target Kyma environment
+```
+
+## See also
+
+* [kyma alpha](kyma_alpha.md) - Groups command prototypes for which the API may still change

--- a/docs/user/gen-docs/kyma_app_push.md
+++ b/docs/user/gen-docs/kyma_app_push.md
@@ -45,33 +45,49 @@ kyma app push [flags]
 	--env-from-configmap MY_ENV2=my-configmap:key2 \
 	--env-from-secret my-secret:SECRET_ \
 	--env-from-secret MY_ENV3=my-secret:key3
+
+## Push an application and mount a Secret, ConfigMap or Service Binding Secret:
+# Depending on your needs, you can mount specific keys or the whole resource.
+# You can use these flags multiple times to mount more than one resource.
+# Flags --mount-secret and --mount-config support below formats:
+# - Normal format: 'name=NAME,path=MOUNT_PATH,key=KEY,ro=READ_ONLY' (key and ro are optional)
+# - Shorthand format: 'NAME:KEY=MOUNT_PATH:ro' (ro is optional)
+# - Legacy format: 'NAME' (mounts the whole secret at /bindings/secret-<NAME> or configmap at /bindings/configmap-<NAME>) 
+  kyma app push --name my-app --code-path . \
+	--mount-secret name=my-secret,path=/app/secret,key=secret-key,ro=true \
+    --mount-secret my-secret:secret-key=/app/secret:ro \
+	--mount-secret my-secret 
+	--mount-config name=my-configmap,path=/app/config,key=config-key \
+	--mount-config my-configmap:config-key=/app/config:ro \
+	--mount-service-binding-secret my-service-binding-secret
 ```
 
 ## Flags
 
 ```text
-      --code-path string                   Path to the application source code directory
-      --container-port int                 Port on which the application is exposed
-      --dockerfile string                  Path to the Dockerfile
-      --dockerfile-build-arg stringArray   Variables used while building an application from Dockerfile as args
-      --dockerfile-context string          Context path for building Dockerfile (defaults to the current working directory)
-      --env stringArray                    Environment variables for the app in format NAME=VALUE
-      --env-from-configmap stringArray     Environment variables for the app loaded from a ConfigMap in format ENV_NAME=RESOURCE:RESOURCE_KEY for a single key or RESOURCE[:ENVS_PREFIX] to fetch all keys
-      --env-from-file stringArray          Environment variables for the app loaded from a file in format ENV_NAME=FILE_PATH:FILE_KEY for a single key or FILE_PATH[:ENVS_PREFIX] to fetch all keys
-      --env-from-secret stringArray        Environment variables for the app loaded from a Secret in format ENV_NAME=RESOURCE:RESOURCE_KEY for a single key or RESOURCE[:ENVS_PREFIX] to fetch all keys
-      --expose                             Creates an APIRule for the app
-      --image string                       Name of the image to deploy
-      --image-pull-secret string           Name of the Kubernetes Secret with credentials to pull the image
-      --istio-inject                       Enables Istio for the app
-      --mount-config stringArray           Mounts ConfigMap content to the /bindings/configmap-<CONFIGMAP_NAME> path (default "[]")
-      --mount-secret stringArray           Mounts Secret content to the /bindings/secret-<SECRET_NAME> path (default "[]")
-      --name string                        Name of the app
-  -n, --namespace string                   Namespace where the app is deployed (default "default")
-  -q, --quiet                              Suppresses non-essential output (prints only the URL of the pushed app, if exposed)
-  -h, --help                               Help for the command
-      --kubeconfig string                  Path to the Kyma kubeconfig file
-      --show-extensions-error              Prints a possible error when fetching extensions fails
-      --skip-extensions                    Skip fetching extensions from the target Kyma environment
+      --code-path string                                      Path to the application source code directory
+      --container-port int                                    Port on which the application is exposed
+      --dockerfile string                                     Path to the Dockerfile
+      --dockerfile-build-arg stringArray                      Variables used while building an application from Dockerfile as args
+      --dockerfile-context string                             Context path for building Dockerfile (defaults to the current working directory)
+      --env stringArray                                       Environment variables for the app in format NAME=VALUE
+      --env-from-configmap stringArray                        Environment variables for the app loaded from a ConfigMap in format ENV_NAME=RESOURCE:RESOURCE_KEY for a single key or RESOURCE[:ENVS_PREFIX] to fetch all keys
+      --env-from-file stringArray                             Environment variables for the app loaded from a file in format ENV_NAME=FILE_PATH:FILE_KEY for a single key or FILE_PATH[:ENVS_PREFIX] to fetch all keys
+      --env-from-secret stringArray                           Environment variables for the app loaded from a Secret in format ENV_NAME=RESOURCE:RESOURCE_KEY for a single key or RESOURCE[:ENVS_PREFIX] to fetch all keys
+      --expose                                                Creates an APIRule for the app
+      --image string                                          Name of the image to deploy
+      --image-pull-secret string                              Name of the Kubernetes Secret with credentials to pull the image
+      --istio-inject                                          Enables Istio for the app
+      --mount-config stringArray                              Mounts ConfigMap content. Format: 'name=configmap,path=/app/config,key=key,ro=false' or shorthand 'configmap:key=/app/config'. Path traversal (..) is prohibited.
+      --mount-secret stringArray                              Mounts Secret content. Format: 'name=secret,path=/app/config,key=key,ro=true' or shorthand 'secret:key=/app/config:ro'. Path traversal (..) is prohibited.
+      --mount-service-binding-secret service-binding-secret   Mounts Secret as service binding at /bindings/secret-<NAME> (readOnly)
+      --name string                                           Name of the app
+  -n, --namespace string                                      Namespace where the app is deployed (default "default")
+  -q, --quiet                                                 Suppresses non-essential output (prints only the URL of the pushed app, if exposed)
+  -h, --help                                                  Help for the command
+      --kubeconfig string                                     Path to the Kyma kubeconfig file
+      --show-extensions-error                                 Prints a possible error when fetching extensions fails
+      --skip-extensions                                       Skip fetching extensions from the target Kyma environment
 ```
 
 ## See also

--- a/internal/cmdcommon/types/mount.go
+++ b/internal/cmdcommon/types/mount.go
@@ -1,0 +1,230 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+// MountSpec represents a volume mount specification
+type MountSpec struct {
+	Name     string
+	Path     string
+	Key      string
+	ReadOnly bool
+}
+
+// MountArray holds an array of mount specifications
+type MountArray struct {
+	Mounts []MountSpec
+}
+
+// String returns the string representation
+func (m *MountArray) String() string {
+	if len(m.Mounts) == 0 {
+		return ""
+	}
+	var parts []string
+	for _, mount := range m.Mounts {
+		if mount.Key != "" {
+			if mount.ReadOnly {
+				parts = append(parts, fmt.Sprintf("name=%s,path=%s,key=%s,ro=true", mount.Name, mount.Path, mount.Key))
+			} else {
+				parts = append(parts, fmt.Sprintf("name=%s,path=%s,key=%s,ro=false", mount.Name, mount.Path, mount.Key))
+			}
+		} else {
+			if mount.ReadOnly {
+				parts = append(parts, fmt.Sprintf("name=%s,path=%s,ro=true", mount.Name, mount.Path))
+			} else {
+				parts = append(parts, fmt.Sprintf("name=%s,path=%s,ro=false", mount.Name, mount.Path))
+			}
+		}
+	}
+	return strings.Join(parts, ";")
+}
+
+// Type returns the type name
+func (m *MountArray) Type() string {
+	return "stringArray"
+}
+
+// isShorthandFormat determines if a value is in shorthand format
+func isShorthandFormat(value string) bool {
+	// If it contains comma, it's definitely normal format (multiple key=value pairs)
+	if strings.Contains(value, ",") {
+		return false
+	}
+	if !strings.Contains(value, "=") {
+		// No equals sign - backward compatibility (just a name)
+		return false
+	}
+
+	// Has equals but no comma - could be shorthand or simple normal format
+	// Check if it follows shorthand pattern: either "name=path" or "name:key=path"
+	eqParts := strings.SplitN(value, "=", 2)
+	if len(eqParts) == 2 {
+		leftSide := eqParts[0]
+		rightSide := eqParts[1]
+
+		// If left side contains a colon, it's likely shorthand (name:key=path)
+		// If right side looks like a path (starts with / or doesn't contain =), it's likely shorthand
+		if strings.Contains(leftSide, ":") ||
+			(strings.HasPrefix(rightSide, "/") || !strings.Contains(rightSide, "=")) {
+			return true
+		}
+	}
+	return false
+}
+
+// Set parses and sets a mount specification
+func (m *MountArray) Set(value string) error {
+	if value == "" {
+		return nil
+	}
+
+	// Check for invalid shorthand attempts (colon without equals)
+	if strings.Contains(value, ":") && !strings.Contains(value, "=") {
+		return fmt.Errorf("invalid mount format: shorthand format requires equals sign")
+	}
+
+	currentIsShorthand := isShorthandFormat(value)
+
+	var mount MountSpec
+	var err error
+
+	if currentIsShorthand {
+		mount, err = parseShorthandMount(value)
+	} else {
+		mount, err = parseNormalMount(value)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	// Validate path traversal
+	if err := validatePath(mount.Path); err != nil {
+		return err
+	}
+
+	m.Mounts = append(m.Mounts, mount)
+	return nil
+}
+
+// parseNormalMount parses normal format: name=resource,path=/path,key=key,ro=true
+func parseNormalMount(value string) (MountSpec, error) {
+	mount := MountSpec{}
+
+	// Handle backward compatibility - if it's just a name, return it
+	if !strings.Contains(value, "=") {
+		mount.Name = value
+		return mount, nil
+	}
+
+	fields := strings.Split(value, ",")
+	for _, field := range fields {
+		parts := strings.SplitN(field, "=", 2)
+		if len(parts) != 2 {
+			return mount, fmt.Errorf("invalid mount format: field '%s' should be in format key=value", field)
+		}
+
+		key, val := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+		switch key {
+		case "name":
+			mount.Name = val
+		case "path":
+			mount.Path = val
+		case "key":
+			mount.Key = val
+		case "ro":
+			mount.ReadOnly = val == "true"
+		default:
+			return mount, fmt.Errorf("unknown mount field: '%s', supported fields are 'name', 'path', 'key', 'ro'", key)
+		}
+	}
+
+	if mount.Name == "" {
+		return mount, fmt.Errorf("invalid mount format: name is required")
+	}
+
+	// Path is required for new format (when any key=value is specified)
+	if mount.Path == "" && (strings.Contains(value, "path=") || strings.Contains(value, "key=") || strings.Contains(value, "ro=")) {
+		return mount, fmt.Errorf("mount path is required")
+	}
+
+	return mount, nil
+}
+
+// parseShorthandMount parses shorthand format: name:key=path:ro or name=path:ro
+func parseShorthandMount(value string) (MountSpec, error) {
+	mount := MountSpec{}
+
+	// Split by first = to separate name[:key] from path[:ro]
+	eqParts := strings.SplitN(value, "=", 2)
+	if len(eqParts) != 2 {
+		return mount, fmt.Errorf("invalid mount format: shorthand format should be 'name:key=path:ro' or 'name=path:ro'")
+	}
+
+	nameKeyPart := eqParts[0]
+	pathRoPart := eqParts[1]
+
+	// Parse name[:key]
+	nameParts := strings.Split(nameKeyPart, ":")
+	mount.Name = nameParts[0]
+	if len(nameParts) > 1 {
+		mount.Key = nameParts[1]
+	}
+
+	// Parse path[:ro]
+	pathParts := strings.Split(pathRoPart, ":")
+	mount.Path = pathParts[0]
+	if len(pathParts) > 1 && pathParts[1] == "ro" {
+		mount.ReadOnly = true
+	}
+
+	if mount.Name == "" {
+		return mount, fmt.Errorf("invalid mount format: name is required")
+	}
+	if mount.Path == "" {
+		return mount, fmt.Errorf("mount path is required")
+	}
+
+	return mount, nil
+}
+
+// validatePath checks for path traversal attempts
+func validatePath(path string) error {
+	if path == "" {
+		return nil // Empty path is valid for backward compatibility
+	}
+
+	// Check for path traversal patterns before cleaning
+	if strings.Contains(path, "..") {
+		return fmt.Errorf("path traversal is not allowed")
+	}
+
+	return nil
+}
+
+// ServiceBindingSecretArray holds service binding secret specifications
+type ServiceBindingSecretArray struct {
+	Names []string
+}
+
+// String returns the string representation
+func (s *ServiceBindingSecretArray) String() string {
+	return strings.Join(s.Names, ",")
+}
+
+// Type returns the type name
+func (s *ServiceBindingSecretArray) Type() string {
+	return "service-binding-secret"
+}
+
+// Set adds a service binding secret name
+func (s *ServiceBindingSecretArray) Set(value string) error {
+	if value == "" {
+		return nil
+	}
+	s.Names = append(s.Names, value)
+	return nil
+}

--- a/internal/cmdcommon/types/mount_test.go
+++ b/internal/cmdcommon/types/mount_test.go
@@ -1,0 +1,411 @@
+package types
+
+import (
+	"testing"
+)
+
+func TestMountArray_Set_NormalFormat(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    MountSpec
+		expectError bool
+	}{
+		{
+			name:  "backward compatibility - just name",
+			input: "my-secret",
+			expected: MountSpec{
+				Name:     "my-secret",
+				Path:     "",
+				Key:      "",
+				ReadOnly: false,
+			},
+			expectError: false,
+		},
+		{
+			name:  "full normal format",
+			input: "name=my-secret,path=/app/config,key=config.yaml,ro=true",
+			expected: MountSpec{
+				Name:     "my-secret",
+				Path:     "/app/config",
+				Key:      "config.yaml",
+				ReadOnly: true,
+			},
+			expectError: false,
+		},
+		{
+			name:  "normal format without key",
+			input: "name=my-configmap,path=/app/data,ro=false",
+			expected: MountSpec{
+				Name:     "my-configmap",
+				Path:     "/app/data",
+				Key:      "",
+				ReadOnly: false,
+			},
+			expectError: false,
+		},
+		{
+			name:  "normal format without readonly",
+			input: "name=tls-secret,path=/etc/certs,key=tls.crt",
+			expected: MountSpec{
+				Name:     "tls-secret",
+				Path:     "/etc/certs",
+				Key:      "tls.crt",
+				ReadOnly: false,
+			},
+			expectError: false,
+		},
+		{
+			name:        "missing name",
+			input:       "path=/app/config,key=config.yaml",
+			expectError: true,
+		},
+		{
+			name:        "missing path when other fields specified",
+			input:       "name=my-secret,key=config.yaml",
+			expectError: true,
+		},
+		{
+			name:        "invalid field",
+			input:       "name=my-secret,path=/app,invalid=value",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &MountArray{}
+			err := m.Set(tt.input)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if len(m.Mounts) != 1 {
+				t.Errorf("expected 1 mount, got %d", len(m.Mounts))
+				return
+			}
+
+			got := m.Mounts[0]
+			if got.Name != tt.expected.Name {
+				t.Errorf("expected name %q, got %q", tt.expected.Name, got.Name)
+			}
+			if got.Path != tt.expected.Path {
+				t.Errorf("expected path %q, got %q", tt.expected.Path, got.Path)
+			}
+			if got.Key != tt.expected.Key {
+				t.Errorf("expected key %q, got %q", tt.expected.Key, got.Key)
+			}
+			if got.ReadOnly != tt.expected.ReadOnly {
+				t.Errorf("expected readonly %v, got %v", tt.expected.ReadOnly, got.ReadOnly)
+			}
+		})
+	}
+}
+
+func TestMountArray_Set_ShorthandFormat(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    MountSpec
+		expectError bool
+	}{
+		{
+			name:  "shorthand with key and readonly",
+			input: "tls-secret:tls.crt=/etc/certs:ro",
+			expected: MountSpec{
+				Name:     "tls-secret",
+				Path:     "/etc/certs",
+				Key:      "tls.crt",
+				ReadOnly: true,
+			},
+			expectError: false,
+		},
+		{
+			name:  "shorthand without key and readonly",
+			input: "app-config=/app/config",
+			expected: MountSpec{
+				Name:     "app-config",
+				Path:     "/app/config",
+				Key:      "",
+				ReadOnly: false,
+			},
+			expectError: false,
+		},
+		{
+			name:  "shorthand with key but not readonly",
+			input: "my-secret:password=/app/secrets",
+			expected: MountSpec{
+				Name:     "my-secret",
+				Path:     "/app/secrets",
+				Key:      "password",
+				ReadOnly: false,
+			},
+			expectError: false,
+		},
+		{
+			name:  "shorthand without key but with readonly",
+			input: "my-configmap=/app/data:ro",
+			expected: MountSpec{
+				Name:     "my-configmap",
+				Path:     "/app/data",
+				Key:      "",
+				ReadOnly: true,
+			},
+			expectError: false,
+		},
+		{
+			name:        "shorthand missing path",
+			input:       "my-secret:key=",
+			expectError: true,
+		},
+		{
+			name:        "shorthand missing path",
+			input:       "my-secret:key",
+			expectError: true,
+		},
+		{
+			name:        "shorthand empty name",
+			input:       ":key=/path",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &MountArray{}
+			err := m.Set(tt.input)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if len(m.Mounts) != 1 {
+				t.Errorf("expected 1 mount, got %d", len(m.Mounts))
+				return
+			}
+
+			got := m.Mounts[0]
+			if got.Name != tt.expected.Name {
+				t.Errorf("expected name %q, got %q", tt.expected.Name, got.Name)
+			}
+			if got.Path != tt.expected.Path {
+				t.Errorf("expected path %q, got %q", tt.expected.Path, got.Path)
+			}
+			if got.Key != tt.expected.Key {
+				t.Errorf("expected key %q, got %q", tt.expected.Key, got.Key)
+			}
+			if got.ReadOnly != tt.expected.ReadOnly {
+				t.Errorf("expected readonly %v, got %v", tt.expected.ReadOnly, got.ReadOnly)
+			}
+		})
+	}
+}
+
+func TestMountArray_Set_PathTraversal(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectError bool
+	}{
+		{
+			name:        "path traversal with ..",
+			input:       "name=secret,path=../etc/passwd",
+			expectError: true,
+		},
+		{
+			name:        "path traversal with ../../",
+			input:       "name=secret,path=../../root",
+			expectError: true,
+		},
+		{
+			name:        "path traversal in shorthand",
+			input:       "secret=/../../etc/passwd",
+			expectError: true,
+		},
+		{
+			name:        "valid path",
+			input:       "name=secret,path=/app/config",
+			expectError: false,
+		},
+		{
+			name:        "valid relative path",
+			input:       "name=secret,path=config",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &MountArray{}
+			err := m.Set(tt.input)
+
+			if tt.expectError && err == nil {
+				t.Errorf("expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestMountArray_Set_MixedFormats(t *testing.T) {
+	tests := []struct {
+		name        string
+		inputs      []string
+		expectError bool
+	}{
+		{
+			name:        "mixing normal and shorthand",
+			inputs:      []string{"name=secret,path=/app", "secret2=/path"},
+			expectError: false, // mixing is now allowed since we don't track format
+		},
+		{
+			name:        "mixing shorthand and normal",
+			inputs:      []string{"secret=/path", "name=secret2,path=/app"},
+			expectError: false, // mixing is now allowed since we don't track format
+		},
+		{
+			name:        "all normal format",
+			inputs:      []string{"name=secret1,path=/app1", "name=secret2,path=/app2"},
+			expectError: false,
+		},
+		{
+			name:        "all shorthand format",
+			inputs:      []string{"secret1=/app1", "secret2=/app2"},
+			expectError: false,
+		},
+		{
+			name:        "backward compatibility mixed with normal",
+			inputs:      []string{"old-secret", "name=new-secret,path=/app"},
+			expectError: false, // backward compatibility should work with normal format
+		},
+		{
+			name:        "invalid shorthand format in sequence",
+			inputs:      []string{"secret1=/app1", "invalid:format"},
+			expectError: true, // second input has colon but no equals - should error
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &MountArray{}
+			var err error
+			for _, input := range tt.inputs {
+				err = m.Set(input)
+				if err != nil {
+					break
+				}
+			}
+
+			if tt.expectError && err == nil {
+				t.Errorf("expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestMountArray_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		mounts   []MountSpec
+		expected string
+	}{
+		{
+			name:     "empty mounts",
+			mounts:   []MountSpec{},
+			expected: "",
+		},
+		{
+			name: "single mount with all fields",
+			mounts: []MountSpec{
+				{Name: "secret", Path: "/app", Key: "key", ReadOnly: true},
+			},
+			expected: "name=secret,path=/app,key=key,ro=true",
+		},
+		{
+			name: "single mount without key",
+			mounts: []MountSpec{
+				{Name: "secret", Path: "/app", ReadOnly: false},
+			},
+			expected: "name=secret,path=/app,ro=false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &MountArray{Mounts: tt.mounts}
+			got := m.String()
+			if got != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestServiceBindingSecretArray_Set(t *testing.T) {
+	tests := []struct {
+		name     string
+		inputs   []string
+		expected []string
+	}{
+		{
+			name:     "single secret",
+			inputs:   []string{"secret1"},
+			expected: []string{"secret1"},
+		},
+		{
+			name:     "multiple secrets",
+			inputs:   []string{"secret1", "secret2", "secret3"},
+			expected: []string{"secret1", "secret2", "secret3"},
+		},
+		{
+			name:     "empty input",
+			inputs:   []string{""},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &ServiceBindingSecretArray{}
+			for _, input := range tt.inputs {
+				err := s.Set(input)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+
+			if len(s.Names) != len(tt.expected) {
+				t.Errorf("expected %d names, got %d", len(tt.expected), len(s.Names))
+				return
+			}
+
+			for i, expected := range tt.expected {
+				if s.Names[i] != expected {
+					t.Errorf("expected name[%d] %q, got %q", i, expected, s.Names[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/kube/resources/deployment_test.go
+++ b/internal/kube/resources/deployment_test.go
@@ -21,15 +21,25 @@ func Test_CreateDeployment(t *testing.T) {
 			TestKubernetesInterface: k8s_fake.NewSimpleClientset(),
 		}
 		trueValue := true
+
+		// Create MountArray for secrets (backward compatibility - just names)
+		secretMounts := types.MountArray{}
+		_ = secretMounts.Set("test-name")
+
+		// Create MountArray for configmaps (backward compatibility - just names)
+		configMounts := types.MountArray{}
+		_ = configMounts.Set("test-name")
+
 		err := CreateDeployment(context.Background(), kubeClient, CreateDeploymentOpts{
-			Name:            "test-name",
-			Namespace:       "default",
-			Image:           "test:image",
-			ImagePullSecret: "test-image-pull-secret",
-			InjectIstio:     types.NullableBool{Value: &trueValue},
-			SecretMounts:    []string{"test-name"},
-			ConfigmapMounts: []string{"test-name"},
-			Envs:            fixDeploymentCustomEnvs(),
+			Name:                       "test-name",
+			Namespace:                  "default",
+			Image:                      "test:image",
+			ImagePullSecret:            "test-image-pull-secret",
+			InjectIstio:                types.NullableBool{Value: &trueValue},
+			SecretMounts:               secretMounts,
+			ConfigmapMounts:            configMounts,
+			ServiceBindingSecretMounts: types.ServiceBindingSecretArray{}, // empty
+			Envs:                       fixDeploymentCustomEnvs(),
 		})
 		require.NoError(t, err)
 
@@ -43,15 +53,25 @@ func Test_CreateDeployment(t *testing.T) {
 			TestKubernetesInterface: k8s_fake.NewSimpleClientset(fixDeployment()),
 		}
 		trueValue := true
+
+		// Create MountArray for secrets (backward compatibility - just names)
+		secretMounts := types.MountArray{}
+		_ = secretMounts.Set("test-name")
+
+		// Create MountArray for configmaps (backward compatibility - just names)
+		configMounts := types.MountArray{}
+		_ = configMounts.Set("test-name")
+
 		err := CreateDeployment(context.Background(), kubeClient, CreateDeploymentOpts{
-			Name:            "test-name",
-			Namespace:       "default",
-			Image:           "test:image",
-			ImagePullSecret: "test-image-pull-secret",
-			InjectIstio:     types.NullableBool{Value: &trueValue},
-			SecretMounts:    []string{"test-name"},
-			ConfigmapMounts: []string{"test-name"},
-			Envs:            fixDeploymentCustomEnvs(),
+			Name:                       "test-name",
+			Namespace:                  "default",
+			Image:                      "test:image",
+			ImagePullSecret:            "test-image-pull-secret",
+			InjectIstio:                types.NullableBool{Value: &trueValue},
+			SecretMounts:               secretMounts,
+			ConfigmapMounts:            configMounts,
+			ServiceBindingSecretMounts: types.ServiceBindingSecretArray{}, // empty
+			Envs:                       fixDeploymentCustomEnvs(),
 		})
 		require.ErrorContains(t, err, `deployments.apps "test-name" already exists`)
 	})
@@ -115,7 +135,7 @@ func fixDeployment() *appsv1.Deployment {
 				Spec: corev1.PodSpec{
 					Volumes: []corev1.Volume{
 						{
-							Name: "secret-test-name",
+							Name: "secret-test-name-0",
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
 									SecretName: "test-name",
@@ -123,7 +143,7 @@ func fixDeployment() *appsv1.Deployment {
 							},
 						},
 						{
-							Name: "configmap-test-name",
+							Name: "configmap-test-name-0",
 							VolumeSource: corev1.VolumeSource{
 								ConfigMap: &corev1.ConfigMapVolumeSource{
 									LocalObjectReference: corev1.LocalObjectReference{
@@ -153,12 +173,14 @@ func fixDeployment() *appsv1.Deployment {
 							}),
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      "secret-test-name",
+									Name:      "secret-test-name-0",
 									MountPath: "/bindings/secret-test-name",
+									ReadOnly:  false,
 								},
 								{
-									Name:      "configmap-test-name",
+									Name:      "configmap-test-name-0",
 									MountPath: "/bindings/configmap-test-name",
+									ReadOnly:  false,
 								},
 							},
 							Resources: corev1.ResourceRequirements{

--- a/tests/k3d/Makefile
+++ b/tests/k3d/Makefile
@@ -1,3 +1,7 @@
 .PHONY: e2e-test
 e2e-test: 
 	./integration-test-k3d.sh
+
+.PHONY: mount-test
+mount-test:
+	./test-mount-flags-simple.sh

--- a/tests/k3d/test-mount-flags-simple.sh
+++ b/tests/k3d/test-mount-flags-simple.sh
@@ -1,0 +1,206 @@
+#!/bin/bash
+
+echo "Running mount flags test scenario for kyma CLI on k3d runtime (using pre-built image)"
+
+# Set strict error handling
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Cleanup function
+cleanup() {
+    print_status "Cleaning up test resources..."
+    kubectl delete deployment test-mount-app --ignore-not-found=true
+    kubectl delete service test-mount-app --ignore-not-found=true
+    kubectl delete secret test-secret --ignore-not-found=true
+    kubectl delete secret test-service-binding --ignore-not-found=true
+    kubectl delete configmap test-configmap --ignore-not-found=true
+    pkill -f "kubectl port-forward" || true
+    print_status "Cleanup completed"
+}
+
+# Set trap for cleanup on exit
+trap cleanup EXIT
+
+# -------------------------------------------------------------------------------------
+# Generate kubeconfig for service account
+
+print_status "Step 1: Generating temporary access for new service account"
+../../bin/kyma alpha kubeconfig generate --clusterrole cluster-admin --serviceaccount test-sa --output /tmp/kubeconfig.yaml --time 2h --cluster-wide --namespace default
+export KUBECONFIG="/tmp/kubeconfig.yaml"
+
+if [[ $(kubectl config view --minify --raw | yq '.users[0].name') != 'test-sa' ]]; then
+    print_error "Failed to set up service account"
+    exit 1
+fi
+print_status "Running test in user context of: $(kubectl config view --minify --raw | yq '.users[0].name')"
+
+# -------------------------------------------------------------------------------------
+# Create test resources (Secret, ConfigMap, Service Binding Secret)
+
+print_status "Step 2: Creating test resources for mounting"
+
+# Create a test secret
+kubectl create secret generic test-secret \
+  --from-literal=username=testuser \
+  --from-literal=password=testpass \
+  --from-literal=config.json='{"database":"postgres","host":"localhost"}'
+
+print_status "Created test secret with keys: username, password, config.json"
+
+# Create a test configmap
+kubectl create configmap test-configmap \
+  --from-literal=app.properties='debug=true
+logging.level=INFO
+server.port=8080' \
+  --from-literal=database.url=jdbc:postgresql://localhost:5432/testdb
+
+print_status "Created test configmap with keys: app.properties, database.url"
+
+# Create a service binding secret (simulates a service binding)
+kubectl create secret generic test-service-binding \
+  --from-literal=type=postgresql \
+  --from-literal=provider=bitnami \
+  --from-literal=host=postgres.example.com \
+  --from-literal=port=5432 \
+  --from-literal=username=bindinguser \
+  --from-literal=password=bindingpass
+
+print_status "Created service binding secret with connection details"
+
+# -------------------------------------------------------------------------------------
+# Push app using nginx image with mount flags (to avoid buildpack issues)
+
+print_status "Step 3: Push application using nginx image with mount flags"
+
+../../bin/kyma app push \
+  --name test-mount-app \
+  --image nginx:alpine \
+  --container-port 80 \
+  --mount-secret "name=test-secret,path=/app/secrets,ro=true" \
+  --mount-secret "test-secret:username=/app/secrets2:ro" \
+  --mount-config "name=test-configmap,path=/app/config,ro=false" \
+  --mount-service-binding-secret test-service-binding
+
+print_status "Application pushed with mount flags:"
+print_status "  --mount-secret: test-secret -> /app/secrets (read-only)"
+print_status "  --mount-secret: test-secret:username -> /app/secrets2 (read-only)"
+print_status "  --mount-config: test-configmap -> /app/config (read-write)"
+print_status "  --mount-service-binding-secret: test-service-binding -> /bindings/secret-test-service-binding (read-only)"
+
+kubectl wait --for condition=Available deployment test-mount-app --timeout=120s
+
+# -------------------------------------------------------------------------------------
+# Verify mounts by inspecting the pod
+
+print_status "Step 4: Verifying mounted files in the pod"
+
+POD_NAME=$(kubectl get pods -l app=test-mount-app -o jsonpath='{.items[0].metadata.name}')
+print_status "Inspecting pod: $POD_NAME"
+
+# Check volume mounts in pod spec
+print_status "Volume mounts in pod:"
+kubectl describe pod $POD_NAME | grep -A 20 "Mounts:" || true
+
+# Check volumes in pod spec
+print_status "Volumes in pod spec:"
+kubectl get pod $POD_NAME -o yaml | yq '.spec.volumes[].name' | head -10
+
+# -------------------------------------------------------------------------------------
+# Test file contents by executing commands in the pod
+
+print_status "Step 5: Testing mounted file contents"
+
+print_status "Testing secret mount at /app/secrets:"
+kubectl exec $POD_NAME -- ls -la /app/secrets/ || print_warning "Secret mount path not accessible"
+kubectl exec $POD_NAME -- cat /app/secrets/username || print_warning "Could not read username from secret"
+kubectl exec $POD_NAME -- cat /app/secrets/password || print_warning "Could not read password from secret"
+kubectl exec $POD_NAME -- cat /app/secrets/config.json || print_warning "Could not read config.json from secret"
+
+print_status "Testing configmap mount at /app/config:"
+kubectl exec $POD_NAME -- ls -la /app/config/ || print_warning "ConfigMap mount path not accessible"
+kubectl exec $POD_NAME -- cat /app/config/app.properties || print_warning "Could not read app.properties from configmap"
+kubectl exec $POD_NAME -- cat /app/config/database.url || print_warning "Could not read database.url from configmap"
+
+print_status "Testing service binding mount at /bindings:"
+kubectl exec $POD_NAME -- ls -la /bindings/ || print_warning "Service binding mount path not accessible"
+BINDING_DIR=$(kubectl exec $POD_NAME -- ls /bindings/ | grep secret- | head -1)
+if [[ -n "$BINDING_DIR" ]]; then
+    print_status "Found service binding directory: $BINDING_DIR"
+    kubectl exec $POD_NAME -- ls -la /bindings/$BINDING_DIR/ || print_warning "Could not list service binding files"
+    kubectl exec $POD_NAME -- cat /bindings/$BINDING_DIR/type || print_warning "Could not read type from service binding"
+    kubectl exec $POD_NAME -- cat /bindings/$BINDING_DIR/host || print_warning "Could not read host from service binding"
+else
+    print_warning "No service binding directory found"
+fi
+
+# -------------------------------------------------------------------------------------
+# Test read-only permissions
+
+print_status "Step 6: Testing read-only permissions"
+
+print_status "Testing if secret mount is read-only:"
+if kubectl exec $POD_NAME -- touch /app/secrets/test-file 2>/dev/null; then
+    print_warning "Secret mount is NOT read-only (unexpected)"
+    kubectl exec $POD_NAME -- rm /app/secrets/test-file
+else
+    print_status "✓ Secret mount is read-only as expected"
+fi
+
+print_status "Testing if configmap mount allows writes:"
+if kubectl exec $POD_NAME -- touch /app/config/test-file 2>/dev/null; then
+    print_status "✓ ConfigMap mount allows writes as expected"
+    kubectl exec $POD_NAME -- rm /app/config/test-file
+else
+    print_warning "ConfigMap mount is read-only (might be expected behavior)"
+fi
+
+if [[ -n "$BINDING_DIR" ]]; then
+    print_status "Testing if service binding mount is read-only:"
+    if kubectl exec $POD_NAME -- touch /bindings/$BINDING_DIR/test-file 2>/dev/null; then
+        print_warning "Service binding mount is NOT read-only (unexpected)"
+        kubectl exec $POD_NAME -- rm /bindings/$BINDING_DIR/test-file
+    else
+        print_status "✓ Service binding mount is read-only as expected"
+    fi
+fi
+
+# -------------------------------------------------------------------------------------
+# Verify deployment configuration
+
+print_status "Step 7: Verifying deployment configuration"
+
+print_status "Checking deployment YAML for volume mounts:"
+kubectl get deployment test-mount-app -o yaml | yq '.spec.template.spec.containers[0].volumeMounts'
+
+print_status "Checking deployment YAML for volumes:"
+kubectl get deployment test-mount-app -o yaml | yq '.spec.template.spec.volumes'
+
+# -------------------------------------------------------------------------------------
+print_status "Mount flags test completed!"
+print_status "Summary of tests performed:"
+print_status "  ✓ --mount-secret: Created secret mount at /app/secrets (read-only)"
+print_status "  ✓ --mount-secret: Created shorthand secret mount at /app/secrets (read-only)"
+print_status "  ✓ --mount-config: Created configmap mount at /app/config"
+print_status "  ✓ --mount-service-binding-secret: Created service binding mount at /bindings/secret-*"
+print_status "  ✓ Verified file contents are accessible"
+print_status "  ✓ Verified read-only permissions where applicable"
+
+exit 0

--- a/tests/k3d/test-mount-flags.sh
+++ b/tests/k3d/test-mount-flags.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+
+echo "Running mount flags test scenario for kyma CLI on k3d runtime"
+
+# Set strict error handling
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Cleanup function
+cleanup() {
+    kubectl delete deployment test-mount-app --ignore-not-found=true >/dev/null 2>&1
+    kubectl delete service test-mount-app --ignore-not-found=true >/dev/null 2>&1
+    kubectl delete secret test-secret --ignore-not-found=true >/dev/null 2>&1
+    kubectl delete secret test-service-binding --ignore-not-found=true >/dev/null 2>&1
+    kubectl delete configmap test-configmap --ignore-not-found=true >/dev/null 2>&1
+    pkill -f "kubectl port-forward" >/dev/null 2>&1 || true
+}
+
+# Set trap for cleanup on exit
+trap cleanup EXIT
+
+# -------------------------------------------------------------------------------------
+# Generate kubeconfig for service account
+
+print_status "Generating service account access..."
+../../bin/kyma alpha kubeconfig generate --clusterrole cluster-admin --serviceaccount test-sa --output /tmp/kubeconfig.yaml --time 2h --cluster-wide --namespace default >/dev/null 2>&1
+export KUBECONFIG="/tmp/kubeconfig.yaml"
+
+if [[ $(kubectl config view --minify --raw | yq '.users[0].name') != 'test-sa' ]]; then
+    print_error "Failed to set up service account"
+    exit 1
+fi
+
+# -------------------------------------------------------------------------------------
+# Enable Docker Registry
+
+print_status "Setting up Docker Registry..."
+kubectl create namespace kyma-system >/dev/null 2>&1 || true
+kubectl apply -f https://github.com/kyma-project/docker-registry/releases/latest/download/dockerregistry-operator.yaml >/dev/null 2>&1
+kubectl apply -f https://github.com/kyma-project/docker-registry/releases/latest/download/default-dockerregistry-cr.yaml -n kyma-system >/dev/null 2>&1
+kubectl wait --for condition=Installed dockerregistries.operator.kyma-project.io/default -n kyma-system --timeout=360s >/dev/null 2>&1
+
+# -------------------------------------------------------------------------------------
+# Create test resources (Secret, ConfigMap, Service Binding Secret)
+
+print_status "Creating test resources..."
+
+# Create a test secret
+kubectl create secret generic test-secret \
+  --from-literal=username=testuser \
+  --from-literal=password=testpass \
+  --from-literal=config.json='{"database":"postgres","host":"localhost"}' >/dev/null 2>&1
+
+# Create a test configmap
+kubectl create configmap test-configmap \
+  --from-literal=app.properties='debug=true
+logging.level=INFO
+server.port=8080' \
+  --from-literal=database.url=jdbc:postgresql://localhost:5432/testdb >/dev/null 2>&1
+
+# Create a service binding secret (simulates a service binding)
+kubectl create secret generic test-service-binding \
+  --from-literal=type=postgresql \
+  --from-literal=provider=bitnami \
+  --from-literal=host=postgres.example.com \
+  --from-literal=port=5432 \
+  --from-literal=username=bindinguser \
+  --from-literal=password=bindingpass >/dev/null 2>&1
+
+# -------------------------------------------------------------------------------------
+# Push sample app with all mount flags
+
+print_status "Pushing application with mount flags..."
+
+../../bin/kyma app push \
+  --name test-mount-app \
+  --code-path sample-go \
+  --container-port 8080 \
+  --mount-secret "name=test-secret,path=/app/secrets,ro=true" \
+  --mount-config "name=test-configmap,path=/app/config,ro=false" \
+  --mount-service-binding-secret test-service-binding
+
+echo "Mount flags used:"
+echo "  --mount-secret: test-secret -> /app/secrets (read-only)"
+echo "  --mount-config: test-configmap -> /app/config (read-write)"
+echo "  --mount-service-binding-secret: test-service-binding -> /bindings/secret-test-service-binding (read-only)"
+
+kubectl wait --for condition=Available deployment test-mount-app --timeout=120s >/dev/null 2>&1
+
+# -------------------------------------------------------------------------------------
+# Test the application and verify mounts
+
+print_status "Testing application and verifying mounts..."
+
+# Port forward in background
+kubectl port-forward deployments/test-mount-app 8080:8080 >/dev/null 2>&1 &
+PF_PID=$!
+sleep 5 # wait for ports to get forwarded
+
+# Test basic endpoint
+response=$(curl -s localhost:8080)
+echo "Basic endpoint response: $response"
+
+if [[ $response != 'okey dokey' ]]; then
+    print_error "Basic endpoint test failed"
+    exit 1
+fi
+
+# Instead of using a /mounts endpoint, verify mounts by directly inspecting the pod
+POD_NAME=$(kubectl get pods -l app=test-mount-app -o jsonpath='{.items[0].metadata.name}')
+echo "Verifying mounts in pod: $POD_NAME"
+
+# Check if secret files are mounted and accessible
+print_status "Checking secret mount..."
+if kubectl exec $POD_NAME -- ls /app/secrets >/dev/null 2>&1; then
+    print_status "✓ Secret mounted successfully"
+    echo "Secret files:"
+    kubectl exec $POD_NAME -- ls -la /app/secrets
+
+    # Test read-only
+    if kubectl exec $POD_NAME -- touch /app/secrets/test-file 2>/dev/null; then
+        print_warning "Secret mount is NOT read-only"
+        kubectl exec $POD_NAME -- rm /app/secrets/test-file
+    else
+        print_status "✓ Secret mount is read-only as expected"
+    fi
+else
+    print_error "✗ Secret not mounted properly"
+fi
+
+# Check if configmap files are mounted and accessible
+print_status "Checking configmap mount..."
+if kubectl exec $POD_NAME -- ls /app/config >/dev/null 2>&1; then
+    print_status "✓ ConfigMap mounted successfully"
+    echo "ConfigMap files:"
+    kubectl exec $POD_NAME -- ls -la /app/config
+else
+    print_error "✗ ConfigMap not mounted properly"
+fi
+
+# Check if service binding secret is mounted
+print_status "Checking service binding mount..."
+if kubectl exec $POD_NAME -- ls /bindings >/dev/null 2>&1; then
+    binding_dirs=$(kubectl exec $POD_NAME -- ls /bindings 2>/dev/null || echo "")
+    if [[ -n "$binding_dirs" ]]; then
+        print_status "✓ Service binding secret mounted"
+        echo "Service binding directories:"
+        kubectl exec $POD_NAME -- ls -la /bindings
+
+        # Check the first service binding directory
+        first_dir=$(kubectl exec $POD_NAME -- ls /bindings | head -1)
+        if [[ -n "$first_dir" ]]; then
+            echo "Service binding files in $first_dir:"
+            kubectl exec $POD_NAME -- ls -la "/bindings/$first_dir"
+
+            # Test read-only
+            if kubectl exec $POD_NAME -- touch "/bindings/$first_dir/test-file" 2>/dev/null; then
+                print_warning "Service binding mount is NOT read-only"
+                kubectl exec $POD_NAME -- rm "/bindings/$first_dir/test-file"
+            else
+                print_status "✓ Service binding mount is read-only as expected"
+            fi
+        fi
+    else
+        print_error "✗ No service binding directories found"
+    fi
+else
+    print_error "✗ Service binding secret not mounted properly"
+fi
+
+# -------------------------------------------------------------------------------------
+# Show actual file contents
+
+echo ""
+echo "Secret files content:"
+for file in $(kubectl exec $POD_NAME -- ls /app/secrets 2>/dev/null || echo ""); do
+    echo "  $file:"
+    kubectl exec $POD_NAME -- cat "/app/secrets/$file" 2>/dev/null || echo "    (could not read)"
+done
+
+echo ""
+echo "ConfigMap files content:"
+for file in $(kubectl exec $POD_NAME -- ls /app/config 2>/dev/null || echo ""); do
+    echo "  $file:"
+    kubectl exec $POD_NAME -- cat "/app/config/$file" 2>/dev/null || echo "    (could not read)"
+done
+
+echo ""
+echo "Service binding files content:"
+if [[ -n "$first_dir" ]]; then
+    for file in $(kubectl exec $POD_NAME -- ls "/bindings/$first_dir" 2>/dev/null || echo ""); do
+        echo "  $file:"
+        kubectl exec $POD_NAME -- cat "/bindings/$first_dir/$file" 2>/dev/null || echo "    (could not read)"
+    done
+fi
+
+# -------------------------------------------------------------------------------------
+print_status "Mount flags test completed successfully!"
+echo "✓ --mount-secret"
+echo "✓ --mount-config"
+echo "✓ --mount-service-binding-secret"
+
+exit 0


### PR DESCRIPTION
**Description**
The updated flags now support legacy format (just name) as well as 
"regular format"
--mount-config name=<cm-name>,path=</target/path>[,key=<datakey>][,ro=<true|false>]
--mount-secret name=<secret-name>,path=</target/path>[,key=<datakey>][,ro=<true|false>]
"shorthand format"
--mount-config <cm-name>[:key]=</target/path>[:ro]
--mount-secret <secret-name>[:key]=</target/path>[:ro]
Also added a flag --mount-service-binding-secret that is called only using secret name

included is automated test that can be run via the script `./test-mount-flags-simple.sh`                                                                                                                                                                                                                                                                            

**Related issue(s)**
https://github.com/kyma-project/cli/issues/2616
