### PR TITLE
Add a hint in a case where user misues a command

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,6 @@ func main() {
 	cmd := cmd.NewKymaCMD()
 
 	if err := cmd.Execute(); err != nil {
-		clierror.Check(clierror.Wrap(err, clierror.New("failed to execute command")))
+		clierror.Check(clierror.Wrap(err, clierror.New("failed to execute command", "use --help to see available commands and examples")))
 	}
 }


### PR DESCRIPTION
**Description**
Currently if a user provides no arguements for a command requiring some he sees only error with no hints or details. 
Added a hint to guide the user.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
