### PR TITLE
feat(app push): add --build-tag flag for custom image tags

### DIFF
--- a/docs/user/gen-docs/kyma_app_push.md
+++ b/docs/user/gen-docs/kyma_app_push.md
@@ -17,6 +17,10 @@ kyma app push [flags]
   # The application will be built using Cloud Native Buildpacks:
   kyma app push --name my-app --code-path .
 
+  # Push with a custom image tag (e.g. a Git commit SHA for CI/CD traceability):
+  kyma app push --name my-app --code-path . --build-tag abc1234
+  kyma app push --name my-app --dockerfile ./Dockerfile --build-tag $GITHUB_SHA
+
   # Push an application based on a Dockerfile located in the current directory:
   kyma app push --name my-app --dockerfile ./Dockerfile --dockerfile-context .
 
@@ -65,6 +69,7 @@ kyma app push [flags]
 ## Flags
 
 ```text
+      --build-tag string                                      Custom tag for the built image (e.g. a Git commit SHA). Applies only to --code-path and --dockerfile builds.
       --code-path string                                      Path to the application source code directory
       --container-port int                                    Port on which the application is exposed
       --dockerfile string                                     Path to the Dockerfile

--- a/internal/cmd/app/push.go
+++ b/internal/cmd/app/push.go
@@ -27,6 +27,7 @@ type appPushConfig struct {
 	namespace                  string
 	image                      string
 	imagePullSecretName        string
+	imageTag                   string
 	dockerfilePath             string
 	dockerfileSrcContext       string
 	dockerfileArgs             types.Map
@@ -43,7 +44,6 @@ type appPushConfig struct {
 	mountServiceBindingSecrets types.ServiceBindingSecretArray
 	quiet                      bool
 	insecure                   bool
-	imageTag                   string
 }
 
 func NewAppPushCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {

--- a/internal/cmd/app/push.go
+++ b/internal/cmd/app/push.go
@@ -332,7 +332,7 @@ func createDeployment(cfg *appPushConfig, client kube.Client, image, imagePullSe
 
 func buildAndImportImage(client kube.Client, cfg *appPushConfig, registryConfig *registry.InternalRegistryConfig) (string, clierror.Error) {
 	out.Msgln("Building image\n")
-	imageName, err := buildImage(cfg)
+	imageName, err := buildImage(cfg, cfg.imageTag)
 	if err != nil {
 		return "", clierror.Wrap(err, clierror.New("failed to build image from Dockerfile"))
 	}
@@ -369,9 +369,16 @@ func buildAndImportImage(client kube.Client, cfg *appPushConfig, registryConfig 
 	return pushedImage, nil
 }
 
-func buildImage(cfg *appPushConfig) (string, error) {
-	imageTag := time.Now().Format("2006-01-02_15-04-05")
-	imageName := fmt.Sprintf("%s:%s", cfg.name, imageTag)
+// resolveImageTag returns imageTag if non-empty, otherwise a timestamp-based tag.
+func resolveImageTag(imageTag string) string {
+	if imageTag != "" {
+		return imageTag
+	}
+	return time.Now().Format("2006-01-02_15-04-05")
+}
+
+func buildImage(cfg *appPushConfig, imageTag string) (string, error) {
+	imageName := fmt.Sprintf("%s:%s", cfg.name, resolveImageTag(imageTag))
 
 	var err error
 	if cfg.packAppPath != "" {

--- a/internal/cmd/app/push.go
+++ b/internal/cmd/app/push.go
@@ -21,6 +21,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var imageTagRegexp = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$`)
+
 type appPushConfig struct {
 	*cmdcommon.KymaConfig
 
@@ -183,8 +185,7 @@ func (apc *appPushConfig) complete() clierror.Error {
 	}
 
 	if apc.imageTag != "" {
-		validTag := regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_.\-]{0,127}$`)
-		if !validTag.MatchString(apc.imageTag) {
+		if !imageTagRegexp.MatchString(apc.imageTag) {
 			return clierror.New(
 				fmt.Sprintf("invalid image tag %q", apc.imageTag),
 				"tag must start with a letter, digit, or underscore",

--- a/internal/cmd/app/push.go
+++ b/internal/cmd/app/push.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"time"
 
 	"github.com/kyma-project/cli.v3/internal/clierror"
@@ -178,6 +179,18 @@ func (apc *appPushConfig) complete() clierror.Error {
 				return clierror.Wrap(err, clierror.New("failed to get current working directory",
 					"Provide the path to the Dockerfile context using --dockerfile-context flag"))
 			}
+		}
+	}
+
+	if apc.imageTag != "" {
+		validTag := regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_.\-]{0,127}$`)
+		if !validTag.MatchString(apc.imageTag) {
+			return clierror.New(
+				fmt.Sprintf("invalid image tag %q", apc.imageTag),
+				"tag must start with a letter, digit, or underscore",
+				"tag may only contain letters, digits, underscores, dots, and hyphens",
+				"tag must be at most 128 characters",
+			)
 		}
 	}
 

