### PR TITLE
Stop using the `os.Stdout` and the `os.Stderr`

### DIFF
--- a/internal/dockerfile/build.go
+++ b/internal/dockerfile/build.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
+	"github.com/kyma-project/cli.v3/internal/out"
 	"github.com/moby/go-archive"
 	"github.com/moby/term"
 	"github.com/pkg/errors"
@@ -36,7 +37,7 @@ func Build(ctx context.Context, opts *BuildOptions) error {
 
 	builder := imageBuilder{
 		dockerClient: cli,
-		out:          os.Stdout,
+		out:          out.Default.MsgWriter(),
 	}
 
 	return builder.do(ctx, opts)

--- a/internal/out/out.go
+++ b/internal/out/out.go
@@ -227,7 +227,20 @@ func (p *Printer) Errfln(format string, a ...interface{}) {
 // Write implements the io.Writer interface for Printer
 // it allows using Printer as an io.Writer
 func (p *Printer) Write(b []byte) (n int, err error) {
-	return p.outWriter.Write(b)
+	return p.MsgWriter().Write(b)
+}
+
+// MsgWriter returns the output writer
+// for passing it to functions that require an io.Writer
+// in this way the output can be muted using DisableMsg()
+func (p *Printer) MsgWriter() io.Writer {
+	return p.outWriter
+}
+
+// ErrWriter returns the error output writer
+// for passing it to functions that require an io.Writer
+func (p *Printer) ErrWriter() io.Writer {
+	return p.errWriter
 }
 
 func write(writer io.Writer, format string, a ...interface{}) {

--- a/internal/pack/build.go
+++ b/internal/pack/build.go
@@ -8,11 +8,12 @@ import (
 	"github.com/buildpacks/pack/pkg/cache"
 	"github.com/buildpacks/pack/pkg/client"
 	"github.com/buildpacks/pack/pkg/logging"
+	"github.com/kyma-project/cli.v3/internal/out"
 	"github.com/pkg/errors"
 )
 
 func Build(ctx context.Context, appName, appPath string) error {
-	pack, err := client.NewClient(client.WithLogger(logging.NewLogWithWriters(os.Stdout, os.Stderr)))
+	pack, err := client.NewClient(client.WithLogger(logging.NewLogWithWriters(out.Default.MsgWriter(), out.Default.ErrWriter())))
 	if err != nil {
 		return errors.Wrap(err, "failed to create buildpack client")
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- as in the title

After merging these changes:

```bash
grep 'os.Stdout|os.Stderr' *
internal/out/out.go
63:             outWriter:        os.Stdout,
64:             errWriter:        os.Stderr,
65:             prioOutWriter:    os.Stdout,
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- previous PR - https://github.com/kyma-project/cli/pull/2674