### PR TITLE
fix(app): make app push idempotent using server-side apply

### DIFF
--- a/internal/cmd/app/push.go
+++ b/internal/cmd/app/push.go
@@ -222,7 +222,7 @@ func runAppPush(cfg *appPushConfig) clierror.Error {
 		imagePullSecret = registryConfig.SecretName
 	}
 
-	out.Msgfln("\nApplying deployment %s/%s", cfg.namespace, cfg.name)
+	out.Msgfln("\nApplying Deployment %s/%s", cfg.namespace, cfg.name)
 
 	clierr = createDeployment(cfg, client, image, imagePullSecret)
 	if clierr != nil {
@@ -230,7 +230,7 @@ func runAppPush(cfg *appPushConfig) clierror.Error {
 	}
 
 	if cfg.containerPort.Value != nil {
-		out.Msgfln("\nApplying service %s/%s", cfg.namespace, cfg.name)
+		out.Msgfln("\nApplying Service %s/%s", cfg.namespace, cfg.name)
 		err := resources.ApplyService(cfg.Ctx, client, cfg.name, cfg.namespace, int32(*cfg.containerPort.Value))
 		if err != nil {
 			return clierror.Wrap(err, clierror.New("failed to apply Service"))

--- a/internal/cmd/app/push.go
+++ b/internal/cmd/app/push.go
@@ -222,7 +222,7 @@ func runAppPush(cfg *appPushConfig) clierror.Error {
 		imagePullSecret = registryConfig.SecretName
 	}
 
-	out.Msgfln("\nCreating deployment %s/%s", cfg.namespace, cfg.name)
+	out.Msgfln("\nApplying deployment %s/%s", cfg.namespace, cfg.name)
 
 	clierr = createDeployment(cfg, client, image, imagePullSecret)
 	if clierr != nil {
@@ -230,10 +230,10 @@ func runAppPush(cfg *appPushConfig) clierror.Error {
 	}
 
 	if cfg.containerPort.Value != nil {
-		out.Msgfln("\nCreating service %s/%s", cfg.namespace, cfg.name)
-		err := resources.CreateService(cfg.Ctx, client, cfg.name, cfg.namespace, int32(*cfg.containerPort.Value))
+		out.Msgfln("\nApplying service %s/%s", cfg.namespace, cfg.name)
+		err := resources.ApplyService(cfg.Ctx, client, cfg.name, cfg.namespace, int32(*cfg.containerPort.Value))
 		if err != nil {
-			return clierror.Wrap(err, clierror.New("failed to create Service"))
+			return clierror.Wrap(err, clierror.New("failed to apply Service"))
 		}
 	}
 
@@ -294,7 +294,7 @@ func createDeployment(cfg *appPushConfig, client kube.Client, image, imagePullSe
 	envs = append(envs, fileEnvs...)
 	envs = append(envs, plainEnvs...)
 
-	err = resources.CreateDeployment(cfg.Ctx, client, resources.CreateDeploymentOpts{
+	err = resources.ApplyDeployment(cfg.Ctx, client, resources.CreateDeploymentOpts{
 		Name:                       cfg.name,
 		Namespace:                  cfg.namespace,
 		Image:                      image,
@@ -307,7 +307,7 @@ func createDeployment(cfg *appPushConfig, client kube.Client, image, imagePullSe
 		Insecure:                   cfg.insecure,
 	})
 	if err != nil {
-		return clierror.Wrap(err, clierror.New("failed to create Deployment"))
+		return clierror.Wrap(err, clierror.New("failed to apply Deployment"))
 	}
 
 	return nil

--- a/internal/kube/resources/deployment.go
+++ b/internal/kube/resources/deployment.go
@@ -33,12 +33,6 @@ type CreateDeploymentOpts struct {
 	Insecure                   bool
 }
 
-func CreateDeployment(ctx context.Context, client kube.Client, opts CreateDeploymentOpts) error {
-	deployment := buildDeployment(&opts)
-	_, err := client.Static().AppsV1().Deployments(opts.Namespace).Create(ctx, deployment, metav1.CreateOptions{})
-	return err
-}
-
 func ApplyDeployment(ctx context.Context, client kube.Client, opts CreateDeploymentOpts) error {
 	deployment := buildDeployment(&opts)
 	deployment.TypeMeta = metav1.TypeMeta{

--- a/internal/kube/resources/deployment.go
+++ b/internal/kube/resources/deployment.go
@@ -35,10 +35,6 @@ type CreateDeploymentOpts struct {
 
 func ApplyDeployment(ctx context.Context, client kube.Client, opts CreateDeploymentOpts) error {
 	deployment := buildDeployment(&opts)
-	deployment.TypeMeta = metav1.TypeMeta{
-		APIVersion: "apps/v1",
-		Kind:       "Deployment",
-	}
 	unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(deployment)
 	if err != nil {
 		return err
@@ -85,6 +81,10 @@ func buildDeployment(opts *CreateDeploymentOpts) *appsv1.Deployment {
 	}
 
 	deployment := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      opts.Name,
 			Namespace: opts.Namespace,

--- a/internal/kube/resources/deployment.go
+++ b/internal/kube/resources/deployment.go
@@ -41,14 +41,15 @@ func CreateDeployment(ctx context.Context, client kube.Client, opts CreateDeploy
 
 func ApplyDeployment(ctx context.Context, client kube.Client, opts CreateDeploymentOpts) error {
 	deployment := buildDeployment(&opts)
+	deployment.TypeMeta = metav1.TypeMeta{
+		APIVersion: "apps/v1",
+		Kind:       "Deployment",
+	}
 	unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(deployment)
 	if err != nil {
 		return err
 	}
-	u := &unstructured.Unstructured{Object: unstrObj}
-	u.SetAPIVersion("apps/v1")
-	u.SetKind("Deployment")
-	return client.RootlessDynamic().Apply(ctx, u, false)
+	return client.RootlessDynamic().Apply(ctx, &unstructured.Unstructured{Object: unstrObj}, false)
 }
 
 func buildDeployment(opts *CreateDeploymentOpts) *appsv1.Deployment {
@@ -91,7 +92,8 @@ func buildDeployment(opts *CreateDeploymentOpts) *appsv1.Deployment {
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: opts.Name,
+			Name:      opts.Name,
+			Namespace: opts.Namespace,
 			Labels: map[string]string{
 				"app.kubernetes.io/name":       opts.Name,
 				"app.kubernetes.io/created-by": "kyma-cli",

--- a/internal/kube/resources/deployment.go
+++ b/internal/kube/resources/deployment.go
@@ -10,6 +10,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 )
 
@@ -35,6 +37,18 @@ func CreateDeployment(ctx context.Context, client kube.Client, opts CreateDeploy
 	deployment := buildDeployment(&opts)
 	_, err := client.Static().AppsV1().Deployments(opts.Namespace).Create(ctx, deployment, metav1.CreateOptions{})
 	return err
+}
+
+func ApplyDeployment(ctx context.Context, client kube.Client, opts CreateDeploymentOpts) error {
+	deployment := buildDeployment(&opts)
+	unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(deployment)
+	if err != nil {
+		return err
+	}
+	u := &unstructured.Unstructured{Object: unstrObj}
+	u.SetAPIVersion("apps/v1")
+	u.SetKind("Deployment")
+	return client.RootlessDynamic().Apply(ctx, u, false)
 }
 
 func buildDeployment(opts *CreateDeploymentOpts) *appsv1.Deployment {

--- a/internal/kube/resources/deployment_test.go
+++ b/internal/kube/resources/deployment_test.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8s_fake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/utils/ptr"
 )
@@ -169,6 +170,7 @@ func Test_ApplyDeployment(t *testing.T) {
 		require.Equal(t, "apps/v1", rdClient.ApplyObjs[0].GetAPIVersion())
 		require.Equal(t, "Deployment", rdClient.ApplyObjs[0].GetKind())
 		require.Equal(t, "test-app", rdClient.ApplyObjs[0].GetName())
+		require.Equal(t, "default", rdClient.ApplyObjs[0].GetNamespace())
 	})
 
 	t.Run("apply updates deployment when it already exists", func(t *testing.T) {
@@ -193,6 +195,12 @@ func Test_ApplyDeployment(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Len(t, rdClient.ApplyObjs, 2)
+
+		// Verify the second apply carried the updated image
+		containers, _, _ := unstructured.NestedSlice(rdClient.ApplyObjs[1].Object, "spec", "template", "spec", "containers")
+		require.Len(t, containers, 1)
+		container := containers[0].(map[string]interface{})
+		require.Equal(t, "test:v2", container["image"])
 	})
 }
 

--- a/internal/kube/resources/deployment_test.go
+++ b/internal/kube/resources/deployment_test.go
@@ -7,77 +7,12 @@ import (
 	"github.com/kyma-project/cli.v3/internal/cmdcommon/types"
 	kube_fake "github.com/kyma-project/cli.v3/internal/kube/fake"
 	"github.com/stretchr/testify/require"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	k8s_fake "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/utils/ptr"
 )
 
-func Test_CreateDeployment(t *testing.T) {
+func Test_BuildDeployment(t *testing.T) {
 	t.Parallel()
-	t.Run("create deployment", func(t *testing.T) {
-		kubeClient := &kube_fake.KubeClient{
-			TestKubernetesInterface: k8s_fake.NewSimpleClientset(),
-		}
-		trueValue := true
-
-		// Create MountArray for secrets (backward compatibility - just names)
-		secretMounts := types.MountArray{}
-		_ = secretMounts.Set("test-name")
-
-		// Create MountArray for configmaps (backward compatibility - just names)
-		configMounts := types.MountArray{}
-		_ = configMounts.Set("test-name")
-
-		err := CreateDeployment(context.Background(), kubeClient, CreateDeploymentOpts{
-			Name:                       "test-name",
-			Namespace:                  "default",
-			Image:                      "test:image",
-			ImagePullSecret:            "test-image-pull-secret",
-			InjectIstio:                types.NullableBool{Value: &trueValue},
-			SecretMounts:               secretMounts,
-			ConfigmapMounts:            configMounts,
-			ServiceBindingSecretMounts: types.ServiceBindingSecretArray{}, // empty
-			Envs:                       fixDeploymentCustomEnvs(),
-		})
-		require.NoError(t, err)
-
-		deploy, err := kubeClient.Static().AppsV1().Deployments("default").Get(context.Background(), "test-name", metav1.GetOptions{})
-		require.NoError(t, err)
-		require.Equal(t, fixDeployment(), deploy)
-	})
-
-	t.Run("already exists error", func(t *testing.T) {
-		kubeClient := &kube_fake.KubeClient{
-			TestKubernetesInterface: k8s_fake.NewSimpleClientset(fixDeployment()),
-		}
-		trueValue := true
-
-		// Create MountArray for secrets (backward compatibility - just names)
-		secretMounts := types.MountArray{}
-		_ = secretMounts.Set("test-name")
-
-		// Create MountArray for configmaps (backward compatibility - just names)
-		configMounts := types.MountArray{}
-		_ = configMounts.Set("test-name")
-
-		err := CreateDeployment(context.Background(), kubeClient, CreateDeploymentOpts{
-			Name:                       "test-name",
-			Namespace:                  "default",
-			Image:                      "test:image",
-			ImagePullSecret:            "test-image-pull-secret",
-			InjectIstio:                types.NullableBool{Value: &trueValue},
-			SecretMounts:               secretMounts,
-			ConfigmapMounts:            configMounts,
-			ServiceBindingSecretMounts: types.ServiceBindingSecretArray{}, // empty
-			Envs:                       fixDeploymentCustomEnvs(),
-		})
-		require.ErrorContains(t, err, `deployments.apps "test-name" already exists`)
-	})
-
 	t.Run("SERVICE_BINDING_ROOT env var behavior", func(t *testing.T) {
 		t.Run("should not add SERVICE_BINDING_ROOT when no service binding secrets", func(t *testing.T) {
 			deployment := buildDeployment(&CreateDeploymentOpts{
@@ -119,37 +54,6 @@ func Test_CreateDeployment(t *testing.T) {
 			require.True(t, found, "SERVICE_BINDING_ROOT should be present when service binding secrets are used")
 		})
 	})
-}
-
-func fixDeploymentCustomEnvs() []corev1.EnvVar {
-	return []corev1.EnvVar{
-		{
-			Name: "PREFIX_username",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					Key: "username",
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "my-secret",
-					},
-				},
-			},
-		},
-		{
-			Name: "PREFIX_password",
-			ValueFrom: &corev1.EnvVarSource{
-				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-					Key: "password",
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "my-cm",
-					},
-				},
-			},
-		},
-		{
-			Name:  "test",
-			Value: "value",
-		},
-	}
 }
 
 func Test_ApplyDeployment(t *testing.T) {
@@ -199,130 +103,7 @@ func Test_ApplyDeployment(t *testing.T) {
 		// Verify the second apply carried the updated image
 		containers, _, _ := unstructured.NestedSlice(rdClient.ApplyObjs[1].Object, "spec", "template", "spec", "containers")
 		require.Len(t, containers, 1)
-		container := containers[0].(map[string]interface{})
+		container := containers[0].(map[string]any)
 		require.Equal(t, "test:v2", container["image"])
 	})
-}
-
-func fixDeployment() *appsv1.Deployment {
-	return &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-name",
-			Namespace: "default",
-			Labels: map[string]string{
-				"app.kubernetes.io/name":       "test-name",
-				"app.kubernetes.io/created-by": "kyma-cli",
-			},
-		},
-		Spec: appsv1.DeploymentSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"app": "test-name",
-				},
-			},
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-name",
-					Labels: map[string]string{
-						"app":                     "test-name",
-						"sidecar.istio.io/inject": "true",
-					},
-				},
-				Spec: corev1.PodSpec{
-					AutomountServiceAccountToken: ptr.To(false),
-					SecurityContext: &corev1.PodSecurityContext{
-						RunAsUser:    ptr.To(int64(1000)),
-						RunAsGroup:   ptr.To(int64(3000)),
-						RunAsNonRoot: ptr.To(true),
-						SeccompProfile: &corev1.SeccompProfile{
-							Type: corev1.SeccompProfileTypeRuntimeDefault,
-						},
-						AppArmorProfile: &corev1.AppArmorProfile{
-							Type: corev1.AppArmorProfileTypeRuntimeDefault,
-						},
-					},
-					Volumes: []corev1.Volume{
-						{
-							Name: "tmp",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{},
-							},
-						},
-						{
-							Name: "secret-test-name-0",
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{
-									SecretName: "test-name",
-								},
-							},
-						},
-						{
-							Name: "configmap-test-name-0",
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{
-										Name: "test-name",
-									},
-								},
-							},
-						},
-					},
-					ImagePullSecrets: []corev1.LocalObjectReference{
-						{
-							Name: "test-image-pull-secret",
-						},
-					},
-					Containers: []corev1.Container{
-						{
-							Ports: []corev1.ContainerPort{
-								{
-									ContainerPort: 80,
-								},
-							},
-							Name:  "test-name",
-							Image: "test:image",
-							Env:   fixDeploymentCustomEnvs(),
-							VolumeMounts: []corev1.VolumeMount{
-								{
-									Name:      "tmp",
-									MountPath: "/tmp",
-								},
-								{
-									Name:      "secret-test-name-0",
-									MountPath: "/bindings/secret-test-name",
-									ReadOnly:  false,
-								},
-								{
-									Name:      "configmap-test-name-0",
-									MountPath: "/bindings/configmap-test-name",
-									ReadOnly:  false,
-								},
-							},
-							SecurityContext: &corev1.SecurityContext{
-								Privileged:               ptr.To(false),
-								AllowPrivilegeEscalation: ptr.To(false),
-								RunAsNonRoot:             ptr.To(true),
-								Capabilities: &corev1.Capabilities{
-									Drop: []corev1.Capability{
-										"All",
-									},
-								},
-								ReadOnlyRootFilesystem: ptr.To(true),
-							},
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("64Mi"),
-									corev1.ResourceCPU:    resource.MustParse("50m"),
-								},
-								Limits: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("512Mi"),
-									corev1.ResourceCPU:    resource.MustParse("300m"),
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
 }

--- a/internal/kube/resources/deployment_test.go
+++ b/internal/kube/resources/deployment_test.go
@@ -151,6 +151,51 @@ func fixDeploymentCustomEnvs() []corev1.EnvVar {
 	}
 }
 
+func Test_ApplyDeployment(t *testing.T) {
+	t.Parallel()
+	t.Run("apply creates deployment when it does not exist", func(t *testing.T) {
+		rdClient := &kube_fake.RootlessDynamicClient{}
+		kubeClient := &kube_fake.KubeClient{
+			TestRootlessDynamicInterface: rdClient,
+		}
+
+		err := ApplyDeployment(context.Background(), kubeClient, CreateDeploymentOpts{
+			Name:      "test-app",
+			Namespace: "default",
+			Image:     "test:v1",
+		})
+		require.NoError(t, err)
+		require.Len(t, rdClient.ApplyObjs, 1)
+		require.Equal(t, "apps/v1", rdClient.ApplyObjs[0].GetAPIVersion())
+		require.Equal(t, "Deployment", rdClient.ApplyObjs[0].GetKind())
+		require.Equal(t, "test-app", rdClient.ApplyObjs[0].GetName())
+	})
+
+	t.Run("apply updates deployment when it already exists", func(t *testing.T) {
+		rdClient := &kube_fake.RootlessDynamicClient{}
+		kubeClient := &kube_fake.KubeClient{
+			TestRootlessDynamicInterface: rdClient,
+		}
+
+		// First apply
+		err := ApplyDeployment(context.Background(), kubeClient, CreateDeploymentOpts{
+			Name:      "test-app",
+			Namespace: "default",
+			Image:     "test:v1",
+		})
+		require.NoError(t, err)
+
+		// Second apply with different image — no error
+		err = ApplyDeployment(context.Background(), kubeClient, CreateDeploymentOpts{
+			Name:      "test-app",
+			Namespace: "default",
+			Image:     "test:v2",
+		})
+		require.NoError(t, err)
+		require.Len(t, rdClient.ApplyObjs, 2)
+	})
+}
+
 func fixDeployment() *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/kube/resources/service.go
+++ b/internal/kube/resources/service.go
@@ -16,12 +16,6 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func CreateService(ctx context.Context, client kube.Client, name, namespace string, port int32) error {
-	service := buildService(name, namespace, port)
-	_, err := client.Static().CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
-	return err
-}
-
 func ApplyService(ctx context.Context, client kube.Client, name, namespace string, port int32) error {
 	service := buildService(name, namespace, port)
 	service.TypeMeta = metav1.TypeMeta{

--- a/internal/kube/resources/service.go
+++ b/internal/kube/resources/service.go
@@ -18,10 +18,6 @@ import (
 
 func ApplyService(ctx context.Context, client kube.Client, name, namespace string, port int32) error {
 	service := buildService(name, namespace, port)
-	service.TypeMeta = metav1.TypeMeta{
-		APIVersion: "v1",
-		Kind:       "Service",
-	}
 	unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(service)
 	if err != nil {
 		return err
@@ -47,6 +43,10 @@ func buildService(name, namespace string, port int32) *corev1.Service {
 				"app.kubernetes.io/name":       name,
 				"app.kubernetes.io/created-by": "kyma-cli",
 			},
+		},
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{

--- a/internal/kube/resources/service.go
+++ b/internal/kube/resources/service.go
@@ -22,6 +22,19 @@ func CreateService(ctx context.Context, client kube.Client, name, namespace stri
 	return err
 }
 
+func ApplyService(ctx context.Context, client kube.Client, name, namespace string, port int32) error {
+	service := buildService(name, namespace, port)
+	service.TypeMeta = metav1.TypeMeta{
+		APIVersion: "v1",
+		Kind:       "Service",
+	}
+	unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(service)
+	if err != nil {
+		return err
+	}
+	return client.RootlessDynamic().Apply(ctx, &unstructured.Unstructured{Object: unstrObj}, false)
+}
+
 func CreateAPIRule(ctx context.Context, client rootlessdynamic.Interface, name, namespace, host string, port uint32) error {
 	apirule := buildAPIRule(name, namespace, host, port)
 	uAPIRule, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&apirule)

--- a/internal/kube/resources/service_test.go
+++ b/internal/kube/resources/service_test.go
@@ -8,37 +8,8 @@ import (
 	kube_fake "github.com/kyma-project/cli.v3/internal/kube/fake"
 	"github.com/kyma-project/cli.v3/internal/kube/istio"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	k8s_fake "k8s.io/client-go/kubernetes/fake"
 )
-
-func Test_CreateService(t *testing.T) {
-	t.Parallel()
-	t.Run("create service", func(t *testing.T) {
-		kubeClient := &kube_fake.KubeClient{
-			TestKubernetesInterface: k8s_fake.NewSimpleClientset(),
-		}
-
-		err := CreateService(context.Background(), kubeClient, "test-svc", "default", 8080)
-		require.NoError(t, err)
-
-		svc, err := kubeClient.Static().CoreV1().Services("default").Get(context.Background(), "test-svc", metav1.GetOptions{})
-		require.NoError(t, err)
-		require.Equal(t, fixService(), svc)
-	})
-
-	t.Run("service already exists error", func(t *testing.T) {
-		kubeClient := &kube_fake.KubeClient{
-			TestKubernetesInterface: k8s_fake.NewSimpleClientset(fixService()),
-		}
-
-		err := CreateService(context.Background(), kubeClient, "test-svc", "default", 8080)
-		require.ErrorContains(t, err, `services "test-svc" already exists`)
-	})
-}
 
 func Test_CreateAPIRule(t *testing.T) {
 	t.Run("create apiRule", func(t *testing.T) {
@@ -143,28 +114,4 @@ func Test_ApplyService(t *testing.T) {
 		port := ports[0].(map[string]any)
 		require.Equal(t, int64(9090), port["port"])
 	})
-}
-
-func fixService() *corev1.Service {
-	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-svc",
-			Namespace: "default",
-			Labels: map[string]string{
-				"app.kubernetes.io/name":       "test-svc",
-				"app.kubernetes.io/created-by": "kyma-cli",
-			},
-		},
-		Spec: corev1.ServiceSpec{
-			Selector: map[string]string{
-				"app": "test-svc",
-			},
-			Ports: []corev1.ServicePort{
-				{
-					Port:       8080,
-					TargetPort: intstr.FromInt32(8080),
-				},
-			},
-		},
-	}
 }

--- a/internal/kube/resources/service_test.go
+++ b/internal/kube/resources/service_test.go
@@ -105,6 +105,46 @@ func fixAPIRule(apiRuleName, namespace, host string, port uint32) unstructured.U
 	}
 }
 
+func Test_ApplyService(t *testing.T) {
+	t.Parallel()
+	t.Run("apply creates service when it does not exist", func(t *testing.T) {
+		rdClient := &kube_fake.RootlessDynamicClient{}
+		kubeClient := &kube_fake.KubeClient{
+			TestRootlessDynamicInterface: rdClient,
+		}
+
+		err := ApplyService(context.Background(), kubeClient, "test-svc", "default", 8080)
+		require.NoError(t, err)
+		require.Len(t, rdClient.ApplyObjs, 1)
+		require.Equal(t, "v1", rdClient.ApplyObjs[0].GetAPIVersion())
+		require.Equal(t, "Service", rdClient.ApplyObjs[0].GetKind())
+		require.Equal(t, "test-svc", rdClient.ApplyObjs[0].GetName())
+		require.Equal(t, "default", rdClient.ApplyObjs[0].GetNamespace())
+	})
+
+	t.Run("apply updates service when it already exists", func(t *testing.T) {
+		rdClient := &kube_fake.RootlessDynamicClient{}
+		kubeClient := &kube_fake.KubeClient{
+			TestRootlessDynamicInterface: rdClient,
+		}
+
+		// First apply
+		err := ApplyService(context.Background(), kubeClient, "test-svc", "default", 8080)
+		require.NoError(t, err)
+
+		// Second apply with different port — no error
+		err = ApplyService(context.Background(), kubeClient, "test-svc", "default", 9090)
+		require.NoError(t, err)
+		require.Len(t, rdClient.ApplyObjs, 2)
+
+		// Verify the second apply carried the updated port
+		ports, _, _ := unstructured.NestedSlice(rdClient.ApplyObjs[1].Object, "spec", "ports")
+		require.Len(t, ports, 1)
+		port := ports[0].(map[string]interface{})
+		require.Equal(t, int64(9090), port["port"])
+	})
+}
+
 func fixService() *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/kube/resources/service_test.go
+++ b/internal/kube/resources/service_test.go
@@ -140,7 +140,7 @@ func Test_ApplyService(t *testing.T) {
 		// Verify the second apply carried the updated port
 		ports, _, _ := unstructured.NestedSlice(rdClient.ApplyObjs[1].Object, "spec", "ports")
 		require.Len(t, ports, 1)
-		port := ports[0].(map[string]interface{})
+		port := ports[0].(map[string]any)
 		require.Equal(t, int64(9090), port["port"])
 	})
 }


### PR DESCRIPTION
## Summary

- `kyma app push` previously failed on rerun with \"already exists\" errors for Deployment and Service
- Adds `ApplyDeployment` and `ApplyService` functions using Server-Side Apply (SSA) via the existing `rootlessdynamic.Apply()` infrastructure — the same pattern already used by `CreateAPIRule`
- `push.go` now calls the new `Apply*` functions; existing `Create*` functions are preserved for backward compatibility

## Changes

- `internal/kube/resources/deployment.go` — add `ApplyDeployment`
- `internal/kube/resources/service.go` — add `ApplyService`
- `internal/cmd/app/push.go` — switch to `ApplyDeployment`/`ApplyService`; update output messages from "Creating" to "Applying"
- Tests cover create (first run) and upsert (rerun) paths for both new functions

## Test plan

- [ ] `go test ./internal/kube/resources/... ./internal/cmd/app/...` passes
- [ ] Run `kyma app push --name my-app --image <image>` twice against a cluster — second run should succeed without errors

## Related to 

Fixes https://github.com/kyma-project/cli/issues/2905
#2899 
#2410