--- a/internal/cmd/app/push.go
+++ b/internal/cmd/app/push.go
@@ -188,17 +188,6 @@ func (apc *appPushConfig) complete() clierror.Error {
 		}
 	}
 
-	if apc.buildTag != "" {
-		if !buildTagRegexp.MatchString(apc.buildTag) {
-			return clierror.New(
-				fmt.Sprintf("invalid image tag %q", apc.buildTag),
-				"tag must start with a letter, digit, or underscore",
-				"tag may only contain letters, digits, underscores, dots, and hyphens",
-				"tag must be at most 128 characters",
-			)
-		}
-	}
-
 	return nil
 }
 
@@ -212,6 +201,17 @@ func (apc *appPushConfig) validate() clierror.Error {
 	// 		"make sure api-gateway module is installed",
 	// 	)
 	// }
+
+	if apc.buildTag != "" {
+		if !buildTagRegexp.MatchString(apc.buildTag) {
+			return clierror.New(
+				fmt.Sprintf("invalid image tag %q", apc.buildTag),
+				"tag must start with a letter, digit, or underscore",
+				"tag may only contain letters, digits, underscores, dots, and hyphens",
+				"tag must be at most 128 characters",
+			)
+		}
+	}
 
 	return nil
 }

--- a/internal/cmd/app/push.go
+++ b/internal/cmd/app/push.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var imageTagRegexp = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$`)
+var buildTagRegexp = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$`)
 
 type appPushConfig struct {
 	*cmdcommon.KymaConfig
@@ -30,7 +30,7 @@ type appPushConfig struct {
 	namespace                  string
 	image                      string
 	imagePullSecretName        string
-	imageTag                   string
+	buildTag                   string
 	dockerfilePath             string
 	dockerfileSrcContext       string
 	dockerfileArgs             types.Map
@@ -64,8 +64,8 @@ func NewAppPushCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
   kyma app push --name my-app --code-path .
 
   # Push with a custom image tag (e.g. a Git commit SHA for CI/CD traceability):
-  kyma app push --name my-app --code-path . --image-tag abc1234
-  kyma app push --name my-app --dockerfile ./Dockerfile --image-tag $GITHUB_SHA
+  kyma app push --name my-app --code-path . --build-tag abc1234
+  kyma app push --name my-app --dockerfile ./Dockerfile --build-tag $GITHUB_SHA
 
   # Push an application based on a Dockerfile located in the current directory:
   kyma app push --name my-app --dockerfile ./Dockerfile --dockerfile-context .
@@ -118,7 +118,7 @@ func NewAppPushCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 				flags.MarkExactlyOneRequired("image", "dockerfile", "code-path"),
 				flags.MarkExclusive("dockerfile-context", "image", "code-path"),
 				flags.MarkExclusive("dockerfile-build-arg", "image", "code-path"),
-				flags.MarkExclusive("image-tag", "image"),
+				flags.MarkExclusive("build-tag", "image"),
 				flags.MarkPrerequisites("expose", "container-port"),
 				flags.MarkPrerequisites("image-pull-secret", "image"),
 			))
@@ -141,7 +141,7 @@ func NewAppPushCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	// image flags
 	cmd.Flags().StringVar(&config.image, "image", "", "Name of the image to deploy")
 	cmd.Flags().StringVar(&config.imagePullSecretName, "image-pull-secret", "", "Name of the Kubernetes Secret with credentials to pull the image")
-	cmd.Flags().StringVar(&config.imageTag, "image-tag", "", "Custom tag for the built image (e.g. a Git commit SHA). Applies only to --code-path and --dockerfile builds.")
+	cmd.Flags().StringVar(&config.buildTag, "build-tag", "", "Custom tag for the built image (e.g. a Git commit SHA). Applies only to --code-path and --dockerfile builds.")
 
 	// dockerfile flags
 	cmd.Flags().StringVar(&config.dockerfilePath, "dockerfile", "", "Path to the Dockerfile")
