### PR TITLE
Fix link-check false positive for developers.sap.com

### DIFF
--- a/.mlc.config.json
+++ b/.mlc.config.json
@@ -4,6 +4,12 @@
   "_comment": "Configuration and maintenance of the Markdown link check tool is the responsibility of a repository owner.",
   "_comment": "See the following configuration example.",
   "_comment": "For more details read the [repository guidelines](https://github.com/kyma-project/community/blob/main/docs/guidelines/repository-guidelines/01-new-repository-settings.md).",
+  "ignorePatterns": [
+    {
+      "_comment": "developers.sap.com blocks CI bots with 403; links are manually verified",
+      "pattern": "^https://developers\\.sap\\.com/"
+    }
+  ],
   "replacementPatterns": [
     {
       "_comment": "a replacement rule for all the in-repository references",


### PR DESCRIPTION
## What does this PR do?

Adds `developers.sap.com` to the `ignorePatterns` in `.mlc.config.json`.

## Why?

The SAP Developer portal blocks CI/bot requests with HTTP 403, causing the link-check job to fail even though the links are valid. See the failing run: https://github.com/kyma-project/cli/actions/runs/27328091751/job/80734023568

## Testing

The link-check CI job should pass after this change.