@@ -188,10 +188,10 @@ func (apc *appPushConfig) complete() clierror.Error {
 		}
 	}
 
-	if apc.imageTag != "" {
-		if !imageTagRegexp.MatchString(apc.imageTag) {
+	if apc.buildTag != "" {
+		if !buildTagRegexp.MatchString(apc.buildTag) {
 			return clierror.New(
-				fmt.Sprintf("invalid image tag %q", apc.imageTag),
+				fmt.Sprintf("invalid image tag %q", apc.buildTag),
 				"tag must start with a letter, digit, or underscore",
 				"tag may only contain letters, digits, underscores, dots, and hyphens",
 				"tag must be at most 128 characters",
@@ -382,7 +382,7 @@ func resolveImageTag(imageTag string) string {
 }
 
 func buildImage(cfg *appPushConfig) (string, error) {
-	imageName := fmt.Sprintf("%s:%s", cfg.name, resolveImageTag(cfg.imageTag))
+	imageName := fmt.Sprintf("%s:%s", cfg.name, resolveImageTag(cfg.buildTag))
 
 	var err error
 	if cfg.packAppPath != "" {

--- a/internal/cmd/app/push.go
+++ b/internal/cmd/app/push.go
@@ -43,6 +43,7 @@ type appPushConfig struct {
 	mountServiceBindingSecrets types.ServiceBindingSecretArray
 	quiet                      bool
 	insecure                   bool
+	imageTag                   string
 }
 
 func NewAppPushCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
@@ -110,6 +111,7 @@ func NewAppPushCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 				flags.MarkExactlyOneRequired("image", "dockerfile", "code-path"),
 				flags.MarkExclusive("dockerfile-context", "image", "code-path"),
 				flags.MarkExclusive("dockerfile-build-arg", "image", "code-path"),
+				flags.MarkExclusive("image-tag", "image"),
 				flags.MarkPrerequisites("expose", "container-port"),
 				flags.MarkPrerequisites("image-pull-secret", "image"),
 			))
@@ -132,6 +134,7 @@ func NewAppPushCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
 	// image flags
 	cmd.Flags().StringVar(&config.image, "image", "", "Name of the image to deploy")
 	cmd.Flags().StringVar(&config.imagePullSecretName, "image-pull-secret", "", "Name of the Kubernetes Secret with credentials to pull the image")
+	cmd.Flags().StringVar(&config.imageTag, "image-tag", "", "Custom tag for the built image (e.g. a Git commit SHA). Applies only to --code-path and --dockerfile builds.")
 
 	// dockerfile flags
 	cmd.Flags().StringVar(&config.dockerfilePath, "dockerfile", "", "Path to the Dockerfile")

--- a/internal/cmd/app/push.go
+++ b/internal/cmd/app/push.go
@@ -332,9 +332,9 @@ func createDeployment(cfg *appPushConfig, client kube.Client, image, imagePullSe
 
 func buildAndImportImage(client kube.Client, cfg *appPushConfig, registryConfig *registry.InternalRegistryConfig) (string, clierror.Error) {
 	out.Msgln("Building image\n")
-	imageName, err := buildImage(cfg, cfg.imageTag)
+	imageName, err := buildImage(cfg)
 	if err != nil {
-		return "", clierror.Wrap(err, clierror.New("failed to build image from Dockerfile"))
+		return "", clierror.Wrap(err, clierror.New("failed to build image"))
 	}
 
 	pushFunc := registry.NewPushWithPortforwardFunc(
@@ -377,8 +377,8 @@ func resolveImageTag(imageTag string) string {
 	return time.Now().Format("2006-01-02_15-04-05")
 }
 
-func buildImage(cfg *appPushConfig, imageTag string) (string, error) {
-	imageName := fmt.Sprintf("%s:%s", cfg.name, resolveImageTag(imageTag))
+func buildImage(cfg *appPushConfig) (string, error) {
+	imageName := fmt.Sprintf("%s:%s", cfg.name, resolveImageTag(cfg.imageTag))
 
 	var err error
 	if cfg.packAppPath != "" {

--- a/internal/cmd/app/push.go
+++ b/internal/cmd/app/push.go
@@ -63,6 +63,10 @@ func NewAppPushCMD(kymaConfig *cmdcommon.KymaConfig) *cobra.Command {
   # The application will be built using Cloud Native Buildpacks:
   kyma app push --name my-app --code-path .
 
+  # Push with a custom image tag (e.g. a Git commit SHA for CI/CD traceability):
+  kyma app push --name my-app --code-path . --image-tag abc1234
+  kyma app push --name my-app --dockerfile ./Dockerfile --image-tag $GITHUB_SHA
+
   # Push an application based on a Dockerfile located in the current directory:
   kyma app push --name my-app --dockerfile ./Dockerfile --dockerfile-context .
 

--- a/internal/cmd/app/push_test.go
+++ b/internal/cmd/app/push_test.go
@@ -93,3 +93,16 @@ func Test_appPushConfig_complete_imageTag(t *testing.T) {
 		})
 	}
 }
+
+func Test_buildImage_tagSelection(t *testing.T) {
+	t.Run("provided tag is used in image name", func(t *testing.T) {
+		imageTag := "abc1234"
+		resolvedTag := resolveImageTag(imageTag)
+		require.Equal(t, "abc1234", resolvedTag)
+	})
+
+	t.Run("empty tag resolves to timestamp format", func(t *testing.T) {
+		resolvedTag := resolveImageTag("")
+		require.Regexp(t, `^\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}$`, resolvedTag)
+	})
+}

--- a/internal/cmd/app/push_test.go
+++ b/internal/cmd/app/push_test.go
@@ -1,0 +1,95 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_appPushConfig_complete_imageTag(t *testing.T) {
+	tests := []struct {
+		name      string
+		imageTag  string
+		wantError bool
+	}{
+		{
+			name:      "empty tag uses timestamp fallback - no error",
+			imageTag:  "",
+			wantError: false,
+		},
+		{
+			name:      "valid commit sha",
+			imageTag:  "abc1234def5678",
+			wantError: false,
+		},
+		{
+			name:      "valid semver",
+			imageTag:  "1.0.0",
+			wantError: false,
+		},
+		{
+			name:      "valid underscore prefix",
+			imageTag:  "_build",
+			wantError: false,
+		},
+		{
+			name:      "valid single char",
+			imageTag:  "1",
+			wantError: false,
+		},
+		{
+			name:      "valid with dots and dashes",
+			imageTag:  "v1.2.3-beta.1",
+			wantError: false,
+		},
+		{
+			name:      "invalid: contains space",
+			imageTag:  "my tag",
+			wantError: true,
+		},
+		{
+			name:      "invalid: contains colon",
+			imageTag:  "my:tag",
+			wantError: true,
+		},
+		{
+			name:      "invalid: contains slash",
+			imageTag:  "my/tag",
+			wantError: true,
+		},
+		{
+			name:      "invalid: contains @",
+			imageTag:  "my@tag",
+			wantError: true,
+		},
+		{
+			name:      "invalid: starts with dot",
+			imageTag:  ".mytag",
+			wantError: true,
+		},
+		{
+			name:      "invalid: starts with dash",
+			imageTag:  "-mytag",
+			wantError: true,
+		},
+		{
+			name:      "invalid: exceeds 128 chars",
+			imageTag:  "a123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &appPushConfig{
+				imageTag: tt.imageTag,
+			}
+			err := cfg.complete()
+			if tt.wantError {
+				require.NotNil(t, err, "expected validation error for imageTag=%q", tt.imageTag)
+			} else {
+				require.Nil(t, err, "expected no error for imageTag=%q", tt.imageTag)
+			}
+		})
+	}
+}

--- a/internal/cmd/app/push_test.go
+++ b/internal/cmd/app/push_test.go
@@ -8,9 +8,9 @@ import (
 
 func Test_appPushConfig_complete_imageTag(t *testing.T) {
 	tests := []struct {
-		name    string
+		name     string
 		imageTag string
-		wantErr bool
+		wantErr  bool
 	}{
 		{
 			name:     "empty tag skips validation - no error",

--- a/internal/cmd/app/push_test.go
+++ b/internal/cmd/app/push_test.go
@@ -84,7 +84,7 @@ func Test_appPushConfig_complete_buildTag(t *testing.T) {
 			cfg := &appPushConfig{
 				buildTag: tt.buildTag,
 			}
-			err := cfg.complete()
+			err := cfg.validate()
 			if tt.wantErr {
 				require.NotNil(t, err, "expected validation error for buildTag=%q", tt.buildTag)
 			} else {

--- a/internal/cmd/app/push_test.go
+++ b/internal/cmd/app/push_test.go
@@ -94,7 +94,7 @@ func Test_appPushConfig_complete_imageTag(t *testing.T) {
 	}
 }
 
-func Test_buildImage_tagSelection(t *testing.T) {
+func Test_resolveImageTag(t *testing.T) {
 	t.Run("provided tag is used in image name", func(t *testing.T) {
 		imageTag := "abc1234"
 		resolvedTag := resolveImageTag(imageTag)

--- a/internal/cmd/app/push_test.go
+++ b/internal/cmd/app/push_test.go
@@ -6,75 +6,75 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_appPushConfig_complete_imageTag(t *testing.T) {
+func Test_appPushConfig_complete_buildTag(t *testing.T) {
 	tests := []struct {
 		name     string
-		imageTag string
+		buildTag string
 		wantErr  bool
 	}{
 		{
 			name:     "empty tag skips validation - no error",
-			imageTag: "",
+			buildTag: "",
 			wantErr:  false,
 		},
 		{
 			name:     "valid commit sha",
-			imageTag: "abc1234def5678",
+			buildTag: "abc1234def5678",
 			wantErr:  false,
 		},
 		{
 			name:     "valid semver",
-			imageTag: "1.0.0",
+			buildTag: "1.0.0",
 			wantErr:  false,
 		},
 		{
 			name:     "valid underscore prefix",
-			imageTag: "_build",
+			buildTag: "_build",
 			wantErr:  false,
 		},
 		{
 			name:     "valid single char",
-			imageTag: "1",
+			buildTag: "1",
 			wantErr:  false,
 		},
 		{
 			name:     "valid with dots and dashes",
-			imageTag: "v1.2.3-beta.1",
+			buildTag: "v1.2.3-beta.1",
 			wantErr:  false,
 		},
 		{
 			name:     "invalid: contains space",
-			imageTag: "my tag",
+			buildTag: "my tag",
 			wantErr:  true,
 		},
 		{
 			name:     "invalid: contains colon",
-			imageTag: "my:tag",
+			buildTag: "my:tag",
 			wantErr:  true,
 		},
 		{
 			name:     "invalid: contains slash",
-			imageTag: "my/tag",
+			buildTag: "my/tag",
 			wantErr:  true,
 		},
 		{
 			name:     "invalid: contains @",
-			imageTag: "my@tag",
+			buildTag: "my@tag",
 			wantErr:  true,
 		},
 		{
 			name:     "invalid: starts with dot",
-			imageTag: ".mytag",
+			buildTag: ".mytag",
 			wantErr:  true,
 		},
 		{
 			name:     "invalid: starts with dash",
-			imageTag: "-mytag",
+			buildTag: "-mytag",
 			wantErr:  true,
 		},
 		{
 			name:     "invalid: exceeds 128 chars",
-			imageTag: "abbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			buildTag: "abbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 			wantErr:  true,
 		},
 	}
@@ -82,13 +82,13 @@ func Test_appPushConfig_complete_imageTag(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &appPushConfig{
-				imageTag: tt.imageTag,
+				buildTag: tt.buildTag,
 			}
 			err := cfg.complete()
 			if tt.wantErr {
-				require.NotNil(t, err, "expected validation error for imageTag=%q", tt.imageTag)
+				require.NotNil(t, err, "expected validation error for buildTag=%q", tt.buildTag)
 			} else {
-				require.Nil(t, err, "expected no error for imageTag=%q", tt.imageTag)
+				require.Nil(t, err, "expected no error for buildTag=%q", tt.buildTag)
 			}
 		})
 	}

--- a/internal/cmd/app/push_test.go
+++ b/internal/cmd/app/push_test.go
@@ -74,7 +74,7 @@ func Test_appPushConfig_complete_imageTag(t *testing.T) {
 		},
 		{
 			name:     "invalid: exceeds 128 chars",
-			imageTag: "abbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			imageTag: "abbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 			wantErr:  true,
 		},
 	}

--- a/internal/cmd/app/push_test.go
+++ b/internal/cmd/app/push_test.go
@@ -8,74 +8,74 @@ import (
 
 func Test_appPushConfig_complete_imageTag(t *testing.T) {
 	tests := []struct {
-		name      string
-		imageTag  string
-		wantError bool
+		name    string
+		imageTag string
+		wantErr bool
 	}{
 		{
-			name:      "empty tag uses timestamp fallback - no error",
-			imageTag:  "",
-			wantError: false,
+			name:     "empty tag skips validation - no error",
+			imageTag: "",
+			wantErr:  false,
 		},
 		{
-			name:      "valid commit sha",
-			imageTag:  "abc1234def5678",
-			wantError: false,
+			name:     "valid commit sha",
+			imageTag: "abc1234def5678",
+			wantErr:  false,
 		},
 		{
-			name:      "valid semver",
-			imageTag:  "1.0.0",
-			wantError: false,
+			name:     "valid semver",
+			imageTag: "1.0.0",
+			wantErr:  false,
 		},
 		{
-			name:      "valid underscore prefix",
-			imageTag:  "_build",
-			wantError: false,
+			name:     "valid underscore prefix",
+			imageTag: "_build",
+			wantErr:  false,
 		},
 		{
-			name:      "valid single char",
-			imageTag:  "1",
-			wantError: false,
+			name:     "valid single char",
+			imageTag: "1",
+			wantErr:  false,
 		},
 		{
-			name:      "valid with dots and dashes",
-			imageTag:  "v1.2.3-beta.1",
-			wantError: false,
+			name:     "valid with dots and dashes",
+			imageTag: "v1.2.3-beta.1",
+			wantErr:  false,
 		},
 		{
-			name:      "invalid: contains space",
-			imageTag:  "my tag",
-			wantError: true,
+			name:     "invalid: contains space",
+			imageTag: "my tag",
+			wantErr:  true,
 		},
 		{
-			name:      "invalid: contains colon",
-			imageTag:  "my:tag",
-			wantError: true,
+			name:     "invalid: contains colon",
+			imageTag: "my:tag",
+			wantErr:  true,
 		},
 		{
-			name:      "invalid: contains slash",
-			imageTag:  "my/tag",
-			wantError: true,
+			name:     "invalid: contains slash",
+			imageTag: "my/tag",
+			wantErr:  true,
 		},
 		{
-			name:      "invalid: contains @",
-			imageTag:  "my@tag",
-			wantError: true,
+			name:     "invalid: contains @",
+			imageTag: "my@tag",
+			wantErr:  true,
 		},
 		{
-			name:      "invalid: starts with dot",
-			imageTag:  ".mytag",
-			wantError: true,
+			name:     "invalid: starts with dot",
+			imageTag: ".mytag",
+			wantErr:  true,
 		},
 		{
-			name:      "invalid: starts with dash",
-			imageTag:  "-mytag",
-			wantError: true,
+			name:     "invalid: starts with dash",
+			imageTag: "-mytag",
+			wantErr:  true,
 		},
 		{
-			name:      "invalid: exceeds 128 chars",
-			imageTag:  "a123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",
-			wantError: true,
+			name:     "invalid: exceeds 128 chars",
+			imageTag: "abbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			wantErr:  true,
 		},
 	}
 
@@ -85,7 +85,7 @@ func Test_appPushConfig_complete_imageTag(t *testing.T) {
 				imageTag: tt.imageTag,
 			}
 			err := cfg.complete()
-			if tt.wantError {
+			if tt.wantErr {
 				require.NotNil(t, err, "expected validation error for imageTag=%q", tt.imageTag)
 			} else {
 				require.Nil(t, err, "expected no error for imageTag=%q", tt.imageTag)


### PR DESCRIPTION
## Summary

- Adds `--build-tag` flag to `kyma app push` allowing users to supply a custom Docker image tag when building from source (`--code-path` or `--dockerfile`)
- Falls back to the existing timestamp-based tag when the flag is omitted (no behaviour change for existing users)
- Flag is mutually exclusive with `--image` (which already embeds the tag)
- Tag is validated against Docker tag rules: starts with `[a-zA-Z0-9_]`, only `[a-zA-Z0-9_.-]` allowed, max 128 chars

## Motivation

Enables CI/CD pipelines to use deterministic, traceable image tags:
```bash
kyma app push --name my-app --code-path . --build-tag ${{ github.sha }}
```

Closes #2907

## Test Plan
- [ ] `go test ./internal/cmd/app/... -v` — 15 tests pass (13 validation cases + 2 resolveImageTag cases)
- [ ] `go build ./...` — no errors
- [ ] Manual: `kyma app push --name my-app --code-path . --build-tag abc1234` uses tag `abc1234`
- [ ] Manual: `kyma app push --name my-app --code-path .` still uses timestamp tag (no regression)
- [ ] Manual: `kyma app push --name my-app --image myimage:latest --build-tag abc` fails with exclusivity error
- [ ] Manual: `kyma app push --name my-app --code-path . --build-tag "bad tag"` fails with clear validation error